### PR TITLE
feat: cotisation minimale par club, éditable par le staff (défaut 100 €)

### DIFF
--- a/apps/web/app/(app)/admin/settings/SettingsView.tsx
+++ b/apps/web/app/(app)/admin/settings/SettingsView.tsx
@@ -45,6 +45,7 @@ function toFormState(s: ClubSettings): ClubSettingsInput {
     country: s.country ?? '',
     brokerAccountRef: s.brokerAccountRef ?? '',
     annualInvestmentCap: s.annualInvestmentCap === null ? '' : String(s.annualInvestmentCap),
+    minContribution: String(s.minContribution),
   }
 }
 
@@ -197,6 +198,25 @@ export function SettingsView({ initialSettings }: { initialSettings: ClubSetting
               )}
             </FormField>
           </div>
+
+          {/* Cotisation minimale du club (EUR) — éditable par le staff, défaut 100. Non sensible. */}
+          <FormField
+            label={t('fields.minContribution')}
+            helpText={t('hints.minContribution')}
+            required
+            {...errorProp(fieldError('min_contribution_invalid'))}
+          >
+            {(p) => (
+              <Input
+                {...p}
+                inputMode="decimal"
+                value={form.minContribution}
+                onChange={set('minContribution')}
+                placeholder="100"
+                disabled={isPending}
+              />
+            )}
+          </FormField>
         </section>
 
         {/* Paramètres sensibles (double-confirmation). */}

--- a/apps/web/lib/data/clubSettings.test.ts
+++ b/apps/web/lib/data/clubSettings.test.ts
@@ -16,6 +16,7 @@ const mkInput = (over: Partial<ClubSettingsInput> = {}): ClubSettingsInput => ({
   country: 'FR',
   brokerAccountRef: 'BRK-123',
   annualInvestmentCap: '10000',
+  minContribution: '100',
   ...over,
 })
 
@@ -95,6 +96,15 @@ describe('validateInput', () => {
   it('plafond vide est accepté (nullable)', () => {
     expect(validateInput(mkInput({ annualInvestmentCap: '' }))).toEqual([])
   })
+  it('cotisation minimale vide → min_contribution_invalid (requise)', () => {
+    expect(validateInput(mkInput({ minContribution: '' }))).toContain('min_contribution_invalid')
+  })
+  it('cotisation minimale négative → min_contribution_invalid', () => {
+    expect(validateInput(mkInput({ minContribution: '-1' }))).toContain('min_contribution_invalid')
+  })
+  it('cotisation minimale valide → aucune erreur', () => {
+    expect(validateInput(mkInput({ minContribution: '150' }))).toEqual([])
+  })
 })
 
 describe('buildUpdateArgs', () => {
@@ -106,6 +116,7 @@ describe('buildUpdateArgs', () => {
       p_country: 'FR',
       p_broker_account_ref: 'BRK-123',
       p_annual_investment_cap: 10000,
+      p_min_contribution: 100,
     })
   })
   it('champs vides → null (city, broker, cap)', () => {

--- a/apps/web/lib/data/clubSettings.ts
+++ b/apps/web/lib/data/clubSettings.ts
@@ -25,6 +25,8 @@ export interface ClubSettings {
   country: string | null // ISO 3166-1 alpha-2 (MAJUSCULES) ou null
   brokerAccountRef: string | null // champ SENSIBLE
   annualInvestmentCap: number | null // champ sensible (EUR)
+  /** Cotisation minimale du club (EUR). Éditable par le staff ; toujours définie (défaut 100). */
+  minContribution: number
   /** Lecture seule (jamais éditable ici) : nom du courtier issu de settings.broker_name. */
   brokerName: string | null
 }
@@ -37,6 +39,8 @@ export interface ClubSettingsInput {
   brokerAccountRef: string
   /** Chaîne du champ montant (peut contenir des espaces, virgule décimale FR). */
   annualInvestmentCap: string
+  /** Chaîne du champ cotisation minimale (EUR). Requis (valeur toujours présente). */
+  minContribution: string
 }
 
 /** Arguments passés à la RPC update_club_settings (null-safe). */
@@ -47,9 +51,14 @@ export interface ClubSettingsRpcArgs {
   p_country: string | null
   p_broker_account_ref: string | null
   p_annual_investment_cap: number | null
+  p_min_contribution: number | null
 }
 
-export type ValidationErrorCode = 'name_required' | 'country_invalid' | 'cap_invalid'
+export type ValidationErrorCode =
+  | 'name_required'
+  | 'country_invalid'
+  | 'cap_invalid'
+  | 'min_contribution_invalid'
 
 // ─── Helpers PURS (testés sans DB) ───────────────────────────────────────────
 
@@ -93,12 +102,16 @@ export function validateInput(input: ClubSettingsInput): ValidationErrorCode[] {
   if (!isValidCountry(normalizeCountry(input.country))) errors.push('country_invalid')
   const cap = parseAmount(input.annualInvestmentCap)
   if (cap !== null && (Number.isNaN(cap) || cap < 0)) errors.push('cap_invalid')
+  // Cotisation minimale : REQUISE (valeur toujours présente) + nombre ≥ 0.
+  const minC = parseAmount(input.minContribution)
+  if (minC === null || Number.isNaN(minC) || minC < 0) errors.push('min_contribution_invalid')
   return errors
 }
 
 /** Construit les arguments RPC null-safe à partir d'une entrée formulaire (suppose valide). */
 export function buildUpdateArgs(clubId: string, input: ClubSettingsInput): ClubSettingsRpcArgs {
   const cap = parseAmount(input.annualInvestmentCap)
+  const minC = parseAmount(input.minContribution)
   return {
     p_club_id: clubId,
     p_name: input.name.trim(),
@@ -106,6 +119,8 @@ export function buildUpdateArgs(clubId: string, input: ClubSettingsInput): ClubS
     p_country: normalizeCountry(input.country),
     p_broker_account_ref: normalizeText(input.brokerAccountRef),
     p_annual_investment_cap: cap !== null && !Number.isNaN(cap) ? cap : null,
+    // null → inchangé côté RPC (colonne NOT NULL) ; sinon la nouvelle valeur saisie.
+    p_min_contribution: minC !== null && !Number.isNaN(minC) ? minC : null,
   }
 }
 
@@ -123,12 +138,20 @@ export async function getClubSettings(
 ): Promise<ClubSettings> {
   const { data, error } = await supabase
     .from('clubs')
-    .select('id, name, city, country, broker_account_ref, annual_investment_cap, settings')
+    .select(
+      'id, name, city, country, broker_account_ref, annual_investment_cap, min_contribution, settings'
+    )
     .eq('id', clubId)
     .single<
       Pick<
         ClubRow,
-        'id' | 'name' | 'city' | 'country' | 'broker_account_ref' | 'annual_investment_cap'
+        | 'id'
+        | 'name'
+        | 'city'
+        | 'country'
+        | 'broker_account_ref'
+        | 'annual_investment_cap'
+        | 'min_contribution'
       > & { settings: ClubRow['settings'] }
     >()
   if (error) throw error
@@ -144,6 +167,8 @@ export async function getClubSettings(
     brokerAccountRef: data.broker_account_ref,
     annualInvestmentCap:
       data.annual_investment_cap === null ? null : Number(data.annual_investment_cap),
+    // NOT NULL en DB (défaut 100) ; repli défensif sur 100 si jamais absent.
+    minContribution: data.min_contribution === null ? 100 : Number(data.min_contribution),
     brokerName,
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -620,13 +620,15 @@
         "city": "City",
         "country": "Country",
         "brokerAccountRef": "Club broker account ID",
-        "annualInvestmentCap": "Annual investment cap"
+        "annualInvestmentCap": "Annual investment cap",
+        "minContribution": "Minimum contribution"
       },
       "hints": {
         "city": "City where the club is based.",
         "country": "ISO 2-letter country code (e.g. FR, BE, LU).",
         "brokerAccountRef": "The club's account reference at the broker. Sensitive field.",
-        "annualInvestmentCap": "Maximum amount investable per year, in euros. Sensitive field."
+        "annualInvestmentCap": "Maximum amount investable per year, in euros. Sensitive field.",
+        "minContribution": "Minimum contribution amount per member, in euros (default 100)."
       },
       "readonly": {
         "brokerName": "Broker: {value}"
@@ -634,7 +636,8 @@
       "errors": {
         "name_required": "The club name is required.",
         "country_invalid": "Invalid country code (2 letters expected, e.g. FR).",
-        "cap_invalid": "Invalid cap (a positive amount is expected)."
+        "cap_invalid": "Invalid cap (a positive amount is expected).",
+        "min_contribution_invalid": "Invalid minimum contribution (a positive amount is expected)."
       },
       "confirm": {
         "title": "Sensitive operation",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -620,13 +620,15 @@
         "city": "Ville",
         "country": "Pays",
         "brokerAccountRef": "Identifiant du club chez le courtier",
-        "annualInvestmentCap": "Plafond annuel d’investissement"
+        "annualInvestmentCap": "Plafond annuel d’investissement",
+        "minContribution": "Cotisation minimale"
       },
       "hints": {
         "city": "Ville où le club est domicilié.",
         "country": "Code pays ISO à 2 lettres (ex. FR, BE, LU).",
         "brokerAccountRef": "Référence du compte du club chez le courtier. Champ sensible.",
-        "annualInvestmentCap": "Montant maximum investissable par an, en euros. Champ sensible."
+        "annualInvestmentCap": "Montant maximum investissable par an, en euros. Champ sensible.",
+        "minContribution": "Montant minimum de cotisation par membre, en euros (défaut 100)."
       },
       "readonly": {
         "brokerName": "Courtier : {value}"
@@ -634,7 +636,8 @@
       "errors": {
         "name_required": "Le nom du club est obligatoire.",
         "country_invalid": "Code pays invalide (2 lettres attendues, ex. FR).",
-        "cap_invalid": "Plafond invalide (montant positif attendu)."
+        "cap_invalid": "Plafond invalide (montant positif attendu).",
+        "min_contribution_invalid": "Cotisation minimale invalide (montant positif attendu)."
       },
       "confirm": {
         "title": "Opération sensible",

--- a/packages/data/src/supabase/types.gen.ts
+++ b/packages/data/src/supabase/types.gen.ts
@@ -76,7 +76,7 @@ export type Database = {
           currency: string
           id: string
           last_error_email_sent_at: string | null
-          min_contribution: number | null
+          min_contribution: number
           name: string
           settings: Json
           sheet_id: string | null
@@ -93,7 +93,7 @@ export type Database = {
           currency?: string
           id?: string
           last_error_email_sent_at?: string | null
-          min_contribution?: number | null
+          min_contribution?: number
           name: string
           settings?: Json
           sheet_id?: string | null
@@ -110,7 +110,7 @@ export type Database = {
           currency?: string
           id?: string
           last_error_email_sent_at?: string | null
-          min_contribution?: number | null
+          min_contribution?: number
           name?: string
           settings?: Json
           sheet_id?: string | null
@@ -797,6 +797,7 @@ export type Database = {
           p_city?: string
           p_club_id: string
           p_country?: string
+          p_min_contribution?: number
           p_name?: string
         }
         Returns: undefined

--- a/supabase/migrations/033_club_min_contribution.sql
+++ b/supabase/migrations/033_club_min_contribution.sql
@@ -1,0 +1,92 @@
+-- 033_club_min_contribution.sql — Cotisation minimale par club, éditable par le staff.
+--
+-- L'owner veut un montant de cotisation MINIMUM par club, paramétrable par le trésorier/
+-- président dans l'espace admin, avec une valeur par DÉFAUT de 100 €.
+--
+-- La colonne `clubs.min_contribution` existe déjà (002) mais était nullable, sans défaut,
+-- et non exposée à l'édition. Ici : défaut 100, backfill des NULL existants, passage NOT NULL
+-- (la valeur est désormais toujours présente), et ajout du paramètre à la RPC staff d'édition.
+--
+-- Réf : 025/028 (update_club_settings), DATA_MODEL §4.1, CLAUDE.md (RLS, jamais service-role).
+
+-- 1. Défaut 100 + backfill + NOT NULL (toujours une valeur).
+ALTER TABLE clubs ALTER COLUMN min_contribution SET DEFAULT 100;
+UPDATE clubs SET min_contribution = 100 WHERE min_contribution IS NULL;
+ALTER TABLE clubs ALTER COLUMN min_contribution SET NOT NULL;
+
+-- 2. RPC d'édition : on ajoute p_min_contribution. La signature change (7e param) → on DROP
+--    l'ancienne (6 args) avant de recréer, sinon Postgres crée une surcharge ambiguë.
+DROP FUNCTION IF EXISTS public.update_club_settings(UUID, TEXT, TEXT, TEXT, TEXT, NUMERIC);
+
+CREATE OR REPLACE FUNCTION public.update_club_settings(
+  p_club_id                 UUID,
+  p_name                    TEXT    DEFAULT NULL,
+  p_city                    TEXT    DEFAULT NULL,
+  p_country                 TEXT    DEFAULT NULL,
+  p_broker_account_ref      TEXT    DEFAULT NULL,
+  p_annual_investment_cap   NUMERIC DEFAULT NULL,
+  p_min_contribution        NUMERIC DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_catalog
+AS $$
+DECLARE
+  v_name    TEXT;
+  v_city    TEXT;
+  v_country TEXT;
+  v_broker  TEXT;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM clubs WHERE id = p_club_id) THEN
+    RAISE EXCEPTION 'club introuvable' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Autorité staff vérifiée AVANT écriture (cf. 028).
+  IF NOT public.is_club_staff(p_club_id) THEN
+    RAISE EXCEPTION 'acces refuse : staff requis' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_name    := NULLIF(btrim(p_name), '');
+  v_city    := NULLIF(btrim(p_city), '');
+  v_country := NULLIF(btrim(p_country), '');
+  v_broker  := NULLIF(btrim(p_broker_account_ref), '');
+
+  IF v_name IS NULL THEN
+    v_name := (SELECT name FROM clubs WHERE id = p_club_id);
+  END IF;
+
+  IF v_country IS NOT NULL THEN
+    v_country := upper(v_country);
+    IF v_country !~ '^[A-Z]{2}$' THEN
+      RAISE EXCEPTION 'pays invalide (code ISO alpha-2 attendu)'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+  END IF;
+
+  IF p_annual_investment_cap IS NOT NULL AND p_annual_investment_cap < 0 THEN
+    RAISE EXCEPTION 'plafond annuel invalide (négatif)'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Cotisation minimale : négatif interdit. NULL → inchangé (la colonne est NOT NULL,
+  -- on ne l'efface jamais), via COALESCE dans l'UPDATE.
+  IF p_min_contribution IS NOT NULL AND p_min_contribution < 0 THEN
+    RAISE EXCEPTION 'cotisation minimale invalide (négative)'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  UPDATE clubs
+     SET name                  = v_name,
+         city                  = v_city,
+         country               = v_country,
+         broker_account_ref    = v_broker,
+         annual_investment_cap = p_annual_investment_cap,
+         min_contribution      = COALESCE(p_min_contribution, min_contribution),
+         updated_at            = NOW()
+   WHERE id = p_club_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_club_settings(UUID, TEXT, TEXT, TEXT, TEXT, NUMERIC, NUMERIC) FROM public;
+GRANT EXECUTE ON FUNCTION public.update_club_settings(UUID, TEXT, TEXT, TEXT, TEXT, NUMERIC, NUMERIC) TO authenticated;


### PR DESCRIPTION
Demande owner : montant de **cotisation minimum par club**, paramétrable par le trésorier/président dans l'espace admin, **défaut 100 €**. (`clubs.min_contribution` existait mais nullable, sans défaut, et non exposé.)

## Changements
- **Migration 033** : `clubs.min_contribution` défaut **100** + backfill des NULL + **NOT NULL** (toujours défini). `update_club_settings` gagne `p_min_contribution` (négatif interdit ; `NULL`=inchangé via COALESCE puisque la colonne est NOT NULL). DROP+CREATE car la signature passe à 7 params. `types.gen.ts` régénéré.
- **Data** (`clubSettings.ts`) : `minContribution` lu, validé (requis, ≥ 0), mappé vers la RPC.
- **Admin** (`SettingsView.tsx`) : champ « Cotisation minimale » dans les paramètres généraux (non sensible — pas de double-confirm, contrairement au plafond/courtier). Garde staff dans la RPC SECURITY DEFINER (jamais de service-role).
- i18n fr/en + tests (validation + buildUpdateArgs, +3).

## Tests
Gate vert : typecheck, web 138, data 152, ui 372, utils 53 ; lint clean ; i18n parity 559. DB locale vérifiée (NOT NULL + défaut 100 + backfill).

## Suivi owner
- **Appliquer la migration 033 en prod** (`supabase db push`) — le club prod passera à `min_contribution=100` (backfill) ; ajustable ensuite dans /admin/settings.
- Indépendant de la PR #19 (QA mobile). Le « 50 » vu dans le Storybook ContributionStatusCard était un placeholder de story (ne lit pas la donnée club).

🤖 Generated with [Claude Code](https://claude.com/claude-code)