### PR TITLE
fix(vitrine): le switch de locale du blog pointe vers le bon article

### DIFF
--- a/apps/vitrine/src/app/[locale]/blog/[slug]/page.tsx
+++ b/apps/vitrine/src/app/[locale]/blog/[slug]/page.tsx
@@ -14,7 +14,6 @@ interface ArticlePageProps {
   params: Promise<{
     locale: string
     slug: string
-    documentId: string
   }>
 }
 
@@ -31,7 +30,6 @@ export async function generateStaticParams() {
     params.push({
       locale: 'fr',
       slug: article.slug,
-      documentId: article.documentId,
     })
   }
 
@@ -40,7 +38,6 @@ export async function generateStaticParams() {
     params.push({
       locale: 'en',
       slug: article.slug,
-      documentId: article.documentId,
     })
   }
 
@@ -48,7 +45,7 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
-  const { locale, slug, documentId } = await params
+  const { locale, slug } = await params
 
   const article = await getArticleBySlug(slug, locale)
 
@@ -57,10 +54,13 @@ export async function generateMetadata({ params }: ArticlePageProps): Promise<Me
       title: 'Article not found',
     }
   }
-  const alternateArticle = await getArticleOfLocaleAndDocumentId(
-    documentId,
-    locale === 'fr' ? 'en' : 'fr'
-  )
+  // Le `documentId` (identifiant Strapi partagé entre locales) vient de l'article
+  // fetché, PAS des params de route : `[locale]/blog/[slug]` n'a pas de segment
+  // documentId, donc `params.documentId` était `undefined` → l'alternate pointait
+  // sur le premier article de l'autre locale (mauvais article au switch de langue).
+  const alternateArticle = article.documentId
+    ? await getArticleOfLocaleAndDocumentId(article.documentId, locale === 'fr' ? 'en' : 'fr')
+    : null
 
   const alternates = {
     canonical: `/blog/${slug}`,


### PR DESCRIPTION
## Contexte

Suite à EDI-008, des articles ont désormais une locale EN, ce qui a exposé deux comportements i18n du blog vitrine jamais exercés avant. Investigation menée en debug systématique (reproduit en local, root cause confirmée par les tags HTML + la DB).

## Bug #2 — Changer de langue depuis un article redirige vers un AUTRE article (corrigé ici, **code**)

**Symptôme** : sur `/en/blog/lets-avoid-haste/`, cliquer FR redirigeait vers `/fr/blog/investir-en-club-nouvelle-generation/` (un autre article) au lieu de la version FR du même article.

**Root cause** : `generateMetadata` lisait `params.documentId`, mais la route `[locale]/blog/[slug]` **n'a pas de segment `documentId`** → `params.documentId` valait `undefined`. `getArticleOfLocaleAndDocumentId(undefined, …)` renvoyait donc le **premier** article de l'autre locale, et le `<link rel="alternate" hreflang="fr">` pointait sur le mauvais slug (le switcher du header lit ces tags).

**Fix** : récupérer le `documentId` depuis l'article déjà fetché (`article.documentId` — identifiant Strapi partagé entre locales) au lieu des params de route. Nettoyage : `documentId` retiré du type de params et de `generateStaticParams` (clé ignorée par Next, trompeuse).

**Preuve (avant → après, build statique `out/`)** :
- EN `lets-avoid-haste` → alternate `fr` : `investir-en-club-nouvelle-generation` ❌ → `evitons-l-empressement` ✅
- FR `evitons-l-empressement` → alternate `en` : `lets-avoid-haste` ✅
- `next build` vitrine **vert** (types + lint).

## Bug #1 — La 2ᵉ catégorie disparaît en EN (= **donnée**, pas de code)

**Root cause** : le content-type `category` est `localized: true`. En base, « La Quote-Part » n'existait **qu'en `fr`** (pas de ligne `en`), « education » dans les deux. Donc `getAllCategories('en')` ne renvoyait que « education ». **La vitrine est correcte** — il manquait juste la traduction EN de la catégorie.

**Fix = action de contenu (owner)**, pas du code. Vérifié en local : après avoir créé+publié la locale EN de « La Quote-Part » (nom inchangé, c'est un terme de marque), l'API `categories?locale=en` renvoie les deux et les deux chips s'affichent sur `/en/blog`.

### À faire en prod (Strapi DO) — analogue au reset du slug
Pour **chaque catégorie présente seulement en FR** (au moins « La Quote-Part ») :
1. Content Manager → **Category** → ouvrir la catégorie → basculer locale **English (en)**.
2. Renseigner `name` (garder « La Quote-Part » tel quel — terme de marque), une description EN.
3. **Save** puis **Publish**.

> Suivi possible (hors scope) : rendre `category` **non localisé** (catégories partagées entre locales) éviterait d'avoir à traduire chaque catégorie — mais c'est un changement de schéma + migration de données, à décider séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)