### PR TITLE
fix(data): lien de connexion backup en texte brut (anti-prefetch iOS)

### DIFF
--- a/packages/data/src/emails/MagicLinkEmail.tsx
+++ b/packages/data/src/emails/MagicLinkEmail.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Link, Section, Text } from '@react-email/components'
+import { Button, Heading, Section, Text } from '@react-email/components'
 import type { ReactNode } from 'react'
 import { brand, font, radius, semantic } from '@evolve/design-system'
 import { EvolveEmailShell } from './_layout/EvolveEmailShell.tsx'
@@ -107,11 +107,13 @@ export function MagicLinkEmail({
         {t.cta}
       </Button>
 
+      {/* Lien backup en TEXTE BRUT (jamais une ancre) : un long-press iOS pour
+          copier une ancre ouvre un aperçu qui prefetch l'URL et consomme le lien
+          à usage unique avant le clic. En texte, l'utilisateur sélectionne/copie
+          l'URL sans la déclencher. Le CTA « Se connecter » reste le seul lien. */}
       <Section style={plain}>
         <Text style={plainLabel}>{t.backupLabel}</Text>
-        <Link href={magicLink} style={plainUrl}>
-          {magicLink}
-        </Link>
+        <Text style={plainUrl}>{magicLink}</Text>
       </Section>
 
       <Text style={note}>
@@ -190,11 +192,15 @@ const plainLabel: React.CSSProperties = {
 }
 
 const plainUrl: React.CSSProperties = {
+  margin: 0,
   fontFamily: font.mono,
   fontSize: '12px',
   color: semantic.textSec,
   wordBreak: 'break-all',
   lineHeight: '1.5',
+  // Texte sélectionnable, jamais cliquable (cf. <Text> plutôt que <Link>).
+  WebkitUserSelect: 'all',
+  userSelect: 'all',
 }
 
 const note: React.CSSProperties = {

--- a/packages/data/src/emails/_layout/EvolveEmailShell.tsx
+++ b/packages/data/src/emails/_layout/EvolveEmailShell.tsx
@@ -70,6 +70,10 @@ export function EvolveEmailShell({
             Levier standard (Apple Mail, iOS, Outlook ; Gmail partiel). */}
         <meta name="color-scheme" content="light" />
         <meta name="supported-color-schemes" content="light" />
+        {/* Empêche iOS d'auto-détecter (et de rendre cliquables) les longues
+            suites de chiffres — ex. le token d'un magic link — comme des numéros
+            de téléphone/dates, ce qui ajouterait des liens parasites au corps. */}
+        <meta name="format-detection" content="telephone=no,date=no,address=no,email=no" />
       </Head>
       <Preview>{preview}</Preview>
       <Body style={body}>

--- a/packages/data/src/tests/email.test.ts
+++ b/packages/data/src/tests/email.test.ts
@@ -113,10 +113,22 @@ describe('MagicLinkEmail', () => {
 
   it('expose le lien en clair (backup plaintext) et un ton rassurant', async () => {
     const html = await renderEmailHtml(createElement(MagicLinkEmail, { magicLink, expiresInMin }))
-    // Lien backup en clair (apparaît au moins deux fois : href + texte).
+    // L'URL apparaît au moins deux fois : le href du CTA + le texte backup copiable.
     const occurrences = html.split(magicLink).length - 1
     expect(occurrences).toBeGreaterThanOrEqual(2)
     // L'apostrophe est échappée en entité HTML (&#x27;) par React Email.
     expect(html).toMatch(/Tu n(?:'|&#x27;)as pas demandé ce lien/i)
+  })
+
+  it('backup en TEXTE BRUT, jamais une ancre cliquable (anti-prefetch long-press iOS)', async () => {
+    const html = await renderEmailHtml(createElement(MagicLinkEmail, { magicLink, expiresInMin }))
+    // Sur iOS, un long-press pour copier une ANCRE ouvre un aperçu qui prefetch
+    // l'URL et consomme le lien à usage unique avant même le clic. Le backup doit
+    // donc être du texte : une SEULE ancre pointe vers le magic link — le CTA.
+    const escaped = magicLink.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const anchorsToMagicLink = html.match(new RegExp(`<a\\b[^>]*href="${escaped}"`, 'g')) ?? []
+    expect(anchorsToMagicLink).toHaveLength(1)
+    // …mais l'URL reste affichée en clair (copiable) dans le corps.
+    expect(html).toContain(magicLink)
   })
 })

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -28,6 +28,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light" />
+    <!-- Empêche iOS d'auto-détecter (et de rendre cliquables) les longues suites
+         de chiffres du token comme des numéros de téléphone/dates. -->
+    <meta
+      name="format-detection"
+      content="telephone=no,date=no,address=no,email=no"
+    />
     <title>Connexion à Evolve Capital</title>
   </head>
   <body
@@ -124,7 +130,11 @@
                   </tr>
                 </table>
 
-                <!-- Lien en clair (backup) — toujours {{ .ConfirmationURL }}, jamais de code -->
+                <!-- Lien en clair (backup) — TEXTE BRUT, jamais une ancre : un
+                     long-press iOS pour copier une ancre ouvre un aperçu qui
+                     prefetch l'URL et consomme le lien à usage unique avant le
+                     clic. En texte, l'utilisateur copie l'URL sans la déclencher.
+                     Toujours {{ .ConfirmationURL }}, jamais de code. -->
                 <div
                   style="margin-top: 22px; border: 1px solid #e4e4df; border-radius: 10px; background-color: #fafaf9; padding: 14px 16px;"
                 >
@@ -133,12 +143,9 @@
                   >
                     Ou copie ce lien dans ton navigateur
                   </p>
-                  <a
-                    href="{{ .ConfirmationURL }}"
-                    target="_blank"
-                    style="font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #5f6062; word-break: break-all; line-height: 1.5; text-decoration: none;"
-                    >{{ .ConfirmationURL }}</a
-                  >
+                  <p
+                    style="margin: 0; font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #5f6062; word-break: break-all; line-height: 1.5; -webkit-user-select: all; user-select: all;"
+                  >{{ .ConfirmationURL }}</p>
                 </div>
 
                 <p


### PR DESCRIPTION
## Contexte
Hors MIGRATION_PLAN — correctif UX/sécurité sur l'email de connexion (magic link), remonté après un test réel sur iPhone.

**Bug.** L'email de magic link propose une seconde option : « Ou copie ce lien dans ton navigateur ». Cette URL était rendue comme une **ancre** (`<a href>`) stylée en gris. Sur iOS, un **long-press pour copier** ouvre un aperçu de lien qui **prefetch l'URL** — or le lien est à **usage unique** (`/auth/v1/verify?token=pkce_…`). Le token est donc **consommé avant même le clic**, et la connexion échoue (« lien expiré / déjà utilisé »).

**Fix.** Le lien backup devient du **texte brut** (`<Text>`/`<p>` au lieu de `<a>`/`<Link>`) : l'utilisateur sélectionne et copie l'URL **sans la déclencher**. Le rendu visuel est identique (même boîte grise, monospace). Le CTA « Se connecter » reste la **seule** ancre vers le lien.

Appliqué aux **deux** gabarits :
- `MagicLinkEmail.tsx` (React Email → Auth Hook Brevo, **email prod** — confirmé par la copy « valide 60 min ») ;
- `supabase/templates/magic_link.html` (mailer Go natif, fallback local/prod).

Ajout d'un `<meta format-detection>` (téléphone/date/adresse = no) au gabarit commun + au template Go, pour empêcher iOS d'auto-détecter les longues suites de chiffres du token comme des numéros de téléphone (liens parasites). `user-select: all` rend l'URL sélectionnable d'un seul tap.

## Changes
- `packages/data/src/emails/MagicLinkEmail.tsx` — backup URL : `<Link>` → `<Text>` (texte brut, non cliquable) ; `margin:0` + `user-select:all` sur le style.
- `packages/data/src/emails/_layout/EvolveEmailShell.tsx` — `<meta name="format-detection" content="telephone=no,date=no,address=no,email=no">`.
- `supabase/templates/magic_link.html` — backup `<a>` → `<p>` texte brut + meta format-detection.
- `packages/data/src/tests/email.test.ts` — nouveau test : **une seule ancre** pointe vers le magic link (le CTA), l'URL reste affichée en clair.

## Test plan
- [x] Tests locaux OK — `@evolve/data` : **181 passed** (dont email 10/10, nouveau test anti-ancre vert)
- [x] `turbo typecheck lint` OK sur tout le monorepo (web + packages)
- [x] Vérif **runtime visuelle** des 2 emails rendus (light) — identiques à la réf, backup en texte gris, plus aucune ancre backup
- [ ] `pnpm turbo build` (non lancé — change purement email, hors chemin de build)
- [ ] Vitrine `main` intacte (aucun fichier vitrine touché)

## ⚠️ Risk
| Niveau | Fichier | Note |
|--------|---------|------|
| Moyen | `supabase/templates/magic_link.html` | Email d'auth (login) — **rendu uniquement**, aucune logique ni token modifié. |

**Résiduel / suivi owner.** Ce correctif neutralise l'aperçu WebKit de l'ancre (le prefetch certain qui rend la page et brûle le token). Un client mail peut encore ré-auto-détecter une URL en clair, mais le menu « data-detector » est moins agressif que l'aperçu d'ancre. Le durcissement robuste (anti-scanner d'entreprise / prefetch) passerait par une **page d'interstitiel de confirmation** sur la route `/login/verify` (geste utilisateur avant l'échange du token) — hors scope de ce PR (touche l'auth prod, à cadrer avec l'owner).

## Checklist
- [x] Commits en Conventional Commits (`fix(data)`, `fix(supabase)`)
- [x] Aucun fichier .env commité
- [x] Prettier + ESLint OK (husky lint-staged)
- [x] Pas de breaking change API publique (props `MagicLinkEmail`/`EvolveEmailShell` inchangées)

🤖 Generated with [Claude Code](https://claude.com/claude-code)