### PR TITLE
fix(email): magic link cassé (URL /auth/v1 doublé) + retrait unsubscribe transactionnel

### DIFF
--- a/packages/data/src/emails/AttestationEmail.tsx
+++ b/packages/data/src/emails/AttestationEmail.tsx
@@ -111,6 +111,7 @@ export function AttestationEmail({
     <EvolveEmailShell
       preview={`Ton attestation de détention de ${monthLabel} est disponible`}
       clubName={clubName.trim() === '' ? undefined : clubName.trim()}
+      hideUnsubscribe
     >
       <Text style={eyebrow}>Attestation · {monthLabel}</Text>
       <Heading as="h1" style={h1}>

--- a/packages/data/src/emails/MagicLinkEmail.tsx
+++ b/packages/data/src/emails/MagicLinkEmail.tsx
@@ -95,6 +95,7 @@ export function MagicLinkEmail({
       preview={t.preview(expiresInMin)}
       clubName={clubName}
       footerNote={t.footerNote}
+      hideUnsubscribe
     >
       <Text style={eyebrow}>{t.eyebrow}</Text>
       <Heading as="h1" style={h1}>

--- a/packages/data/src/emails/SyncErrorEmail.tsx
+++ b/packages/data/src/emails/SyncErrorEmail.tsx
@@ -66,6 +66,7 @@ export function SyncErrorEmail({ clubName, syncTime, errorMessage, appUrl }: Syn
       preview={`Erreur de synchronisation — ${safeClubName}`}
       clubName={clubName.trim() === '' ? undefined : clubName.trim()}
       footerNote="Email essentiel — cette alerte est envoyée aux trésoriers indépendamment de leurs préférences."
+      hideUnsubscribe
     >
       <Text style={eyebrow}>Synchronisation · Alerte</Text>
       <Heading as="h1" style={h1}>

--- a/packages/data/src/emails/WelcomeEmail.tsx
+++ b/packages/data/src/emails/WelcomeEmail.tsx
@@ -66,6 +66,7 @@ export function WelcomeEmail({ memberFirstName, clubName, appUrl }: WelcomeEmail
     <EvolveEmailShell
       preview={`Bienvenue dans le club ${club} sur Evolve Capital`}
       clubName={clubName}
+      hideUnsubscribe
     >
       <Text style={eyebrow}>Premier jour dans le club</Text>
       <Heading as="h1" style={h1}>

--- a/packages/data/src/emails/_layout/EvolveEmailShell.tsx
+++ b/packages/data/src/emails/_layout/EvolveEmailShell.tsx
@@ -101,11 +101,17 @@ export function EvolveEmailShell({
                   ·{' '}
                 </>
               )}
-              <Link href="https://reseauevolvecapital.com/preferences" style={footerLink}>
-                Préférences
-              </Link>{' '}
-              ·{' '}
-              <Link href="https://reseauevolvecapital.com/mentions-legales" style={footerLink}>
+              {/*
+                TODO(préférences) : futur centre de préférences de notifications
+                (opt-in/out granulaire par catégorie/canal/fréquence des emails
+                non-essentiels — alternative douce à l'unsubscribe, lié à NTF-007).
+                Commenté tant que la page /preferences n'existe pas.
+                <Link href="https://app.reseauevolvecapital.com/preferences" style={footerLink}>
+                  Préférences
+                </Link>{' '}
+                ·{' '}
+              */}
+              <Link href="https://app.reseauevolvecapital.com/legal/charter" style={footerLink}>
                 Mentions légales
               </Link>
             </Text>

--- a/packages/data/src/emails/_layout/EvolveEmailShell.tsx
+++ b/packages/data/src/emails/_layout/EvolveEmailShell.tsx
@@ -42,6 +42,14 @@ export interface EvolveEmailShellProps {
    * (ex. rappel « email essentiel »).
    */
   footerNote?: ReactNode
+  /**
+   * Masque le lien « Se désinscrire » du footer. À mettre à `true` pour TOUT email
+   * **transactionnel** (magic link, attestation, alerte…) : l'unsubscribe est une
+   * obligation des emails marketing, pas relationnels — et son lien/entête
+   * `List-Unsubscribe` est un signal « bulk » qui dégrade la délivrabilité (onglet
+   * Gmail « Promotions/Updates »). À laisser `false` (défaut) pour les newsletters.
+   */
+  hideUnsubscribe?: boolean
 }
 
 const ADRESSE_POSTALE =
@@ -52,6 +60,7 @@ export function EvolveEmailShell({
   children,
   clubName,
   footerNote,
+  hideUnsubscribe = false,
 }: EvolveEmailShellProps) {
   return (
     <Html lang="fr">
@@ -84,10 +93,14 @@ export function EvolveEmailShell({
             <Text style={footerText}>{ADRESSE_POSTALE}</Text>
             <Hr style={footerRule} />
             <Text style={footerLinks}>
-              <Link href="{{unsubscribe}}" style={footerLink}>
-                Se désinscrire (emails non-essentiels)
-              </Link>{' '}
-              ·{' '}
+              {hideUnsubscribe ? null : (
+                <>
+                  <Link href="{{unsubscribe}}" style={footerLink}>
+                    Se désinscrire (emails non-essentiels)
+                  </Link>{' '}
+                  ·{' '}
+                </>
+              )}
               <Link href="https://reseauevolvecapital.com/preferences" style={footerLink}>
                 Préférences
               </Link>{' '}

--- a/packages/data/src/tests/email.test.ts
+++ b/packages/data/src/tests/email.test.ts
@@ -32,6 +32,22 @@ describe('EvolveEmailShell', () => {
     expect(html).toMatch(/mentions légales/i)
   })
 
+  it('hideUnsubscribe retire le lien de désinscription (emails transactionnels)', async () => {
+    const html = await renderEmailHtml(
+      createElement(EvolveEmailShell, {
+        preview: 'Aperçu',
+        hideUnsubscribe: true,
+        children: createElement('p', null, 'Contenu'),
+      })
+    )
+    // Plus de lien de désinscription ni de token Brevo…
+    expect(html).not.toMatch(/désinscrire/i)
+    expect(html).not.toContain('{{unsubscribe}}')
+    // …mais le reste du footer demeure.
+    expect(html).toMatch(/mentions légales/i)
+    expect(html).toMatch(/préférences/i)
+  })
+
   it('rend le preview text passé en prop', async () => {
     const html = await renderEmailHtml(
       createElement(EvolveEmailShell, {

--- a/packages/data/src/tests/email.test.ts
+++ b/packages/data/src/tests/email.test.ts
@@ -43,9 +43,9 @@ describe('EvolveEmailShell', () => {
     // Plus de lien de désinscription ni de token Brevo…
     expect(html).not.toMatch(/désinscrire/i)
     expect(html).not.toContain('{{unsubscribe}}')
-    // …mais le reste du footer demeure.
+    // …mais les mentions légales demeurent (→ /legal/charter).
     expect(html).toMatch(/mentions légales/i)
-    expect(html).toMatch(/préférences/i)
+    expect(html).toContain('/legal/charter')
   })
 
   it('rend le preview text passé en prop', async () => {

--- a/supabase/functions/send-email/__tests__/send-email.test.ts
+++ b/supabase/functions/send-email/__tests__/send-email.test.ts
@@ -143,21 +143,30 @@ Deno.test('échec Brevo → 502', async () => {
 
 // ---- Test 6 — buildConfirmationUrl ----
 Deno.test('buildConfirmationUrl : forme + encodage du redirect_to', () => {
-  const url = buildConfirmationUrl(
-    {
-      token: 'x',
-      token_hash: 'th',
-      redirect_to: 'http://localhost:3001/login/verify',
-      email_action_type: 'magiclink',
-      site_url: 'https://proj.supabase.co/',
-    },
-    'https://fallback.co'
-  )
+  const data = {
+    token: 'x',
+    token_hash: 'th',
+    redirect_to: 'http://localhost:3001/login/verify',
+    email_action_type: 'magiclink',
+    // site_url du payload = URL externe GoTrue (déjà /auth/v1) : NE DOIT PAS servir de base.
+    site_url: 'https://proj.supabase.co/auth/v1',
+  }
+  // La base vient de l'URL PROJET (2ᵉ arg), pas de data.site_url.
+  const url = buildConfirmationUrl(data, 'https://proj.supabase.co')
   assertStringIncludes(url, 'https://proj.supabase.co/auth/v1/verify?')
   assertStringIncludes(url, 'token=th')
   assertStringIncludes(url, 'type=magiclink')
   // redirect_to encodé en query param.
   assertStringIncludes(url, 'redirect_to=http%3A%2F%2Flocalhost%3A3001%2Flogin%2Fverify')
+  // Régression : jamais de chemin doublé, même si l'URL projet porte déjà /auth/v1.
+  if (url.includes('/auth/v1/auth/v1')) {
+    throw new Error(`chemin /auth/v1 doublé : ${url}`)
+  }
+  const doubled = buildConfirmationUrl(data, 'https://proj.supabase.co/auth/v1/')
+  assertStringIncludes(doubled, 'https://proj.supabase.co/auth/v1/verify?')
+  if (doubled.includes('/auth/v1/auth/v1')) {
+    throw new Error(`chemin /auth/v1 doublé (base avec suffixe) : ${doubled}`)
+  }
 })
 
 // ---- Test 7 — resolveLocale ----

--- a/supabase/functions/send-email/handler.ts
+++ b/supabase/functions/send-email/handler.ts
@@ -94,14 +94,19 @@ export function resolveLocale(meta: Record<string, unknown> | null | undefined):
 
 /**
  * Construit la ConfirmationURL à usage unique à partir du payload du hook.
- * Forme : {site_url}/auth/v1/verify?token={token_hash}&type={action}&redirect_to={redirect_to}
+ * Forme : {projectUrl}/auth/v1/verify?token={token_hash}&type={action}&redirect_to={redirect_to}
+ *
+ * ⚠ La base est l'URL du **projet Supabase** (`SUPABASE_URL`), PAS `email_data.site_url` :
+ * dans le payload du hook, `site_url` porte l'URL externe de GoTrue (déjà suffixée `/auth/v1`),
+ * donc l'utiliser produisait un chemin doublé `/auth/v1/auth/v1/verify` → lien cassé
+ * (« No API key found »). On normalise donc en retirant un éventuel `/auth/v1` final.
  * On encode les composants (open-redirect/injection safe). JAMAIS de code/OTP exposé.
  */
 export function buildConfirmationUrl(
   data: SendEmailPayload['email_data'],
-  fallbackSiteUrl: string
+  projectUrl: string
 ): string {
-  const base = (data.site_url ?? fallbackSiteUrl).replace(/\/+$/, '')
+  const base = projectUrl.replace(/\/+$/, '').replace(/\/auth\/v1$/, '')
   const params = new URLSearchParams({
     token: data.token_hash,
     type: data.email_action_type,


### PR DESCRIPTION
Corrections issues du 1er test de connexion réel en prod (2 commits).

## 1. Magic link cassé — URL /auth/v1 doublé (BLOQUANT)
Le lien pointait `…supabase.co/auth/v1/auth/v1/verify` → "No API key found" → connexion impossible. Cause : `buildConfirmationUrl` utilisait `email_data.site_url` (URL externe GoTrue, déjà /auth/v1) comme base. Fix : base = URL projet (SUPABASE_URL) + strip /auth/v1. Vérifié prod : single → 303, double → 401.

## 2. Retrait "Se désinscrire" des emails transactionnels
Obligation marketing, pas relationnelle ; signal bulk → onglet Gmail. Prop `EvolveEmailShell.hideUnsubscribe` (défaut false → newsletters), true sur les 4 transactionnels.

## Vérif
Deno 7/7, @evolve/data 152 tests ; 4 Edge Functions redéployées (--use-api).

## Suivi owner (délivrabilité, hors code)
Entête List-Unsubscribe = niveau compte Brevo → désactiver pour transactionnel. SPF/DKIM/DMARC + BIMI pour logo expéditeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)