### PR TITLE
feat(web): relais d'appareil PWA iOS — lien de connexion portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Mémoire/instructions locales Claude Code (personnel, non versionné)
+CLAUDE.local.md
+
 # dependencies
 /node_modules
 **/node_modules

--- a/apps/web/app/(app)/profil/InstallSection.tsx
+++ b/apps/web/app/(app)/profil/InstallSection.tsx
@@ -29,7 +29,7 @@ export function InstallSection() {
     promptInstall,
     openInstructionModal,
     closeInstructionModal,
-    copyUrlToClipboard,
+    copyHandoffLink,
   } = usePwaActions()
 
   // SSR-safe : pwaCase = 'unsupported' au render serveur + hydratation → promptable false → null.
@@ -47,12 +47,20 @@ export function InstallSection() {
       openInstructionModal()
       return
     }
-    const ok = await copyUrlToClipboard()
+    // ios-other : lien de connexion portable (auto-login en Safari), fallback URL courante.
+    const { ok, usedHandoff } = await copyHandoffLink()
     if (ok) {
       analyticsEvents.pwa.clipboardCopied()
-      toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
+      if (usedHandoff) {
+        toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
+      } else {
+        toast.success({
+          title: t('toastCopiedPlain.title'),
+          message: t('toastCopiedPlain.message'),
+        })
+      }
     }
-  }, [pwaCase, promptInstall, openInstructionModal, copyUrlToClipboard, toast, t])
+  }, [pwaCase, promptInstall, openInstructionModal, copyHandoffLink, toast, t])
 
   if (!promptable) return null
 

--- a/apps/web/app/(auth)/login/verify/route.test.ts
+++ b/apps/web/app/(auth)/login/verify/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+  verifyOtp: vi.fn(),
+}))
+vi.mock('@evolve/data', () => ({
+  createServerClient: () => ({
+    auth: {
+      exchangeCodeForSession: mocks.exchangeCodeForSession,
+      verifyOtp: mocks.verifyOtp,
+    },
+  }),
+}))
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, getAll: () => [], set: () => {} }),
+}))
+
+import { GET } from './route'
+
+function req(query: string) {
+  return new Request(`http://localhost:3001/login/verify?${query}`)
+}
+
+function location(res: Response): string {
+  return res.headers.get('location') ?? ''
+}
+
+beforeEach(() => {
+  mocks.exchangeCodeForSession.mockReset()
+  mocks.verifyOtp.mockReset()
+})
+
+describe('GET /login/verify', () => {
+  it('redirige /login/verify/expired si ni code ni token_hash', async () => {
+    const res = await GET(req(''))
+    expect(location(res)).toContain('/login/verify/expired')
+  })
+
+  it('redirige /login/verify/expired si Supabase renvoie ?error', async () => {
+    const res = await GET(req('error=access_denied&token_hash=x&type=email'))
+    expect(location(res)).toContain('/login/verify/expired')
+  })
+
+  it('flux nominal token_hash → /dashboard', async () => {
+    mocks.verifyOtp.mockResolvedValue({ error: null })
+    const res = await GET(req('token_hash=HASH&type=email'))
+    expect(location(res)).toContain('/dashboard')
+    expect(location(res)).not.toContain('pwa=ios')
+  })
+
+  it('relais PWA : token_hash + pwa=ios → /dashboard?pwa=ios', async () => {
+    mocks.verifyOtp.mockResolvedValue({ error: null })
+    const res = await GET(req('token_hash=HASH&type=email&pwa=ios'))
+    expect(location(res)).toContain('/dashboard?pwa=ios')
+  })
+
+  it("invitation : pwa=ios n'altère pas la branche onboarding", async () => {
+    mocks.verifyOtp.mockResolvedValue({ error: null })
+    const res = await GET(req('token_hash=HASH&type=email&invited=1&pwa=ios'))
+    expect(location(res)).toContain('/onboarding/step-1?invited=1')
+    expect(location(res)).not.toContain('pwa=ios')
+  })
+
+  it('redirige /login/verify/expired si verifyOtp échoue', async () => {
+    mocks.verifyOtp.mockResolvedValue({ error: { message: 'expired' } })
+    const res = await GET(req('token_hash=HASH&type=email'))
+    expect(location(res)).toContain('/login/verify/expired')
+  })
+})

--- a/apps/web/app/(auth)/login/verify/route.ts
+++ b/apps/web/app/(auth)/login/verify/route.ts
@@ -44,6 +44,9 @@ export async function GET(request: Request): Promise<Response> {
   const tokenHash = url.searchParams.get('token_hash')
   const otpType = url.searchParams.get('type')
   const invited = url.searchParams.get('invited') === '1'
+  // Marqueur « relais d'appareil » PWA (cf. /api/auth/handoff-link) : propagé jusqu'au dashboard
+  // pour proposer l'installation à l'arrivée dans Safari. Sans incidence sur le flux invitation.
+  const pwa = url.searchParams.get('pwa')
 
   // Supabase renvoie ?error=…&error_code=… quand le lien est déjà consommé ou expiré.
   if (url.searchParams.get('error')) return expired()
@@ -68,6 +71,12 @@ export async function GET(request: Request): Promise<Response> {
   // /dashboard ; le middleware re-route vers /onboarding/step-1 si l'inscription n'est pas
   // terminée. Cas invitation : on entre directement dans l'onboarding avec l'accueil dédié
   // (?invited=1) — le membre invité n'est jamais onboardé à ce stade.
-  const destination = invited ? '/onboarding/step-1?invited=1' : '/dashboard'
+  // Cas invitation : onboarding dédié (le marqueur pwa ne s'applique pas à ce flux). Sinon,
+  // on vise /dashboard et on y propage ?pwa=ios pour déclencher la bannière d'installation.
+  const destination = invited
+    ? '/onboarding/step-1?invited=1'
+    : pwa === 'ios'
+      ? '/dashboard?pwa=ios'
+      : '/dashboard'
   return NextResponse.redirect(new URL(destination, origin()))
 }

--- a/apps/web/app/api/auth/handoff-link/route.test.ts
+++ b/apps/web/app/api/auth/handoff-link/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  generateLink: vi.fn(),
+}))
+vi.mock('@evolve/data', () => ({
+  createServerClient: () => ({
+    auth: { getUser: mocks.getUser },
+  }),
+  createServiceRoleClient: () => ({
+    auth: { admin: { generateLink: mocks.generateLink } },
+  }),
+}))
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, getAll: () => [], set: () => {} }),
+}))
+
+import { POST } from './route'
+
+beforeEach(() => {
+  mocks.getUser.mockReset()
+  mocks.generateLink.mockReset()
+})
+
+describe('POST /api/auth/handoff-link', () => {
+  it('401 si pas de session', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthenticated' })
+    expect(mocks.generateLink).not.toHaveBeenCalled()
+  })
+
+  it("401 si l'utilisateur n'a pas d'email", async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1', email: null } } })
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(mocks.generateLink).not.toHaveBeenCalled()
+  })
+
+  it('200 + URL portable vers /login/verify (token_hash, type=email, pwa=ios)', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'membre@example.com' } } })
+    mocks.generateLink.mockResolvedValue({
+      data: { properties: { hashed_token: 'HASH' } },
+      error: null,
+    })
+    const res = await POST()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    // On ne frappe un lien que pour l'email de l'appelant — jamais un email arbitraire.
+    expect(mocks.generateLink).toHaveBeenCalledWith({
+      type: 'magiclink',
+      email: 'membre@example.com',
+    })
+    const body = (await res.json()) as { url: string }
+    expect(body.url).toContain('/login/verify')
+    expect(body.url).toContain('token_hash=HASH')
+    expect(body.url).toContain('type=email')
+    expect(body.url).toContain('pwa=ios')
+  })
+
+  it('500 si generateLink échoue', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'membre@example.com' } } })
+    mocks.generateLink.mockResolvedValue({ data: null, error: { message: 'boom' } })
+    const res = await POST()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'mint_failed' })
+  })
+
+  it('500 si hashed_token absent', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'membre@example.com' } } })
+    mocks.generateLink.mockResolvedValue({ data: { properties: {} }, error: null })
+    const res = await POST()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'mint_failed' })
+  })
+})

--- a/apps/web/app/api/auth/handoff-link/route.ts
+++ b/apps/web/app/api/auth/handoff-link/route.ts
@@ -1,0 +1,71 @@
+// Endpoint POST /api/auth/handoff-link — « relais d'appareil » PWA (iOS).
+//
+// Cas d'usage : un membre déjà connecté sur iPhone-Chrome veut installer la PWA, ce qui
+// n'est possible que depuis Safari. Or Safari est un autre navigateur → aucune session.
+// On frappe une URL de connexion PORTABLE à usage unique pour l'utilisateur COURANT ; le
+// client la copie dans le presse-papiers, et la coller dans Safari l'authentifie.
+//
+// Pourquoi pas le magic link nominal ? Le flux nominal est PKCE (signInWithOtp) : son
+// `code` est lié au navigateur d'origine (cookie `code_verifier`) et ne fonctionnerait pas
+// d'un navigateur à l'autre. On RÉUTILISE donc le chemin OTP portable déjà éprouvé pour les
+// invitations (/login/invite) : `admin.generateLink('magiclink')` produit un `hashed_token`
+// qui se vérifie côté /login/verify via `verifyOtp` (type 'email') — sans cookie, donc
+// portable d'un navigateur à l'autre. Le marqueur `?pwa=ios` est propagé jusqu'au dashboard
+// pour y proposer l'installation à l'arrivée dans Safari.
+//
+// Garde-fous : la session de l'appelant est la garde primaire (on ne frappe un lien que pour
+// SOI-MÊME, jamais pour un email arbitraire). Réponse jamais cachée (no-store : c'est un
+// credential). POST uniquement — pas de GET (un GET frapperait un credential).
+//
+// Réf : /login/invite/route.ts (recette OTP portable), /login/verify/route.ts (verifyOtp),
+// CLAUDE.md (service-role server-only, conventions auth), MEMORY pwa-001-install-banner.
+
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { createServerClient, createServiceRoleClient } from '@evolve/data'
+
+import { siteOrigin } from '@/lib/invitations/token'
+import { checkRateLimit, rateLimitedResponse } from '@/lib/rate-limit'
+
+export const runtime = 'nodejs'
+
+export async function POST(): Promise<NextResponse> {
+  // 1. Session de l'appelant (anon + cookies → RLS) : on ne frappe un lien que pour SOI.
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user || !user.email) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  // 2. Rate limit : 10 req / 5 min par user (anti-rafale de mint ; fail-open si Upstash absent).
+  const rl = await checkRateLimit('handoff', user.id)
+  if (!rl.allowed) {
+    return rateLimitedResponse(rl.retryAfterSeconds)
+  }
+
+  // 3. Mint d'un lien magique (admin/service-role) pour CET email — son hashed_token est portable.
+  const admin = createServiceRoleClient()
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: 'magiclink',
+    email: user.email,
+  })
+
+  const hashed = data?.properties?.hashed_token
+  if (error || !hashed) {
+    // Log server-only — on ne fuite jamais le détail au client (credential / surface d'attaque).
+    console.error('handoff-link: échec generateLink', error?.message ?? 'hashed_token absent')
+    return NextResponse.json({ error: 'mint_failed' }, { status: 500 })
+  }
+
+  // 4. URL portable vers /login/verify : verifyOtp type 'email' (≠ PKCE), + marqueur pwa=ios.
+  const url = new URL('/login/verify', siteOrigin())
+  url.searchParams.set('token_hash', hashed)
+  url.searchParams.set('type', 'email')
+  url.searchParams.set('pwa', 'ios')
+
+  return NextResponse.json({ url: url.toString() }, { headers: { 'Cache-Control': 'no-store' } })
+}

--- a/apps/web/components/pwa/InstallBannerMount.tsx
+++ b/apps/web/components/pwa/InstallBannerMount.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { usePathname } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { Suspense, useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 
 import { PwaInstallSheet, useToast, type IosInstallInstructionsCopy } from '@evolve/ui'
@@ -22,8 +22,15 @@ const IosInstallInstructions = dynamic(
 
 function InstallBannerInner() {
   const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const t = useTranslations('pwa')
   const toast = useToast()
+
+  // Arrivée fraîchement connecté en Safari via le lien de handoff (`/dashboard?pwa=ios`) :
+  // on force l'affichage immédiat de la bannière (bypass éligibilité + délai 0).
+  const forceImmediate = searchParams.get('pwa') === 'ios'
+
   const {
     pwaCase,
     shouldShowBanner,
@@ -32,8 +39,8 @@ function InstallBannerInner() {
     openInstructionModal,
     closeInstructionModal,
     dismiss,
-    copyUrlToClipboard,
-  } = usePwaInstall()
+    copyHandoffLink,
+  } = usePwaInstall({ forceImmediate })
 
   // Masquage local après une action terminée (install acceptée, dismiss, modale fermée).
   const [hidden, setHidden] = useState(false)
@@ -62,6 +69,14 @@ function InstallBannerInner() {
     }
   }, [visible, pwaCase])
 
+  // Nettoie le paramètre `?pwa=ios` de l'URL après montage, pour qu'un refresh ne re-déclenche
+  // pas l'affichage forcé. Strip une seule fois (router.replace même chemin → pas de boucle).
+  useEffect(() => {
+    if (!onDashboard) return
+    if (searchParams.get('pwa') === null) return
+    router.replace(pathname)
+  }, [onDashboard, searchParams, router, pathname])
+
   const handleDismiss = useCallback(() => {
     try {
       const state = dismissStore.read()
@@ -86,14 +101,22 @@ function InstallBannerInner() {
       openInstructionModal()
       return
     }
-    // ios-other : copie l'URL puis invite à coller dans Safari.
-    const ok = await copyUrlToClipboard()
+    // ios-other : copie un lien de connexion portable (auto-login en Safari) puis invite à
+    // coller. Si le handoff échoue, on retombe sur la copie de l'URL courante.
+    const { ok, usedHandoff } = await copyHandoffLink()
     if (ok) {
       analyticsEvents.pwa.clipboardCopied()
-      toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
+      if (usedHandoff) {
+        toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
+      } else {
+        toast.success({
+          title: t('toastCopiedPlain.title'),
+          message: t('toastCopiedPlain.message'),
+        })
+      }
     }
     setHidden(true)
-  }, [pwaCase, promptInstall, openInstructionModal, copyUrlToClipboard, toast, t])
+  }, [pwaCase, promptInstall, openInstructionModal, copyHandoffLink, toast, t])
 
   // Fermeture de la modale iOS (Done ou Escape) = on a montré les instructions → cooldown + masquage.
   const handleModalClose = useCallback(() => {
@@ -172,12 +195,15 @@ function InstallBannerInner() {
 /**
  * Point de montage de la bannière PWA (PWA-001). Monté dans le layout (app) (persiste entre
  * onglets) mais ne s'affiche que sur /dashboard. Toute la logique est enrobée d'un
- * ErrorBoundary : une erreur ici ne peut jamais crasher le dashboard.
+ * ErrorBoundary : une erreur ici ne peut jamais crasher le dashboard. Le `Suspense` est requis
+ * par `useSearchParams` (lecture de `?pwa=ios`) — fallback `null`, rien à afficher en attente.
  */
 export function InstallBannerMount() {
   return (
     <InstallBannerErrorBoundary>
-      <InstallBannerInner />
+      <Suspense fallback={null}>
+        <InstallBannerInner />
+      </Suspense>
     </InstallBannerErrorBoundary>
   )
 }

--- a/apps/web/lib/pwa/copy-handoff-link.test.ts
+++ b/apps/web/lib/pwa/copy-handoff-link.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { copyHandoffLink } from './use-pwa-install'
+
+const HANDOFF_URL = 'https://evolve.example/login/verify?token_hash=abc&type=email&pwa=ios'
+const CURRENT_URL = 'https://evolve.example/dashboard'
+
+// `navigator` est un getter en lecture seule sur Node → on passe par vi.stubGlobal
+// (gère le défini/non-défini et restaure proprement via unstubAllGlobals).
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/** `ClipboardItem` factice : conserve la map d'items pour pouvoir résoudre la Promise<Blob>. */
+class FakeClipboardItem {
+  items: Record<string, Promise<Blob> | Blob>
+  constructor(items: Record<string, Promise<Blob> | Blob>) {
+    this.items = items
+  }
+}
+
+describe('copyHandoffLink', () => {
+  it('palier 1 (ClipboardItem) : succès → usedHandoff true, lien du serveur copié', async () => {
+    vi.stubGlobal('ClipboardItem', FakeClipboardItem)
+    let copiedText: string | null = null
+    const write = vi.fn(async (items: FakeClipboardItem[]) => {
+      // Reproduit Safari : résout la Promise<Blob> tout en préservant le geste utilisateur.
+      const blob = (await items[0]!.items['text/plain']) as Blob
+      copiedText = await blob.text()
+    })
+    vi.stubGlobal('navigator', { clipboard: { write } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ url: HANDOFF_URL }) }))
+    )
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: true, usedHandoff: true })
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(copiedText).toBe(HANDOFF_URL)
+  })
+
+  it('palier 1 : fetch non-200 → bascule fallback (writeText) puis dernier recours URL', async () => {
+    vi.stubGlobal('ClipboardItem', FakeClipboardItem)
+    // write attend la Promise<Blob> qui rejette (handoff_failed) → write rejette → fallback.
+    const write = vi.fn(async (items: FakeClipboardItem[]) => {
+      await items[0]!.items['text/plain']
+    })
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { clipboard: { write, writeText } })
+    // fetch 401 aux deux paliers → dernier recours = copie de l'URL courante.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, json: async () => ({}) }))
+    )
+    vi.stubGlobal('window', { location: { href: CURRENT_URL } })
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: true, usedHandoff: false })
+    expect(writeText).toHaveBeenCalledWith(CURRENT_URL)
+  })
+
+  it('palier 2 (pas de ClipboardItem) : fetch + writeText → usedHandoff true', async () => {
+    vi.stubGlobal('ClipboardItem', undefined)
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ url: HANDOFF_URL }) }))
+    )
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: true, usedHandoff: true })
+    expect(writeText).toHaveBeenCalledWith(HANDOFF_URL)
+  })
+
+  it('palier 2 : fetch non-200 → dernier recours URL courante, usedHandoff false', async () => {
+    vi.stubGlobal('ClipboardItem', undefined)
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, json: async () => ({}) }))
+    )
+    vi.stubGlobal('window', { location: { href: CURRENT_URL } })
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: true, usedHandoff: false })
+    expect(writeText).toHaveBeenLastCalledWith(CURRENT_URL)
+  })
+
+  it('clipboard totalement indisponible → ok false, usedHandoff false', async () => {
+    vi.stubGlobal('ClipboardItem', undefined)
+    vi.stubGlobal('navigator', {}) // pas de clipboard du tout
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ url: HANDOFF_URL }) }))
+    )
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: false, usedHandoff: false })
+  })
+
+  it('SSR-safe : navigator absent → ok false, pas de crash', async () => {
+    vi.stubGlobal('ClipboardItem', undefined)
+    vi.stubGlobal('navigator', undefined)
+    vi.stubGlobal('fetch', undefined)
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: false, usedHandoff: false })
+  })
+
+  it('palier 1 : fetch rejette (réseau) → bascule fallback puis dernier recours', async () => {
+    vi.stubGlobal('ClipboardItem', FakeClipboardItem)
+    const write = vi.fn(async (items: FakeClipboardItem[]) => {
+      await items[0]!.items['text/plain']
+    })
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { clipboard: { write, writeText } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network')
+      })
+    )
+    vi.stubGlobal('window', { location: { href: CURRENT_URL } })
+
+    const res = await copyHandoffLink()
+
+    expect(res).toEqual({ ok: true, usedHandoff: false })
+    expect(writeText).toHaveBeenCalledWith(CURRENT_URL)
+  })
+})

--- a/apps/web/lib/pwa/install-banner-trigger.test.ts
+++ b/apps/web/lib/pwa/install-banner-trigger.test.ts
@@ -90,10 +90,10 @@ describe('BannerTriggerController', () => {
   it('fires onTrigger after the delay when focused & visible', () => {
     const fake = makeFakeEnv()
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
     expect(onTrigger).not.toHaveBeenCalled()
-    vi.advanceTimersByTime(8000)
+    vi.advanceTimersByTime(2000)
     expect(onTrigger).toHaveBeenCalledTimes(1)
     ctrl.stop()
   })
@@ -102,7 +102,7 @@ describe('BannerTriggerController', () => {
     const fake = makeFakeEnv()
     fake.state.hasFocus = false
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
     vi.advanceTimersByTime(20_000)
     expect(onTrigger).not.toHaveBeenCalled()
@@ -113,7 +113,7 @@ describe('BannerTriggerController', () => {
     const fake = makeFakeEnv()
     fake.state.visibility = 'hidden'
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
     vi.advanceTimersByTime(20_000)
     expect(onTrigger).not.toHaveBeenCalled()
@@ -124,7 +124,7 @@ describe('BannerTriggerController', () => {
     const fake = makeFakeEnv()
     fake.state.activeEditable = true
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
     vi.advanceTimersByTime(20_000)
     expect(onTrigger).not.toHaveBeenCalled()
@@ -134,18 +134,18 @@ describe('BannerTriggerController', () => {
   it('resets the timer on blur and restarts on focus', () => {
     const fake = makeFakeEnv()
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
-    vi.advanceTimersByTime(5000)
+    vi.advanceTimersByTime(1000)
     // perte de focus → reset
     fake.state.hasFocus = false
     fake.dispatch('blur')
-    vi.advanceTimersByTime(5000)
+    vi.advanceTimersByTime(1000)
     expect(onTrigger).not.toHaveBeenCalled()
     // retour de focus → on repart de zéro
     fake.state.hasFocus = true
     fake.dispatch('focus')
-    vi.advanceTimersByTime(7999)
+    vi.advanceTimersByTime(1999)
     expect(onTrigger).not.toHaveBeenCalled()
     vi.advanceTimersByTime(1)
     expect(onTrigger).toHaveBeenCalledTimes(1)
@@ -155,7 +155,7 @@ describe('BannerTriggerController', () => {
   it('removes all listeners and timers on stop', () => {
     const fake = makeFakeEnv()
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
     expect(fake.hasListeners()).toBe(true)
     ctrl.stop()
@@ -167,11 +167,11 @@ describe('BannerTriggerController', () => {
   it('fires only once even if the timer would re-run', () => {
     const fake = makeFakeEnv()
     const onTrigger = vi.fn()
-    const ctrl = new BannerTriggerController(fake.env, 8000, onTrigger)
+    const ctrl = new BannerTriggerController(fake.env, 2000, onTrigger)
     ctrl.start()
-    vi.advanceTimersByTime(8000)
+    vi.advanceTimersByTime(2000)
     fake.dispatch('focus')
-    vi.advanceTimersByTime(8000)
+    vi.advanceTimersByTime(2000)
     expect(onTrigger).toHaveBeenCalledTimes(1)
     ctrl.stop()
   })

--- a/apps/web/lib/pwa/install-banner-trigger.ts
+++ b/apps/web/lib/pwa/install-banner-trigger.ts
@@ -3,7 +3,7 @@ import type { PwaDismissState } from '@evolve/types'
 /** Nombre de visites minimum avant de proposer l'installation. */
 export const MIN_VISITS = 2
 /** Délai (ms) d'onglet visible & focus continu avant d'afficher la bannière. */
-export const TRIGGER_DELAY_MS = 8000
+export const TRIGGER_DELAY_MS = 2000
 
 /**
  * Éligibilité « froide » (indépendante du focus/timer) :

--- a/apps/web/lib/pwa/use-install-banner-state.ts
+++ b/apps/web/lib/pwa/use-install-banner-state.ts
@@ -25,7 +25,7 @@ function isPromptable(pwaCase: PwaCase): pwaCase is PwaPromptableCase {
 
 /**
  * Override du délai de trigger via `window.__PWA_TRIGGER_DELAY_MS__` — seam de test
- * uniquement (E2E déterministes sans attendre 8 s réelles). Jamais posé en prod.
+ * uniquement (E2E déterministes sans attendre le délai réel). Jamais posé en prod.
  */
 function readTriggerDelayOverride(): number | null {
   if (typeof window === 'undefined') return null
@@ -76,15 +76,30 @@ export type UseInstallBannerState = {
   shouldShow: boolean
 }
 
+/** Options du hook de bannière PWA. */
+export type UseInstallBannerStateOptions = {
+  /**
+   * Affichage immédiat forcé : délai 0 ET bypass de l'éligibilité froide (compteur de visites,
+   * cooldown, dismiss permanent). Utilisé à l'arrivée fraîchement connecté en Safari
+   * (`/dashboard?pwa=ios`) pour que la bannière d'install iOS apparaisse tout de suite. On
+   * exige toujours un cas promptable et NON standalone (jamais de bannière si déjà installé).
+   */
+  forceImmediate?: boolean
+}
+
 /**
  * Hook fin : enregistre la visite (cas promptable & non standalone), calcule
- * l'éligibilité froide, puis arme un {@link BannerTriggerController} (timer 8 s gaté
+ * l'éligibilité froide, puis arme un {@link BannerTriggerController} (timer 2 s gaté
  * focus/visibilité/non-saisie). Toute la logique testée vit dans `install-banner-trigger.ts` ;
  * ce hook ne fait que câbler le DOM réel et exposer `shouldShow`.
  *
  * SSR-safe : rend `shouldShow=false` au premier render serveur, effets client uniquement.
  */
-export function useInstallBannerState(pwaCase: PwaCase): UseInstallBannerState {
+export function useInstallBannerState(
+  pwaCase: PwaCase,
+  options: UseInstallBannerStateOptions = {}
+): UseInstallBannerState {
+  const { forceImmediate = false } = options
   const [shouldShow, setShouldShow] = useState(false)
 
   useEffect(() => {
@@ -98,9 +113,20 @@ export function useInstallBannerState(pwaCase: PwaCase): UseInstallBannerState {
       return
     }
 
+    // Jamais de bannière si l'app est déjà installée — vrai aussi en mode forcé.
+    if (wasInstalled()) return
+
+    if (forceImmediate) {
+      // Bypass de l'éligibilité froide + délai 0 : la bannière s'affiche tout de suite.
+      const controller = new BannerTriggerController(browserTriggerEnv(), 0, () => {
+        setShouldShow(true)
+      })
+      controller.start()
+      return () => controller.stop()
+    }
+
     // Éligibilité froide.
     const state = dismissStore.read()
-    if (wasInstalled()) return
     if (!computeEligibility(state, Date.now())) return
 
     const delay = readTriggerDelayOverride() ?? TRIGGER_DELAY_MS
@@ -109,7 +135,7 @@ export function useInstallBannerState(pwaCase: PwaCase): UseInstallBannerState {
     })
     controller.start()
     return () => controller.stop()
-  }, [pwaCase])
+  }, [pwaCase, forceImmediate])
 
   return { shouldShow }
 }

--- a/apps/web/lib/pwa/use-pwa-install.ts
+++ b/apps/web/lib/pwa/use-pwa-install.ts
@@ -19,6 +19,29 @@ const NOOP_SUBSCRIBE = (): (() => void) => () => {}
 const getClientPwaCase = (): PwaCase => detectPwaCase()
 const getServerPwaCase = (): PwaCase => 'unsupported'
 
+/**
+ * Copie l'URL courante dans le presse-papier (comportement historique). Implémentation
+ * partagée entre le hook (`copyUrlToClipboard`) et le dernier recours de `copyHandoffLink`.
+ * SSR-safe.
+ */
+async function copyUrlToClipboardImpl(): Promise<boolean> {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return false
+    await navigator.clipboard.writeText(window.location.href)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Résultat de {@link copyHandoffLink} :
+ * - `ok` : quelque chose a bien été copié dans le presse-papier ;
+ * - `usedHandoff` : `true` si c'est un lien de connexion portable (auto-login en Safari),
+ *   `false` si on a dû retomber sur la copie de l'URL courante (comportement historique).
+ */
+export type HandoffCopyResult = { ok: boolean; usedHandoff: boolean }
+
 /** Actions PWA sans la machine de trigger/visite — réutilisable hors dashboard (ex. /profil). */
 export type PwaActions = {
   pwaCase: PwaCase
@@ -28,6 +51,67 @@ export type PwaActions = {
   closeInstructionModal: () => void
   dismiss: () => void
   copyUrlToClipboard: () => Promise<boolean>
+  copyHandoffLink: () => Promise<HandoffCopyResult>
+}
+
+const HANDOFF_ENDPOINT = '/api/auth/handoff-link'
+
+/** Réponse attendue du endpoint de handoff (contrat serveur). */
+type HandoffResponse = { url: string }
+
+/**
+ * Copie un lien de connexion à usage unique (« device handoff ») minté par le serveur, de
+ * sorte qu'un collage dans Safari connecte automatiquement l'utilisateur.
+ *
+ * ⚠ Contrainte iOS WebKit : `navigator.clipboard.writeText(...)` appelé APRÈS un `await fetch`
+ * est souvent rejeté (l'activation transitoire du geste utilisateur a expiré). Le pattern
+ * robuste est `navigator.clipboard.write([new ClipboardItem({ 'text/plain': <Promise<Blob>> })])`
+ * — Safari accepte une Promise comme valeur de ClipboardItem et la résout en préservant le geste.
+ *
+ * Stratégie en 3 paliers :
+ *  1. `ClipboardItem` + `Promise<Blob>` différée (préserve le geste iOS) ;
+ *  2. fallback `fetch` puis `writeText` (non-iOS / `ClipboardItem` indisponible) ;
+ *  3. dernier recours : copie de l'URL courante (ancien comportement, `usedHandoff: false`).
+ *
+ * SSR-safe : gardé par `copyUrlToClipboard` et les checks `navigator`/`ClipboardItem`.
+ */
+async function copyHandoffLink(): Promise<HandoffCopyResult> {
+  // Palier 1 — ClipboardItem avec une Promise<Blob> différée (garde le geste iOS vivant).
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof ClipboardItem !== 'undefined' &&
+      navigator.clipboard?.write
+    ) {
+      const blobPromise = fetch(HANDOFF_ENDPOINT, { method: 'POST' }).then(async (r) => {
+        if (!r.ok) throw new Error('handoff_failed')
+        const { url } = (await r.json()) as HandoffResponse
+        return new Blob([url], { type: 'text/plain' })
+      })
+      await navigator.clipboard.write([new ClipboardItem({ 'text/plain': blobPromise })])
+      return { ok: true, usedHandoff: true }
+    }
+  } catch {
+    /* on bascule sur le fallback */
+  }
+
+  // Palier 2 — fetch puis writeText (non-iOS / ClipboardItem non supporté).
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      const r = await fetch(HANDOFF_ENDPOINT, { method: 'POST' })
+      if (r.ok) {
+        const { url } = (await r.json()) as HandoffResponse
+        await navigator.clipboard.writeText(url)
+        return { ok: true, usedHandoff: true }
+      }
+    }
+  } catch {
+    /* on bascule sur le dernier recours */
+  }
+
+  // Palier 3 — dernier recours : copie de l'URL courante (ancien comportement).
+  const ok = await copyUrlToClipboardImpl()
+  return { ok, usedHandoff: false }
 }
 
 export type UsePwaInstallReturn = PwaActions & {
@@ -78,15 +162,8 @@ export function usePwaActions(): PwaActions {
     }
   }, [pwaCase])
 
-  const copyUrlToClipboard = useCallback(async (): Promise<boolean> => {
-    try {
-      if (typeof navigator === 'undefined' || !navigator.clipboard) return false
-      await navigator.clipboard.writeText(window.location.href)
-      return true
-    } catch {
-      return false
-    }
-  }, [])
+  const copyUrlToClipboard = useCallback(() => copyUrlToClipboardImpl(), [])
+  const copyHandoff = useCallback(() => copyHandoffLink(), [])
 
   return {
     pwaCase,
@@ -96,15 +173,27 @@ export function usePwaActions(): PwaActions {
     closeInstructionModal,
     dismiss,
     copyUrlToClipboard,
+    copyHandoffLink: copyHandoff,
   }
+}
+
+// Réexport nommé pour les tests unitaires (logique pure, hors hook).
+export { copyHandoffLink }
+
+/** Options du hook racine — propagées à {@link useInstallBannerState}. */
+export type UsePwaInstallOptions = {
+  /** Affichage immédiat forcé (arrivée `/dashboard?pwa=ios` en Safari). Voir le hook de state. */
+  forceImmediate?: boolean
 }
 
 /**
  * Hook racine de la bannière PWA (spec §2) : actions PWA + machine de trigger (visite≥2,
- * cooldown, timer 8 s gaté focus/visibilité). Exposé tel quel à `InstallBannerMount`.
+ * cooldown, timer 2 s gaté focus/visibilité). Exposé tel quel à `InstallBannerMount`.
  */
-export function usePwaInstall(): UsePwaInstallReturn {
+export function usePwaInstall(options: UsePwaInstallOptions = {}): UsePwaInstallReturn {
   const actions = usePwaActions()
-  const { shouldShow } = useInstallBannerState(actions.pwaCase)
+  const { shouldShow } = useInstallBannerState(actions.pwaCase, {
+    forceImmediate: options.forceImmediate,
+  })
   return { ...actions, shouldShowBanner: shouldShow }
 }

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -36,6 +36,8 @@ const LIMITERS = {
   marketPrices: { prefix: 'market-prices', tokens: 60, window: '1 m' },
   // GET /api/attestation/detention — 30 req / 5 min par user (génération PDF coûteuse, route authentifiée).
   attestation: { prefix: 'attestation', tokens: 30, window: '5 m' },
+  // POST /api/auth/handoff-link — 10 req / 5 min par user (mint de liens de connexion portables, route authentifiée).
+  handoff: { prefix: 'handoff', tokens: 10, window: '5 m' },
 } as const satisfies Record<string, LimiterConfig>
 
 export type RateLimitName = keyof typeof LIMITERS

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -921,11 +921,15 @@
       "cta": "Show me how"
     },
     "iosOther": {
-      "headline": "Open it in Safari.",
-      "subline": "Installing works from Safari on iPhone. We'll copy the address — just paste it.",
-      "cta": "Continue in Safari"
+      "headline": "Install Evolve on your home screen.",
+      "subline": "We'll copy a sign-in link. Open Safari, paste it — you'll already be signed in, ready to install.",
+      "cta": "Install the app"
     },
     "toastCopied": {
+      "title": "Link copied",
+      "message": "Open Safari and paste the link — you'll be signed in automatically."
+    },
+    "toastCopiedPlain": {
       "title": "Address copied",
       "message": "Open Safari and paste it into the address bar."
     },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -921,11 +921,15 @@
       "cta": "Voir comment"
     },
     "iosOther": {
-      "headline": "Ouvre-la dans Safari.",
-      "subline": "L'installation se fait depuis Safari sur iPhone. On copie l'adresse — tu n'as qu'à la coller.",
-      "cta": "Continuer dans Safari"
+      "headline": "Installe Evolve sur ton écran d'accueil.",
+      "subline": "On copie un lien de connexion. Ouvre Safari, colle-le : tu seras déjà connecté(e), prêt(e) à l'installer.",
+      "cta": "Installer l'application"
     },
     "toastCopied": {
+      "title": "Lien copié",
+      "message": "Ouvre Safari et colle le lien : tu seras connecté(e) automatiquement."
+    },
+    "toastCopiedPlain": {
       "title": "Adresse copiée",
       "message": "Ouvre Safari et colle-la dans la barre d'adresse."
     },

--- a/apps/web/playwright/consent-banner.spec.ts
+++ b/apps/web/playwright/consent-banner.spec.ts
@@ -100,7 +100,9 @@ test('« Personnaliser » ouvre le panneau granulaire ; « Enregistrer » (analy
   await banner.getByRole('button', { name: 'Personnaliser mes choix' }).click()
 
   await expect(banner.getByText('Cookies nécessaires')).toBeVisible()
-  await expect(banner.getByText("Cookies d'analyse")).toBeVisible()
+  // `exact: true` : sinon « Cookies d'analyse » matche AUSSI le titre « Nous utilisons des
+  // cookies d'analyse » (substring) → strict mode violation. On cible le libellé de catégorie seul.
+  await expect(banner.getByText("Cookies d'analyse", { exact: true })).toBeVisible()
 
   // Analyse OFF par défaut → Enregistrer = refus de la mesure d'audience.
   await banner.getByRole('button', { name: 'Enregistrer mes préférences' }).click()

--- a/apps/web/playwright/pwa-install-banner.spec.ts
+++ b/apps/web/playwright/pwa-install-banner.spec.ts
@@ -209,7 +209,7 @@ test.describe('ios safari', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Case 3 — iOS Chrome/Firefox : copie l'URL + toast
+// Case 3 — iOS Chrome/Firefox : copie un lien de connexion portable (handoff) + toast
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('ios other', () => {
   test.use({
@@ -218,19 +218,66 @@ test.describe('ios other', () => {
     permissions: ['clipboard-read', 'clipboard-write'],
   })
 
-  test('bannière « Continuer dans Safari » → URL copiée + toast', async ({ page }) => {
+  test("bannière « Installer l'application » → lien de handoff copié + toast", async ({ page }) => {
     await seedPwaState(page, { pwaCase: 'ios-other', visitCount: 1 })
+    // L'endpoint de mint est couvert unitairement (handoff-link/route.test.ts) ; ici on le STUB
+    // pour tester de façon déterministe le câblage CLIENT (copyHandoffLink → presse-papier + toast),
+    // indépendamment de la dispo du service-role dans l'env e2e.
+    await page.route('**/api/auth/handoff-link', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          url: 'http://localhost:3001/login/verify?token_hash=E2E_HASH&type=email&pwa=ios',
+        }),
+      })
+    )
     await loginAsSeedMember(page)
     await ensureFocus(page)
 
-    await expect(page.getByText('Ouvre-la dans Safari.')).toBeVisible({ timeout: 5000 })
-    await page.getByRole('button', { name: 'Continuer dans Safari' }).click()
+    await expect(page.getByText("Installe Evolve sur ton écran d'accueil.")).toBeVisible({
+      timeout: 5000,
+    })
+    await page.getByRole('button', { name: "Installer l'application" }).click()
 
-    // Toast de confirmation visible.
-    await expect(page.getByText('Adresse copiée')).toBeVisible()
-    // Le presse-papier contient l'URL courante.
+    // Toast « handoff » : un lien de connexion (pas l'URL nue) a été copié.
+    await expect(page.getByText('Lien copié')).toBeVisible()
+    // Le presse-papier contient le lien portable retourné par l'endpoint (token_hash + pwa=ios).
     const clip = await page.evaluate(() => navigator.clipboard.readText())
-    expect(clip).toContain('/dashboard')
+    expect(clip).toContain('/login/verify')
+    expect(clip).toContain('token_hash=E2E_HASH')
+    expect(clip).toContain('pwa=ios')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Arrivée « relais d'appareil » : /dashboard?pwa=ios force la bannière iOS-Safari
+// (bypass éligibilité froide) puis retire le marqueur de l'URL.
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('handoff arrival', () => {
+  test.use({ userAgent: UA.iosSafari, viewport: MOBILE })
+
+  test('`?pwa=ios` force la bannière malgré un dismiss permanent + strip du param', async ({
+    page,
+  }) => {
+    // État qui SUPPRIMERAIT normalement toute bannière (dismiss permanent + visites au-delà du seuil).
+    await seedPwaState(page, {
+      pwaCase: 'ios-safari',
+      visitCount: 9,
+      dismissCount: 3,
+      permanentlyMigratedAt: new Date(Date.now() - 86_400_000).toISOString(),
+    })
+    await loginAsSeedMember(page)
+    // Simule l'atterrissage Safari juste après avoir collé le lien de connexion.
+    await page.goto('/dashboard?pwa=ios')
+    await ensureFocus(page)
+
+    // forceImmediate : la bannière iOS-Safari apparaît tout de suite malgré l'éligibilité froide.
+    await expect(page.getByText('Ta part. Toujours avec toi.')).toBeVisible({ timeout: 5000 })
+    // Le marqueur ?pwa=ios est retiré de l'URL (router.replace) → pas de re-déclenchement au refresh.
+    await expect(page).toHaveURL(/\/dashboard$/)
+    // shouldShow latche : la bannière reste affichée après le strip du param.
+    await expect(page.getByText('Ta part. Toujours avec toi.')).toBeVisible()
   })
 })
 

--- a/docs/qa/QA_REPORT_2026-06-11.md
+++ b/docs/qa/QA_REPORT_2026-06-11.md
@@ -1,0 +1,60 @@
+# Rapport QA — `feat/pwa-ios-magic-link-handoff`
+
+**Date :** 2026-06-11
+**Feature :** Relais d'appareil PWA iOS — la bannière d'install sur iPhone-Chrome copie un **lien de connexion portable à usage unique** (magic link OTP `token_hash`, pas PKCE) ; collé dans Safari il connecte directement → atterrissage sur `/dashboard?pwa=ios` qui force l'affichage immédiat de la bannière d'install iOS-Safari. Délai de trigger ramené 8 s → **2 s**. Copy `ios-other` reformulée (« Installer l'application »).
+**Cycle :** orchestré par `qa-orchestrator` (exécution directe des batteries — la délégation à des sous-agents n'était pas disponible dans le runtime), corrections appliquées par le lead, re-vérification runtime.
+
+## VERDICT GLOBAL : **PASS** ✅
+
+Les 2 violations bloquantes initiales étaient des dérives de tests (specs non mises à jour), corrigées et re-vérifiées au runtime.
+
+---
+
+## Batterie 1 — Unit (Vitest)
+
+**PASS** — `make … typecheck/lint` vert ; **211/211** sur `apps/web` (puis **55/55** sur le périmètre touché en re-vérif).
+
+| Fichier                                             | Tests                                                                                                                              |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `lib/pwa/copy-handoff-link.test.ts` (nouveau)       | 7 — 3 paliers (ClipboardItem+Promise iOS, fetch+writeText, fallback URL nue), non-200 → fallback, SSR-safe                         |
+| `app/api/auth/handoff-link/route.test.ts` (nouveau) | 5 — 401 (no session / no email), 200 (`token_hash`+`type=email`+`pwa=ios`+`no-store`), 500 (generateLink KO / hashed_token absent) |
+| `app/(auth)/login/verify/route.test.ts` (nouveau)   | 6 — propagation `?pwa=ios` → `/dashboard?pwa=ios`, isolation flux invité                                                           |
+| `lib/rate-limit.test.ts`                            | 8 — limiteur `handoff` fail-open inclus                                                                                            |
+| `lib/pwa/install-banner-trigger.test.ts`            | 13 — délai 2000                                                                                                                    |
+
+## Batterie 2 — E2E (Playwright, `--workers=1`)
+
+**PASS** (après corrections).
+
+| Spec                         | Résultat                                                                                                                                                                                                                                                                         |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pwa-install-banner.spec.ts` | **8/8** — dont `ios other` (handoff : CTA « Installer l'application » → toast « Lien copié » + presse-papier = lien `/login/verify?token_hash=…&pwa=ios`) et **`handoff arrival`** (`?pwa=ios` force la bannière malgré dismiss permanent, strip du param, latch de l'affichage) |
+| `cursor-pointer.spec.ts`     | **VERT** (gate obligatoire CLAUDE.md — composants interactifs modifiés)                                                                                                                                                                                                          |
+| `auth.spec.ts`               | **5/5** — flux PKCE nominal NON régressé                                                                                                                                                                                                                                         |
+| `consent-banner.spec.ts`     | **4/4** (après fix locator)                                                                                                                                                                                                                                                      |
+
+### Violations initiales corrigées
+
+1. **`pwa-install-banner.spec.ts` (cas ios-other)** — assertait l'ancienne copy (« Continuer dans Safari » / « Adresse copiée »). Mise à jour vers la nouvelle copy + endpoint de handoff **stubé** (`page.route`) pour un test client déterministe + nouveau test `handoff arrival`. (Bonus debug : apostrophes typographiques `'` U+2019 dans les assertions → remplacées par `'` U+0027 pour matcher `fr.json`.)
+2. **`consent-banner.spec.ts:103`** (pré-existant, hors feature) — `getByText("Cookies d'analyse")` matchait 2 éléments (titre + libellé). Corrigé via `{ exact: true }`.
+
+## Batterie 3 — Visuel (runtime light/dark)
+
+**PASS conditionnel** — `/login`, `/dashboard` (light+dark), `/profil` rendus sans NaN/undefined, tokens sémantiques actifs en dark, pas de chevauchement bannière consent/PWA. La bannière `ios-other` n'est pas capturable en UA desktop ; sa copy est validée via `fr.json` + le test e2e (UA iOS Chrome spoofé).
+
+## Batterie 4 — A11y (axe WCAG2AA)
+
+**PASS** — `a11y.spec.ts` 5/5, `access.spec.ts` axe propre, `cursor-pointer` 13/13 (R-035 non régressé sur `/profil` + routes admin).
+
+## Régressions connues (REGRESSIONS.md)
+
+Aucune réintroduite : R-035 (cursor), R-014 (verify/route), R-017 (guard onboarding), R-024 (parité fr/en) — toutes vertes.
+
+---
+
+## Dette / gotchas harness (pour l'owner)
+
+- **Port `:3001` occupé** (Docker IPv6 + websocket Cursor `HTTP 426`) et le script `dev` fige `-p 3001` → l'e2e a tourné sur `:3100` via une config temporaire (supprimée) + `NEXT_PUBLIC_SITE_URL=http://localhost:3100` (sinon la redirection serveur de `/login/verify` pointe vers `:3001`) + un `storageState` consent cloné pour l'origine `:3100`.
+- **Env e2e** : le runner Playwright n'auto-charge PAS `.env.local` → `SUPABASE_SERVICE_ROLE_KEY` doit être exporté (`set -a; . ./apps/web/.env.local; set +a`) avant `playwright test`, sinon `generate_link` → 401 `no_authorization`.
+- `contributions.spec.ts` / `portfolio.spec.ts` : dérive de seed (matrice réelle en DB locale) — pré-existant, non lié à la feature, nécessite `make db-reset` (destructif → prévenir l'owner).
+- **Vérif terrain restante (owner)** : tester sur un vrai iPhone le geste presse-papier `ClipboardItem`+Promise (WebKit) — non reproductible en Chromium Playwright.


### PR DESCRIPTION
## Pourquoi

Sur **iPhone-Chrome**, la bannière d'install PWA était peu actionnable et l'install n'est possible que depuis Safari — où l'utilisateur est **déconnecté** (navigateur séparé), ce qui le renvoie dans la boucle magic-link → Gmail → rouvre Chrome. Trois irritants traités + une nouveauté.

## Ce que ça change

1. **Copy explicite** — CTA `ios-other` : « Continuer dans Safari » → **« Installer l'application »** ; headline + subline reformulés (FR/EN, parité).
2. **Délai trigger 8 s → 2 s** (`TRIGGER_DELAY_MS`).
3. **Relais d'appareil (magic link portable)** — au lieu de copier l'URL nue, le CTA copie un **lien de connexion portable à usage unique** : collé dans Safari il **auto-connecte** et atterrit sur `/dashboard?pwa=ios`, qui **force l'affichage immédiat** de la bannière d'install iOS-Safari (puis retire le marqueur).

## Comment (clé technique)

Le magic link nominal est **PKCE** (lié au navigateur via `code_verifier`) → casse cross-navigateur. On **réutilise le chemin OTP portable déjà en prod** pour les invitations : `admin.generateLink('magiclink')` → `hashed_token` → `/login/verify?token_hash=…&type=email` → `verifyOtp(type:'email')` (pas de `code_verifier`, donc portable). `/login/verify` branchait déjà sur `token_hash` → **0 changement du handler**.

- **`POST /api/auth/handoff-link`** (nouveau) — authentifié (session = garde primaire), service-role, rate-limit `handoff` 10/5 min fail-open, `no-store`. Mint un lien **pour soi-même uniquement**.
- **`copyHandoffLink()`** — 3 paliers : `ClipboardItem` + `Promise<Blob>` (préserve le geste iOS WebKit à travers le `fetch`) → `fetch`+`writeText` → fallback URL nue.
- **`forceImmediate`** — délai 0 + bypass éligibilité (visites/cooldown/dismiss permanent), **jamais si déjà installée** ; `shouldShow` latche donc le strip du param ne re-cache pas.

## Sécurité

Token **à usage unique + expirant**, minté seulement pour l'appelant authentifié. Threat model équivalent (voire meilleur) au magic link e-mail déjà envoyé. Pas de redirect contrôlé par l'utilisateur. Validé avec l'owner avant implémentation.

## Tests / QA — **PASS**

- Unit : route (5) + verify (6) + `copyHandoffLink` (7) + rate-limit ; **gate web 211/211**, typecheck + lint clean.
- E2E (`--workers=1`) : **pwa-install-banner 8/8** (dont handoff + arrivée `?pwa=ios`), **cursor-pointer ✓** (gate obligatoire), **auth 5/5** (PKCE non régressé), **consent-banner 4/4**.
- Rapport : `docs/qa/QA_REPORT_2026-06-11.md`.

## Reste à faire (owner)

- **Valider le geste presse-papier sur un vrai iPhone** (WebKit non reproductible en Chromium Playwright).
- `SUPABASE_SERVICE_ROLE_KEY` déjà requis côté Vercel (utilisé aussi par les invitations).

## Notes

- Commit `test(web)` séparé : fix d'un locator strict-mode **pré-existant** dans `consent-banner.spec.ts` (hors périmètre feature).
- Commit `chore(infra)` : ignore `CLAUDE.local.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)