### PR TITLE
feat(cms): rebuild auto de la vitrine au changement de contenu Strapi

### DIFF
--- a/.github/workflows/deploy-vitrine.yml
+++ b/.github/workflows/deploy-vitrine.yml
@@ -23,6 +23,12 @@ on:
     types: [strapi-content-update]
   workflow_dispatch:
 
+# Plusieurs publications Strapi rapprochées → plusieurs dispatches. On coalesce : un seul
+# déploiement Pages à la fois, sans annuler celui en cours (cancel-in-progress: false).
+concurrency:
+  group: deploy-vitrine-pages
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/apps/cms/.env.production.example
+++ b/apps/cms/.env.production.example
@@ -38,4 +38,14 @@ DATABASE_SSL=false
 #      donc CORS est peu critique ; on scope quand même au domaine vitrine). ----
 CMS_CORS_ORIGINS=https://reseauevolvecapital.com,https://www.reseauevolvecapital.com
 
+# ---- Rebuild auto de la vitrine au changement de contenu (repository_dispatch GitHub) ----
+# À la publication/dépublication/suppression d'un contenu éditorial, Strapi déclenche le
+# workflow deploy-vitrine.yml. NON renseigné = fonctionnalité OFF (no-op).
+# Token : PAT fine-grained sur CE dépôt avec permission « Contents: Read and write »
+# (ou PAT classic scope `repo`). Server-only — ne JAMAIS exposer au client.
+GITHUB_DISPATCH_TOKEN=
+# Dépôt cible (défaut ci-dessous si vide) et type d'évènement (doit matcher deploy-vitrine.yml).
+GITHUB_DISPATCH_REPO=reseau-evolve-capital/reseau-evolve-capital.github.io
+GITHUB_DISPATCH_EVENT_TYPE=strapi-content-update
+
 NODE_ENV=production

--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -12,12 +12,67 @@ const PUBLIC_READ_UIDS = [
 ] as const
 const PUBLIC_READ_ACTIONS = ['find', 'findOne'] as const
 
+// --- Rebuild de la vitrine (blog statique) au changement de contenu ----------------------
+// À la publication / dépublication / suppression d'un contenu éditorial, on déclenche un
+// `repository_dispatch` GitHub → le workflow deploy-vitrine.yml rebuild le blog SSG avec le
+// contenu à jour. Le webhook NATIF de Strapi ne convient pas (son corps ≠ `{ event_type }`
+// exigé par l'API GitHub), d'où ce déclenchement côté code.
+// NO-OP sans `GITHUB_DISPATCH_TOKEN` → inactif en local et tant que le secret n'est pas posé.
+const REBUILD_UIDS = [
+  'api::article.article',
+  'api::category.category',
+  'api::author.author',
+  'api::tag.tag',
+]
+const REBUILD_ACTIONS = ['publish', 'unpublish', 'delete']
+
+async function triggerVitrineRebuild(strapi: Core.Strapi, reason: string): Promise<void> {
+  const token = process.env.GITHUB_DISPATCH_TOKEN
+  if (!token) {
+    strapi.log.debug('[rebuild] GITHUB_DISPATCH_TOKEN absent → dispatch ignoré (no-op).')
+    return
+  }
+  const repo =
+    process.env.GITHUB_DISPATCH_REPO || 'reseau-evolve-capital/reseau-evolve-capital.github.io'
+  const eventType = process.env.GITHUB_DISPATCH_EVENT_TYPE || 'strapi-content-update'
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ event_type: eventType, client_payload: { reason } }),
+    })
+    if (res.ok) {
+      strapi.log.info(`[rebuild] vitrine déclenchée (${reason}) → ${repo} [${eventType}]`)
+    } else {
+      strapi.log.error(`[rebuild] dispatch GitHub échec ${res.status} : ${await res.text()}`)
+    }
+  } catch (err) {
+    strapi.log.error(`[rebuild] dispatch GitHub erreur : ${(err as Error).message}`)
+  }
+}
+
 export default {
   /**
-   * An asynchronous register function that runs before
-   * your application is initialized.
+   * Enregistre un middleware Document Service qui déclenche le rebuild de la vitrine
+   * sur publish/unpublish/delete des contenus éditoriaux. Fire-and-forget : ne bloque
+   * jamais l'opération admin, ne lève jamais (erreurs loggées). Cf. GITHUB_DISPATCH_* (.env).
    */
-  register(/* { strapi }: { strapi: Core.Strapi } */) {},
+  register({ strapi }: { strapi: Core.Strapi }) {
+    strapi.documents.use(async (context, next) => {
+      const result = await next()
+      const uid = String((context as { uid?: string }).uid ?? '')
+      const action = String((context as { action?: string }).action ?? '')
+      if (REBUILD_UIDS.includes(uid) && REBUILD_ACTIONS.includes(action)) {
+        void triggerVitrineRebuild(strapi, `${uid}:${action}`)
+      }
+      return result
+    })
+  },
 
   /**
    * Accorde au rôle "public" les permissions find/findOne sur les content-types du blog,

--- a/docs/infra/RUNBOOK-cms-digitalocean.md
+++ b/docs/infra/RUNBOOK-cms-digitalocean.md
@@ -284,9 +284,28 @@ ne renvoie aucun article → ne publie jamais un blog vide par-dessus le live).
 - Optionnel : définir des **variables de dépôt** GitHub `NEXT_PUBLIC_STRAPI_API_URL`
   (`…/api`) et `NEXT_PUBLIC_STRAPI_URL` pour surcharger les valeurs par défaut.
 - Déclencher un rebuild manuel : onglet **Actions → Deploy Vitrine → Run workflow**.
-- Pour rebuild le blog **quand le contenu change** (sans commit) : câbler un **webhook Strapi**
-  (Settings → Webhooks) vers un `repository_dispatch` GitHub de type `strapi-content-update`
-  (suivi non bloquant — à faire après le premier déploiement).
+
+### Rebuild automatique au changement de contenu (implémenté)
+
+À la **publication / dépublication / suppression** d'un contenu éditorial, Strapi déclenche
+lui-même le workflow via `repository_dispatch` (code dans `apps/cms/src/index.ts`, middleware
+Document Service). **NO-OP tant que `GITHUB_DISPATCH_TOKEN` n'est pas posé.** Activation :
+
+1. **Créer un PAT** GitHub _fine-grained_ sur le dépôt `reseau-evolve-capital.github.io`
+   avec la permission **Contents: Read and write** (ou PAT classic, scope `repo`).
+2. **Sur le droplet**, ajouter à `/opt/strapi/.env` :
+   ```bash
+   GITHUB_DISPATCH_TOKEN=<le_PAT>
+   # GITHUB_DISPATCH_REPO et GITHUB_DISPATCH_EVENT_TYPE ont déjà les bons défauts.
+   ```
+3. **Recharger** (le code du middleware vit dans l'image → tirer l'image à jour puis relancer) :
+   ```bash
+   cd /opt/strapi && ./deploy-production.sh        # pull image + up -d (recrée avec le nouveau .env)
+   ```
+4. **Tester** : publier un article dans l'admin → un run **deploy-vitrine** apparaît dans Actions
+   (logs Strapi : `[rebuild] vitrine déclenchée (...)`).
+
+> Le `concurrency` du workflow coalesce les déclenchements rapprochés (un déploiement Pages à la fois).
 
 ---
 
@@ -382,7 +401,8 @@ Voir la section **Rollback** ci-dessous (réépingler un tag `:<sha>` connu-bon 
 
 ## Suivis (hors périmètre du premier déploiement)
 
-- **Webhook contenu → rebuild vitrine** (`repository_dispatch strapi-content-update`).
+- ~~Webhook contenu → rebuild vitrine~~ ✅ **implémenté** (§11 — middleware Strapi → `repository_dispatch` ;
+  reste à poser `GITHUB_DISPATCH_TOKEN` sur le droplet pour l'activer).
 - **Upgrade médias DO Spaces / S3** : justifié seulement si les médias grossissent beaucoup,
   qu'on veut un CDN, ou qu'on dépasse **une seule instance** Strapi (un volume local ne se
   partage pas entre réplicas). Les providers `strapi-provider-upload-do` et


### PR DESCRIPTION
Quand un contenu éditorial est **publié / dépublié / supprimé** dans Strapi, le blog statique
de la vitrine se reconstruit automatiquement (plus besoin de lancer le workflow à la main).

## Pourquoi côté code et pas un webhook Strapi natif

Le webhook intégré de Strapi envoie **son propre** corps JSON ; l'API GitHub `repository_dispatch`
**exige** `{"event_type":"strapi-content-update"}` + un token. Un webhook Strapi brut est donc
rejeté (422). On déclenche donc le `repository_dispatch` **depuis le code** (middleware Document
Service), où l'on maîtrise le corps et l'auth.

## Contenu

- **`apps/cms/src/index.ts`** — `register()` enregistre un middleware Document Service ; sur
  `publish` / `unpublish` / `delete` de `article` / `category` / `author` / `tag`, il POST
  `repository_dispatch` à GitHub. **Fire-and-forget** (ne bloque ni ne casse l'action admin,
  erreurs loggées) et **NO-OP sans `GITHUB_DISPATCH_TOKEN`** → inactif en local et tant que le
  secret n'est pas posé sur le droplet.
- **`.env.production.example`** — `GITHUB_DISPATCH_TOKEN` (PAT fine-grained, *Contents: write*) +
  `GITHUB_DISPATCH_REPO` / `GITHUB_DISPATCH_EVENT_TYPE` (défauts fournis).
- **`deploy-vitrine.yml`** — `concurrency` group (coalesce les publications rapprochées → un seul
  déploiement Pages à la fois). Le workflow écoutait déjà `repository_dispatch: [strapi-content-update]`.
- **Runbook §11** — étapes d'activation (créer le PAT, poser le `.env`, `./deploy-production.sh`, tester).

## Tests / validation locale

- `apps/cms` **build** sous Node 22 — `src/index.ts` compile sans erreur (seul le warning
  pré-existant `tailwind.config.ts` subsiste, non bloquant).
- **Boot** OK (`Strapi started successfully`) avec le nouveau middleware ; aucun dispatch au
  démarrage (no-op sans token).
- Aucune source de workspace pnpm modifiée → gate turbo inchangé.

## Activation (action owner, après merge)

1. Merger → l'image CMS se reconstruit (CI), `./deploy-production.sh` sur le droplet.
2. Créer un PAT *Contents: write* sur ce dépôt, le poser dans `/opt/strapi/.env`
   (`GITHUB_DISPATCH_TOKEN=…`), relancer.
3. Publier un article → un run **deploy-vitrine** doit apparaître dans Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)