### PR TITLE
feat(DSH-011): sync feuille reporting vers historique graphe dashboard

### DIFF
--- a/apps/web/lib/data/dashboard-chart.test.ts
+++ b/apps/web/lib/data/dashboard-chart.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+
+import type { createServerClient } from '@evolve/data'
+
+import {
+  deriveMemberSeries,
+  computeVariation,
+  getDashboardChartData,
+  type DashboardChartPoint,
+} from './dashboard-chart'
+
+type ServerClient = ReturnType<typeof createServerClient>
+
+/** Ligne club synthétique (shape minimal lu par le module). */
+type ClubRow = { report_date: string; portfolio_value: number }
+
+/** Génère `count` lignes quotidiennes à partir de `startDate` (valeurs croissantes 1000+i). */
+function makeDailyRows(startDate: string, count: number): ClubRow[] {
+  const startMs = Date.parse(startDate)
+  return Array.from({ length: count }, (_, i) => ({
+    report_date: new Date(startMs + i * 86_400_000).toISOString().slice(0, 10),
+    portfolio_value: 1000 + i,
+  }))
+}
+
+/**
+ * Faux client Supabase chaînable (zéro réseau), même pattern que dashboard.test.ts mais
+ * avec un terminateur `.range(from, to)` qui découpe la fixture — permet de vérifier
+ * la pagination PostgREST (plafond 1 000 lignes). Les appels range sont tracés.
+ */
+function makeSupabaseListMock(
+  rows: ClubRow[],
+  error: unknown = null,
+  rangeCalls: [number, number][] = []
+): ServerClient {
+  const from = () => {
+    const chain: Record<string, unknown> = {}
+    chain.select = () => chain
+    chain.eq = () => chain
+    chain.order = () => chain
+    chain.range = (fromIdx: number, toIdx: number) => {
+      rangeCalls.push([fromIdx, toIdx])
+      return Promise.resolve(
+        error ? { data: null, error } : { data: rows.slice(fromIdx, toIdx + 1), error: null }
+      )
+    }
+    return chain
+  }
+  return { from } as unknown as ServerClient
+}
+
+describe('deriveMemberSeries', () => {
+  it('multiplie portfolio_value par detentionPct', () => {
+    const rows: ClubRow[] = [
+      { report_date: '2026-01-01', portfolio_value: 1000 },
+      { report_date: '2026-01-02', portfolio_value: 2000 },
+    ]
+    const series = deriveMemberSeries(rows, 0.1, null)
+    expect(series).toEqual([
+      { date: '2026-01-01', value: 100 },
+      { date: '2026-01-02', value: 200 },
+    ])
+  })
+
+  it('applique le cutoff joinedAt (report_date >= joinedAt)', () => {
+    const rows: ClubRow[] = [
+      { report_date: '2018-01-01', portfolio_value: 500 },
+      { report_date: '2018-06-01', portfolio_value: 600 },
+      { report_date: '2018-09-01', portfolio_value: 700 },
+    ]
+    const series = deriveMemberSeries(rows, 1, '2018-06-01')
+    // Le point du jour d'adhésion est INCLUS (>=), le point antérieur est exclu.
+    expect(series.map((p) => p.date)).toEqual(['2018-06-01', '2018-09-01'])
+  })
+
+  it('normalise un joinedAt timestamp en cutoff calendaire', () => {
+    const rows: ClubRow[] = [
+      { report_date: '2018-05-31', portfolio_value: 500 },
+      { report_date: '2018-06-01', portfolio_value: 600 },
+    ]
+    const series = deriveMemberSeries(rows, 1, '2018-06-01T00:00:00Z')
+    expect(series.map((p) => p.date)).toEqual(['2018-06-01'])
+  })
+
+  it('ignore le cutoff quand joinedAt est null', () => {
+    const rows = makeDailyRows('2026-01-01', 3)
+    expect(deriveMemberSeries(rows, 1, null)).toHaveLength(3)
+  })
+
+  it('ignore le cutoff quand joinedAt est non parseable', () => {
+    const rows = makeDailyRows('2026-01-01', 3)
+    expect(deriveMemberSeries(rows, 1, 'pas-une-date')).toHaveLength(3)
+  })
+
+  it('écarte les points non finis (NaN / Infinity) — jamais de NaN', () => {
+    const rows: ClubRow[] = [
+      { report_date: '2026-01-01', portfolio_value: 1000 },
+      { report_date: '2026-01-02', portfolio_value: NaN },
+      { report_date: '2026-01-03', portfolio_value: Infinity },
+      { report_date: '2026-01-04', portfolio_value: 2000 },
+    ]
+    const series = deriveMemberSeries(rows, 0.5, null)
+    expect(series.map((p) => p.date)).toEqual(['2026-01-01', '2026-01-04'])
+    expect(series.every((p) => Number.isFinite(p.value))).toBe(true)
+  })
+
+  it('écarte les points dont la date est non parseable', () => {
+    const rows: ClubRow[] = [
+      { report_date: 'n/a', portfolio_value: 1000 },
+      { report_date: '2026-01-02', portfolio_value: 1000 },
+    ]
+    expect(deriveMemberSeries(rows, 1, null).map((p) => p.date)).toEqual(['2026-01-02'])
+  })
+
+  it('garantit le tri ASC même si la source est désordonnée', () => {
+    const rows: ClubRow[] = [
+      { report_date: '2026-01-03', portfolio_value: 3 },
+      { report_date: '2026-01-01', portfolio_value: 1 },
+      { report_date: '2026-01-02', portfolio_value: 2 },
+    ]
+    const series = deriveMemberSeries(rows, 1, null)
+    expect(series.map((p) => p.date)).toEqual(['2026-01-01', '2026-01-02', '2026-01-03'])
+  })
+
+  it('detentionPct non fini → série vide (aucun point NaN émis)', () => {
+    const rows = makeDailyRows('2026-01-01', 3)
+    expect(deriveMemberSeries(rows, NaN, null)).toEqual([])
+  })
+})
+
+describe('computeVariation', () => {
+  const point = (date: string, value: number): DashboardChartPoint => ({ date, value })
+
+  it('d1 nominal : dernier point vs veille sur une série quotidienne', () => {
+    const series = [point('2026-06-08', 100), point('2026-06-09', 102), point('2026-06-10', 105)]
+    const v = computeVariation(series, 1)
+    expect(v).not.toBeNull()
+    expect(v?.amount).toBeCloseTo(3, 10) // 105 − 102
+    expect(v?.percent).toBeCloseTo(3 / 102, 10)
+  })
+
+  it('d30 sur une série de 90 jours → point le plus proche de J−30', () => {
+    const rows = makeDailyRows('2026-01-01', 90) // valeurs 1000..1089
+    const series = deriveMemberSeries(rows, 1, null)
+    const v = computeVariation(series, 30)
+    // lastDate = J89 ; J−30 = J59 → start = 1059, end = 1089.
+    expect(v?.amount).toBeCloseTo(1089 - 1059, 10)
+    expect(v?.percent).toBeCloseTo(30 / 1059, 10)
+  })
+
+  it('d30 avec trous (week-ends) → point calendairement le plus proche', () => {
+    const series = [
+      point('2026-05-01', 100),
+      point('2026-05-09', 110), // J−32 du dernier — le plus proche de J−30
+      point('2026-05-14', 120), // J−27
+      point('2026-06-10', 130),
+    ]
+    const v = computeVariation(series, 30)
+    // Cible 2026-05-11 : 05-09 (2 j) bat 05-14 (3 j) → start = 110.
+    expect(v?.amount).toBeCloseTo(20, 10)
+    expect(v?.percent).toBeCloseTo(20 / 110, 10)
+  })
+
+  it('d30 sur une série de 10 jours (historique court) → premier point', () => {
+    const rows = makeDailyRows('2026-06-01', 10) // valeurs 1000..1009
+    const series = deriveMemberSeries(rows, 1, null)
+    const v = computeVariation(series, 30)
+    expect(v?.amount).toBeCloseTo(9, 10) // 1009 − 1000
+    expect(v?.percent).toBeCloseTo(9 / 1000, 10)
+  })
+
+  it('max → premier vs dernier point', () => {
+    const series = [point('2026-01-01', 200), point('2026-03-01', 150), point('2026-06-01', 260)]
+    const v = computeVariation(series, 'max')
+    expect(v?.amount).toBeCloseTo(60, 10)
+    expect(v?.percent).toBeCloseTo(0.3, 10)
+  })
+
+  it('série vide → null', () => {
+    expect(computeVariation([], 1)).toBeNull()
+    expect(computeVariation([], 'max')).toBeNull()
+  })
+
+  it('un seul point → null', () => {
+    expect(computeVariation([point('2026-06-10', 100)], 1)).toBeNull()
+    expect(computeVariation([point('2026-06-10', 100)], 'max')).toBeNull()
+  })
+
+  it('start = 0 → null (pas de percent sur base nulle, pas de TrendBadge)', () => {
+    const series = [point('2026-06-09', 0), point('2026-06-10', 100)]
+    expect(computeVariation(series, 1)).toBeNull()
+    expect(computeVariation(series, 'max')).toBeNull()
+  })
+
+  it('point de comparaison = dernier lui-même → null', () => {
+    // J−1 du dernier est bien plus proche du dernier (1 j) que du premier (~151 j).
+    const series = [point('2026-01-01', 100), point('2026-06-01', 110)]
+    expect(computeVariation(series, 1)).toBeNull()
+  })
+
+  it('percent exact : 100 → 104.55 donne 0.0455 (à epsilon près)', () => {
+    const series = [point('2026-06-09', 100), point('2026-06-10', 104.55)]
+    const v = computeVariation(series, 1)
+    expect(v?.amount).toBeCloseTo(4.55, 10)
+    expect(v?.percent).toBeCloseTo(0.0455, 10)
+  })
+})
+
+describe('getDashboardChartData', () => {
+  const opts = { detentionPct: 0.1, joinedAt: null }
+
+  it('retourne null si aucune ligne REPORTING (V2 reste en mode demo)', async () => {
+    const supabase = makeSupabaseListMock([])
+    const result = await getDashboardChartData(supabase, 'user-1', 'club-1', opts)
+    expect(result).toBeNull()
+  })
+
+  it('rejette si la requête renvoie une erreur', async () => {
+    const supabase = makeSupabaseListMock([], { message: 'boom' })
+    await expect(getDashboardChartData(supabase, 'user-1', 'club-1', opts)).rejects.toThrow()
+  })
+
+  it('retourne null si la série est vide après cutoff joinedAt', async () => {
+    const supabase = makeSupabaseListMock(makeDailyRows('2020-01-01', 5))
+    const result = await getDashboardChartData(supabase, 'user-1', 'club-1', {
+      detentionPct: 0.1,
+      joinedAt: '2026-01-01', // postérieur à tout l'historique
+    })
+    expect(result).toBeNull()
+  })
+
+  it('compose série, variations et meta (câblage nominal)', async () => {
+    const rows = makeDailyRows('2026-01-01', 90) // valeurs 1000..1089
+    const supabase = makeSupabaseListMock(rows)
+
+    const result = await getDashboardChartData(supabase, 'user-1', 'club-1', {
+      detentionPct: 0.1,
+      joinedAt: '2026-01-11', // coupe les 10 premiers jours
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.source).toBe('live')
+    // 90 jours − 10 coupés par le cutoff = 80 points, valeurs × 0.1.
+    expect(result?.series).toHaveLength(80)
+    expect(result?.series[0]).toEqual({ date: '2026-01-11', value: 101 })
+    expect(result?.series[79]).toEqual({ date: '2026-03-31', value: 108.9 })
+    // Variations câblées sur la série dérivée (d1 = dernier vs veille).
+    expect(result?.variations.d1?.amount).toBeCloseTo(0.1, 10)
+    expect(result?.variations.d30).not.toBeNull()
+    expect(result?.variations.max?.amount).toBeCloseTo(108.9 - 101, 10)
+    // Meta complète (debug / QA).
+    expect(result?.meta).toEqual({
+      clubId: 'club-1',
+      pointCount: 80,
+      firstDate: '2026-01-11',
+      lastDate: '2026-03-31',
+      detentionPctUsed: 0.1,
+      joinedAtCutoff: '2026-01-11',
+    })
+  })
+
+  it('meta.joinedAtCutoff = null quand joinedAt est absent ou non parseable', async () => {
+    const rows = makeDailyRows('2026-01-01', 3)
+    for (const joinedAt of [null, 'pas-une-date']) {
+      const supabase = makeSupabaseListMock(rows)
+      const result = await getDashboardChartData(supabase, 'user-1', 'club-1', {
+        detentionPct: 1,
+        joinedAt,
+      })
+      expect(result?.meta.joinedAtCutoff).toBeNull()
+      expect(result?.meta.pointCount).toBe(3)
+    }
+  })
+
+  it('pagine au-delà du plafond PostgREST de 1 000 lignes (.range en boucle)', async () => {
+    const rows = makeDailyRows('2018-06-01', 2900) // ~série REPORTING réelle
+    const rangeCalls: [number, number][] = []
+    const supabase = makeSupabaseListMock(rows, null, rangeCalls)
+
+    const result = await getDashboardChartData(supabase, 'user-1', 'club-1', {
+      detentionPct: 1,
+      joinedAt: null,
+    })
+
+    // 3 pages : 1000 + 1000 + 900 (page incomplète → stop).
+    expect(rangeCalls).toEqual([
+      [0, 999],
+      [1000, 1999],
+      [2000, 2999],
+    ])
+    expect(result?.meta.pointCount).toBe(2900)
+    expect(result?.meta.firstDate).toBe('2018-06-01')
+    expect(result?.series).toHaveLength(2900)
+  })
+
+  it('pile 1 000 lignes : une page pleine puis une page vide (pas de boucle infinie)', async () => {
+    const rows = makeDailyRows('2020-01-01', 1000)
+    const rangeCalls: [number, number][] = []
+    const supabase = makeSupabaseListMock(rows, null, rangeCalls)
+
+    const result = await getDashboardChartData(supabase, 'user-1', 'club-1', {
+      detentionPct: 1,
+      joinedAt: null,
+    })
+
+    expect(rangeCalls).toEqual([
+      [0, 999],
+      [1000, 1999],
+    ])
+    expect(result?.meta.pointCount).toBe(1000)
+  })
+})

--- a/apps/web/lib/data/dashboard-chart.ts
+++ b/apps/web/lib/data/dashboard-chart.ts
@@ -1,0 +1,223 @@
+// Couche data du graphe « Évolution » du dashboard V2 (DSH-011).
+//
+// Lit la série historique `club_reporting_daily` (alimentée par la sync REPORTING, migration 034)
+// et en dérive la quote-part du membre. Ce module sera branché sur le graphe par DSH-012 ;
+// tant qu'il retourne null (aucune ligne REPORTING en base), le V2 reste en mode demo.
+//
+// HYPOTHÈSE PRODUIT (approximation V0 assumée) :
+//   quote_part_membre(date) ≈ portfolio_value(date) × detention_pct_actuel
+// La détention ACTUELLE est appliquée à tout l'historique — si elle a changé dans le temps,
+// les points anciens sont approximés (pas d'historique de détention en V0). Pour borner cette
+// approximation sur la période MAX, la série est coupée à `report_date >= joinedAt` (date
+// d'adhésion du membre) quand `joinedAt` est parseable.
+//
+// La série COMPLÈTE (triée ASC) est retournée au client, qui filtre lui-même par période
+// (7d/30d/90d/1y/max) — un seul aller-retour serveur, pas une requête par période.
+// Le formatage (formatEUR/formatPct) reste côté UI — jamais de toLocaleString ici.
+//
+// Réf : DSH-011 (couche lecture), DSH-012 (branchement graphe), migration 034.
+
+import type { createServerClient, Database } from '@evolve/data'
+
+/** Client Supabase serveur tel que retourné par `createServerClient` (session + RLS). */
+type ServerClient = ReturnType<typeof createServerClient>
+
+type ClubReportingDailyRow = Database['public']['Tables']['club_reporting_daily']['Row']
+
+/** Sous-ensemble de colonnes lues pour la série du graphe. */
+type ReportingPointRow = Pick<ClubReportingDailyRow, 'report_date' | 'portfolio_value'>
+
+/** Périodes proposées par le graphe — le FILTRAGE par période est fait côté client. */
+export type DashboardChartPeriod = '7d' | '30d' | '90d' | '1y' | 'max'
+
+export interface DashboardChartPoint {
+  /** ISO date calendaire (YYYY-MM-DD), timezone UTC midnight */
+  date: string
+  /** Quote-part membre dérivée (EUR), formaté côté UI via formatEUR */
+  value: number
+}
+
+export interface DashboardChartVariation {
+  /** Delta EUR sur la période. */
+  amount: number
+  /** Fraction (0.0455 = +4,55 %), pour TrendBadge / formatPct. */
+  percent: number
+}
+
+export interface DashboardChartData {
+  source: 'live'
+  /** Série complète triée ASC ; le client filtre par période */
+  series: DashboardChartPoint[]
+  variations: {
+    d1: DashboardChartVariation | null
+    d30: DashboardChartVariation | null
+    max: DashboardChartVariation | null
+  }
+  /** Meta debug / QA — pas exposée GA4 */
+  meta: {
+    clubId: string
+    pointCount: number
+    firstDate: string | null
+    lastDate: string | null
+    detentionPctUsed: number
+    joinedAtCutoff: string | null
+  }
+}
+
+const DAY_MS = 86_400_000
+
+/** Taille de page PostgREST — voir le commentaire pagination dans getDashboardChartData. */
+const PAGE_SIZE = 1000
+
+/**
+ * Normalise `joinedAt` en cutoff calendaire YYYY-MM-DD (UTC). Retourne null si la date
+ * n'est pas parseable (le cutoff est alors ignoré plutôt que de vider la série). PUR.
+ */
+function normalizeJoinedAtCutoff(joinedAt: string | null): string | null {
+  if (joinedAt === null) return null
+  const ms = Date.parse(joinedAt)
+  if (Number.isNaN(ms)) return null
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+/**
+ * Dérive la série quote-part membre depuis les lignes club : `value = portfolio_value × detentionPct`
+ * (hypothèse produit V0, voir en-tête). Coupe à `report_date >= joinedAt` si parseable, écarte tout
+ * point non fini (jamais de NaN à l'écran) et garantit le tri ASC. PUR (testé).
+ */
+export function deriveMemberSeries(
+  clubRows: { report_date: string; portfolio_value: number }[],
+  detentionPct: number,
+  joinedAt: string | null
+): DashboardChartPoint[] {
+  const cutoff = normalizeJoinedAtCutoff(joinedAt)
+
+  const points: DashboardChartPoint[] = []
+  for (const row of clubRows) {
+    // Date non parseable → écartée (sinon NaN dans les calculs de variation en aval).
+    if (Number.isNaN(Date.parse(row.report_date))) continue
+    // Normalisation calendaire YYYY-MM-DD (contrat DashboardChartPoint.date).
+    const date = row.report_date.slice(0, 10)
+    if (cutoff !== null && date < cutoff) continue
+    // Coercition Number() : numeric Postgres peut arriver en string selon le client.
+    const value = Number(row.portfolio_value) * detentionPct
+    // Jamais de NaN/Infinity dans la série (convention « pas de NaN à l'écran »).
+    if (!Number.isFinite(value)) continue
+    points.push({ date, value })
+  }
+
+  // Tri ASC garanti même si la source est désordonnée (comparaison ISO = chronologique).
+  points.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+  return points
+}
+
+/**
+ * Variation entre le dernier point et un point de comparaison :
+ * - `'max'` → premier point de la série ;
+ * - `n` jours → le point le plus proche CALENDAIREMENT de `lastDate − n jours` (les séries
+ *   REPORTING ont des trous week-end/jours fériés ; si l'historique est plus court que n jours,
+ *   la cible tombe avant le premier point → comparaison = premier point). À distance égale,
+ *   le point le plus ancien gagne (la variation couvre au moins n jours).
+ * Retourne null si : < 2 points, point de comparaison = dernier point lui-même, ou
+ * `start ≤ 0` (un percent sur base nulle/négative n'a pas de sens → pas de TrendBadge).
+ * Jamais de NaN/Infinity. PUR (testé).
+ */
+export function computeVariation(
+  series: DashboardChartPoint[],
+  daysBack: number | 'max'
+): DashboardChartVariation | null {
+  if (series.length < 2) return null
+  const first = series[0]
+  const end = series[series.length - 1]
+  if (!first || !end) return null
+
+  let start: DashboardChartPoint
+  if (daysBack === 'max') {
+    start = first
+  } else {
+    const targetMs = Date.parse(end.date) - daysBack * DAY_MS
+    let best = first
+    let bestIndex = 0
+    let bestDist = Math.abs(Date.parse(first.date) - targetMs)
+    for (let i = 1; i < series.length; i++) {
+      const p = series[i]
+      if (!p) continue
+      const dist = Math.abs(Date.parse(p.date) - targetMs)
+      // `<` strict : à égalité de distance, le point le plus ancien (déjà retenu) gagne.
+      if (dist < bestDist) {
+        best = p
+        bestIndex = i
+        bestDist = dist
+      }
+    }
+    // Le point de comparaison est le dernier lui-même → pas de période à comparer.
+    if (bestIndex === series.length - 1) return null
+    start = best
+  }
+
+  // percent sur base nulle/négative → pas de variation affichable (pas de TrendBadge).
+  if (!(start.value > 0)) return null
+  const amount = end.value - start.value
+  const percent = amount / start.value
+  if (!Number.isFinite(amount) || !Number.isFinite(percent)) return null
+  return { amount, percent }
+}
+
+/**
+ * Charge la série REPORTING du club et dérive les données du graphe membre.
+ * RLS membre s'applique sur `club_reporting_daily` (lecture par club du membre).
+ * Retourne null si aucune ligne REPORTING en base (V2 reste en mode demo).
+ */
+export async function getDashboardChartData(
+  supabase: ServerClient,
+  userId: string,
+  clubId: string,
+  opts: { detentionPct: number; joinedAt: string | null }
+): Promise<DashboardChartData | null> {
+  // ⚠ PostgREST plafonne chaque requête à 1 000 lignes (max-rows) et la série REPORTING
+  // dépasse largement ce plafond (~2 900+ lignes d'historique quotidien) : sans pagination,
+  // le graphe serait silencieusement tronqué aux 1 000 premiers jours. On pagine donc avec
+  // `.range()` en boucle jusqu'à recevoir une page incomplète (= dernière page).
+  const rows: ReportingPointRow[] = []
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('club_reporting_daily')
+      .select('report_date, portfolio_value')
+      .eq('club_id', clubId)
+      .order('report_date', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+    if (error) throw error
+    const page = (data ?? []) as ReportingPointRow[]
+    rows.push(...page)
+    if (page.length < PAGE_SIZE) break
+  }
+
+  // Aucune ligne REPORTING → le dashboard V2 reste en mode demo (DSH-012).
+  if (rows.length === 0) return null
+
+  const series = deriveMemberSeries(rows, opts.detentionPct, opts.joinedAt)
+  // Série vide après filtrage (cutoff joinedAt, points non finis) → même fallback demo.
+  if (series.length === 0) return null
+
+  const firstPoint = series[0]
+  const lastPoint = series[series.length - 1]
+
+  return {
+    source: 'live',
+    series,
+    variations: {
+      d1: computeVariation(series, 1),
+      d30: computeVariation(series, 30),
+      max: computeVariation(series, 'max'),
+    },
+    meta: {
+      clubId,
+      pointCount: series.length,
+      firstDate: firstPoint?.date ?? null,
+      lastDate: lastPoint?.date ?? null,
+      detentionPctUsed: opts.detentionPct,
+      // Cutoff réellement appliqué par deriveMemberSeries (null si joinedAt absent/non parseable).
+      joinedAtCutoff: normalizeJoinedAtCutoff(opts.joinedAt),
+    },
+  }
+}

--- a/docs/audits/design-reference-map.md
+++ b/docs/audits/design-reference-map.md
@@ -219,3 +219,15 @@ Réf visuelle : `REC/standalone-exports/PWA Install Banners (standalone).html` (
 - **offline.html** : palette dark uniquement (acceptable V0 ; `prefers-color-scheme` = amélioration future).
 - **Action owner** : logo source idéal = SVG/PNG transparent (les icônes maskables sont générées depuis `logo.jpg` fond noir). Script reproductible : `apps/web/scripts/generate-pwa-icons.mjs`.
 - **Branche non poussée** (worktree isolé) — push/PR sur demande.
+
+---
+
+## DSH-011 — pipeline data REPORTING (2026-06-12)
+
+Arbitrages lead (worktree `feat-dsh-011-reporting-sync`) :
+
+- **Pipeline data uniquement, AUCUN changement UI** : le graphe « Évolution » du dashboard V2 reste sur ses données demo jusqu'à DSH-012 (câblage UI = ticket suivant).
+- **`readSheet`** : paramètre de plage **optionnel** ajouté (défaut inchangé pour les 6 feuilles existantes) ; `REPORTING` lue en `A1:E10000` car la série compte ~2 900+ lignes > plage par défaut `A1:AZ2000` (troncature silencieuse sinon).
+- **REPORTING = 7ᵉ feuille OPTIONNELLE du sync** (insérée entre `Portefeuille` et `HISTORIQUE`) : tout échec (feuille absente, mapping KO) → **warning MOLLE** dans le rapport, jamais `success:false` — les 6 feuilles historiques restent le contrat dur.
+- **Hypothèse produit V0** : quote-part membre dérivée = `portfolio_value × detention_pct` **actuel** (approximation documentée si la détention a changé historiquement ; point de départ de la série membre = `MAX` filtré à `joined_at`).
+- Table `club_reporting_daily` (migration 034 : append-only/upsert par date, RLS lecture membres, écriture service-role) documentée dans `REC/DATA_MODEL.md` §2.10.

--- a/docs/tickets/PROMPT-DEV-DSH-011-REPORTING-SYNC.md
+++ b/docs/tickets/PROMPT-DEV-DSH-011-REPORTING-SYNC.md
@@ -1,0 +1,509 @@
+# PROMPT ORCHESTRATEUR — DSH-011 · Sync feuille REPORTING → historique graphe dashboard
+
+> À coller dans une **nouvelle session Claude Code**, dans un **git worktree isolé** (`feat/dsh-011-reporting-sync` depuis `main`).
+> Branche cible : **`feat/dsh-011-reporting-sync`** — **toujours créée depuis `main` à jour** (worktree dédié). Rebase sur `main` avant PR. Cette feature touche surtout data/sync : peu de risque UI, mais la **gate QA finale** doit prouver que **toute l'app reste fonctionnelle** (navigation, états dashboard, PWA/offline).
+>
+> **Contexte produit** : la matrice Google Sheets contient l'onglet **`REPORTING`** — série quotidienne club (valorisation portefeuille, cotisations cumulées, plus-value, ratio performance). C'est la source naturelle pour alimenter le graphe « Évolution » du dashboard V2. L'agent Dashboard V2 (`docs/tickets/PROMPT-DEV-DASHBOARD-V2-AB.md`) livre l'UI + **données demo** ; **ce ticket** livre le **pipeline data réel** que V2 branchera ensuite (`chart_data_source: 'live'`).
+
+---
+
+Tu es le **LEAD ORCHESTRATEUR** du ticket **DSH-011**.
+Tu ne codes pas toi-même les grosses features : tu **DÉCOMPOSES**, **DISPATCHES** des sub-agents, fais tourner **dev → test → QA**, et **ARBITRES**. Travaille en français.
+
+═══════════════════════════════════════════════════════════════════════════ 0. CADRE & GARDE-FOUS (non négociables — lis CLAUDE.md en entier d'abord)
+═══════════════════════════════════════════════════════════════════════════
+
+- Branche : **`feat/dsh-011-reporting-sync`** depuis **`main`** (jamais depuis une branche feature en cours). **NE JAMAIS refactorer la vitrine** (`apps/vitrine`).
+- **Règle de fin de ticket** : le monorepo doit être **100 % fonctionnel** à la livraison — pas seulement le pipeline REPORTING. Un sub-agent **QA** valide navigation, états dashboard, régressions E2E et comportement PWA/offline (§9).
+- **PÉRIMÈTRE STRICT — data pipeline uniquement** :
+  - Migration Postgres + RLS
+  - DTO / mapper / parser REPORTING (`packages/data`, `supabase/functions/sync`)
+  - Couche lecture serveur **`apps/web/lib/data/dashboard-chart.ts`** (nouveau fichier)
+  - Tests unitaires + tests sync Deno
+  - MAJ `REC/DATA_MODEL.md` §2 (nouvelle table)
+- **INTERDIT dans ce ticket** (réservés au sprint Dashboard V2 A/B ou follow-up UI) :
+  - `DashboardViewV2`, `DashboardEvolutionChart`, composants `@evolve/ui` du graphe
+  - Flag A/B Vercel, analytics GA4, `dashboard-chart-demo.ts`
+  - Modifier le comportement visuel de `DashboardView.tsx` (V1)
+  - Brancher le graphe V2 sur les données live (follow-up **DSH-012** — voir §8)
+- Langue : FR. **Conventional Commits**, scopes `{ supabase | data | sheets | utils | web }`.
+- Commits atomiques. **PUSH uniquement si l'owner le demande.**
+- TypeScript strict, zéro `any`. Pattern DTO strict (RowDTO → mapper → upsert).
+- `packages/ui` ne dépend JAMAIS de `packages/data`.
+
+═══════════════════════════════════════════════════════════════════════════
+
+1. ANALYSE — ÉTAT DES LIEUX (audité 2026-06-11)
+   ═══════════════════════════════════════════════════════════════════════════
+
+### 1.1 Feuille REPORTING (matrice Evolve Capital)
+
+Structure observée sur la matrice prod (capture owner, juin 2026) :
+
+| Col   | En-tête (ligne 2)         | Exemple                | Rôle                                                                           |
+| ----- | ------------------------- | ---------------------- | ------------------------------------------------------------------------------ |
+| **A** | Date                      | `dimanche, 03/05/2026` | Jour civil (week-end inclus)                                                   |
+| **B** | Valorisation portefeuille | `697 286,83`           | Total club (≈ ligne agrégat « Portefeuille » POSITIONS)                        |
+| **C** | Cotisations               | `311 301,24`           | Cotisations cumulées club (quasi constante sur une fenêtre courte)             |
+| **D** | Plus-value                | `385 985,59`           | Gain = B − C (parfois vide sur les dernières lignes)                           |
+| **E** | Performance               | `2,24`                 | Ratio B/C (≈ multiple de performance, **pas** un % — ex. 697286/311301 ≈ 2,24) |
+
+- ~2 000+ lignes historiques (depuis 2018) — une ligne par jour.
+- Les colonnes D/E peuvent être vides sur les jours les plus récents (formules Sheets en retard) : **recalculer côté mapper si manquant** (D = B−C, E = B/C si C > 0).
+
+### 1.2 Sync actuel (`supabase/functions/sync/index.ts`)
+
+Ordre impératif aujourd'hui (6 feuilles) :
+
+```
+PARAMETRAGES → Base → Portefeuille (onglet POSITIONS) → HISTORIQUE → COTISATIONS → Details cotisations
+```
+
+**REPORTING n'est pas importée.** Les snapshots JSONB (`sheet_snapshots`) ne suffisent pas : non requêtable efficacement pour un graphe (pattern déjà tranché pour les agrégats portefeuille → table `portfolio_aggregates`, migration 029).
+
+### 1.3 Schéma Postgres actuel (dashboard)
+
+| Objet                         | Rôle                              | Limite pour le graphe                                    |
+| ----------------------------- | --------------------------------- | -------------------------------------------------------- |
+| `member_quote_part` (vue)     | Quote-part **instantanée** membre | Pas d'historique                                         |
+| `contributions.detention_pct` | Fraction quote-part (ex. 0.0902)  | Stable entre cotisations ; change quand un membre cotise |
+| `portfolio_aggregates`        | Total club **instantané**         | Pas de série temporelle                                  |
+| `sheet_snapshots`             | Audit brut JSONB                  | Non exploitable pour courbe                              |
+
+Décision Sprint 4 (volontaire) : pas de table snapshots membre — composants graphe créés mais non alimentés (`docs/superpowers/plans/2026-05-31-sprint4-e-dsh-dashboard.md` § Décision #2).
+
+### 1.4 Hypothèse membre ← club (validée produit)
+
+> « Chaque cotisation unique varie de la même manière que le portefeuille. »
+
+En pratique V0 :
+
+```
+quote_part_membre(date) ≈ portfolio_value(date) × detention_pct_actuel
+```
+
+- **Avantage** : une seule série club en DB (~2 000 lignes/club) au lieu de N membres × jours.
+- **Limite documentée** : si `detention_pct` a changé historiquement (nouvelle cotisation), la courbe rétroactive est approximative. Acceptable V0 pour 7J/30J/90J ; pour MAX, filtrer `date >= joined_at` du membre.
+- **Alternative rejetée V0** : table `member_quote_part_snapshots` alimentée à chaque sync — duplication, et la feuille REPORTING ne porte pas les quote-parts individuelles.
+
+### 1.5 Chevauchement avec Dashboard V2 A/B
+
+| Zone                          | Agent Dashboard V2 AB          | Ce ticket DSH-011                                         |
+| ----------------------------- | ------------------------------ | --------------------------------------------------------- |
+| UI graphe + demo              | ✅                             | ❌                                                        |
+| `getDashboardData()` existant | Geler (sauf analytics mineur)  | ❌ ne pas modifier                                        |
+| Nouveau `dashboard-chart.ts`  | Consommer plus tard (DSH-012)  | ✅ créer                                                  |
+| Migration + sync REPORTING    | ❌ explicitement hors scope V2 | ✅                                                        |
+| `types.gen.ts`                | Peut diverger en parallèle     | Régénérer en fin de branche ; rebaser sur `main` avant PR |
+
+**Contrat d'intégration pour V2** (à respecter dans les types exportés) :
+
+```ts
+// apps/web/lib/data/dashboard-chart.ts — contrat stable pour DSH-012
+
+export type DashboardChartPeriod = '7d' | '30d' | '90d' | '1y' | 'max'
+
+export interface DashboardChartPoint {
+  /** ISO date calendaire (YYYY-MM-DD), timezone UTC midnight */
+  date: string
+  /** Quote-part membre dérivée (EUR), formaté côté UI via formatEUR */
+  value: number
+}
+
+export interface DashboardChartVariation {
+  amount: number // delta EUR sur la période
+  percent: number // fraction (0.0455 = +4,55 %), pour TrendBadge / formatPct
+}
+
+export interface DashboardChartData {
+  source: 'live'
+  /** Série complète triée ASC ; le client filtre par période */
+  series: DashboardChartPoint[]
+  variations: {
+    d1: DashboardChartVariation | null
+    d30: DashboardChartVariation | null
+    max: DashboardChartVariation | null
+  }
+  /** Meta debug / QA — pas exposée GA4 */
+  meta: {
+    clubId: string
+    pointCount: number
+    firstDate: string | null
+    lastDate: string | null
+    detentionPctUsed: number
+    joinedAtCutoff: string | null
+  }
+}
+
+/** Retourne null si aucune ligne REPORTING en base (V2 reste en mode demo). */
+export async function getDashboardChartData(
+  supabase: ServerClient,
+  userId: string,
+  clubId: string,
+  opts: { detentionPct: number; joinedAt: string | null }
+): Promise<DashboardChartData | null>
+```
+
+V2 fera ensuite :
+
+```ts
+const chartLive = await getDashboardChartData(supabase, userId, clubId, {
+  detentionPct: initialData.detentionPct,
+  joinedAt: initialData.member.joinedAt,
+})
+const chart = chartLive ?? mergeDemoChart(initialData) // demo module existant V2
+const chartDataSource = chartLive ? 'live' : 'demo'
+```
+
+═══════════════════════════════════════════════════════════════════════════ 2. DÉCISION ARCHITECTURALE — INTÉGRER DANS LE SYNC (pas un script séparé)
+═══════════════════════════════════════════════════════════════════════════
+
+**Recommandation : étendre l'Edge Function `/sync` existante** (7ᵉ feuille), pas un cron/script autonome.
+
+| Critère                     | Sync intégré                        | Script séparé                |
+| --------------------------- | ----------------------------------- | ---------------------------- |
+| Déclenchement               | Même `pg_cron` / POST `/api/sync`   | Nouveau cron + auth à câbler |
+| Audit                       | `sheet_snapshots` + checksum        | À dupliquer                  |
+| Credentials Google          | `GOOGLE_SA_KEY_BASE64` déjà injecté | Duplication                  |
+| Cohérence `clubs.synced_at` | Un seul run                         | Risque de dérive             |
+| Pattern codebase            | Identique aux 6 feuilles            | Exception                    |
+
+**Position dans l'ordre de sync** : après **Portefeuille**, avant **HISTORIQUE** — REPORTING est club-level, sans lookup membre ; cohérent de la placer après les données portefeuille instantanées.
+
+```
+… → Portefeuille → REPORTING → HISTORIQUE → …
+```
+
+Étiquette snapshot interne : **`REPORTING`** (nom d'onglet réel).
+
+### 2.1 Résilience sync — REPORTING **optionnelle** (NON négociable)
+
+REPORTING est une **feuille enrichissante**, pas une feuille bloquante comme Base ou COTISATIONS.
+**Aucun scénario ci-dessous ne doit faire crasher le run `/sync` ni mettre `success: false` à lui seul.**
+
+| Scénario                                                                                        | Comportement attendu                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Onglet **`REPORTING` absent** de la matrice Google (HTTP 400 « Unable to parse range » / 404)   | **Warning MOLLE** (`warnings[]`), snapshot `failed` ou `skipped` best-effort, **pas** d'entrée dans `errors[]`. Les 6 feuilles existantes continuent ; `clubs.synced_at` est MAJ si le reste OK. |
+| Feuille présente mais **vide** ou sans lignes data parseables                                   | Warning MOLLE, 0 upsert, pas d'abort.                                                                                                                                                            |
+| Lignes partiellement invalides (date illisible, B/C manquants)                                  | Quarantaine MOLLE (pattern Portefeuille), import du reste.                                                                                                                                       |
+| Table Postgres **`club_reporting_daily` absente** (migration 034 pas encore déployée sur l'env) | Attraper l'erreur Supabase (`relation … does not exist` / code `42P01`) → **warning**, skip upsert, **sync global continue**. Ne jamais throw non attrapé.                                       |
+| Upsert partiel en échec (batch N)                                                               | Log + warning ; ne pas corrompre les batches précédents.                                                                                                                                         |
+
+**Implémentation recommandée** : introduire `runOptionalSheet(name, handler)` (ou param `optional: true` sur `runSheet`) distinct de `runSheet` standard :
+
+- `runSheet` (existant) → erreur → `errors[]` → peut faire `success: false`
+- `runOptionalSheet('REPORTING', …)` → erreur → **`warnings[]` uniquement** → `success` inchangé
+
+Tests Deno **obligatoires** :
+
+1. `readSheet('REPORTING')` throw (onglet absent) → sync 200, `success: true`, `errors` sans `REPORTING`, `warnings` contient une note explicite.
+2. Upsert mock renvoie `42P01` → idem, pas de crash handler.
+3. Feuille REPORTING OK → import normal + présence dans `synced_sheets`.
+
+**Lecture app** : `getDashboardChartData()` retourne déjà `null` si 0 ligne — l'UI (V1 ou V2 demo) ne doit **jamais** crasher ni afficher NaN si REPORTING manque.
+
+═══════════════════════════════════════════════════════════════════════════ 3. SCHÉMA PROPOSÉ — Migration `034_club_reporting_daily.sql`
+═══════════════════════════════════════════════════════════════════════════
+
+```sql
+-- Série quotidienne club — source : feuille REPORTING (cols A–E).
+-- Alimentation : Edge Function sync (service role). Lecture : membres du club (RLS).
+
+CREATE TABLE IF NOT EXISTS club_reporting_daily (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id               UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+  report_date           DATE NOT NULL,
+  portfolio_value       NUMERIC(18,2) NOT NULL,   -- col B
+  total_contributions   NUMERIC(18,2) NOT NULL,   -- col C
+  capital_gain          NUMERIC(18,2),            -- col D (nullable si recalculé)
+  performance_ratio     NUMERIC(12,6),            -- col E (= B/C si C>0)
+  synced_at             TIMESTAMPTZ NOT NULL,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (club_id, report_date)
+);
+
+CREATE INDEX club_reporting_daily_club_date_idx
+  ON club_reporting_daily (club_id, report_date DESC);
+
+ALTER TABLE club_reporting_daily ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "club_reporting_daily: club member read"
+  ON club_reporting_daily FOR SELECT
+  USING (club_id IN (SELECT get_user_club_ids()));
+
+-- Écriture : service role uniquement (sync) — aucune policy INSERT/UPDATE authenticated.
+```
+
+**Pas de soft-delete par synced_at** (contrairement à `positions`) : l'historique REPORTING est append-only / upsert par date. Une ligne absente de la feuille n'est **pas** supprimée automatiquement V0 (évite effacement accidentel si la plage lue est tronquée). Documenter en commentaire migration ; purge manuelle trésorier = V1+.
+
+**Sanity check post-import** (warning MOLLE, pas abort) : comparer la dernière `portfolio_value` avec `portfolio_aggregates` label « Portefeuille » — écart > 1 % → `warnings[]` dans la réponse sync.
+
+═══════════════════════════════════════════════════════════════════════════ 4. COUCHE SHEETS — Fichiers à créer / modifier
+═══════════════════════════════════════════════════════════════════════════
+
+### 4.1 DTO (`packages/data/src/types/sheets.ts`)
+
+```ts
+export interface ReportingRowDTO {
+  reportDateRaw: string | null // col A brute
+  portfolioValue: number | null // col B
+  totalContributions: number | null // col C
+  capitalGain: number | null // col D
+  performanceRatio: number | null // col E
+}
+
+export interface ClubReportingDailyUpsert {
+  club_id: string
+  report_date: string // ISO date YYYY-MM-DD
+  portfolio_value: number
+  total_contributions: number
+  capital_gain: number | null
+  performance_ratio: number | null
+  synced_at: string
+}
+```
+
+### 4.2 Parser (`supabase/functions/sync/sheetParsers.ts`)
+
+- `parseReporting(rows: string[][]): ReportingRowDTO[]`
+- Sauter les 2 premières lignes si ligne 0 = titre matrice / ligne 1 = en-têtes (aligné capture : headers row 2 purple).
+- Col A : extraire la date avec helper dédié **`parseReportingDate`** :
+  - `"dimanche, 03/05/2026"` → `2006-05-03` (regex sur `\d{1,2}/\d{1,2}/\d{4}` après la virgule)
+  - Réutiliser / étendre `parseFrDate` dans `@evolve/utils` (tests obligatoires)
+- Col B–E : `toNumOrNull` (format FR existant)
+
+### 4.3 Mapper (`packages/data/src/sheets/mappers/reporting.mapper.ts`)
+
+- `mapReportingRows(rows: ReportingRowDTO[], clubId: string, syncedAt: string)`
+- Quarantaine MOLLE : lignes sans date parseable ou sans B/C → `skipped[]` + warning
+- Enrichissement : si D null et B,C ok → `capital_gain = B - C`
+- Enrichissement : si E null et C > 0 → `performance_ratio = B / C`
+- Validation : B ≥ 0, C ≥ 0 ; dates uniques (dernière ligne gagne en cas de doublon jour)
+
+### 4.4 Sync handler (`supabase/functions/sync/index.ts`)
+
+Nouveau bloc **`runOptionalSheet('REPORTING', …)`** (cf. §2.1 — pas `runSheet` classique) :
+
+1. `readSheet(sheetId, 'REPORTING')` — si throw → catch → warning + return (pas de rethrow)
+2. `parseReporting` → `mapReportingRows`
+3. Upsert batch par paquets de 500 (`onConflict: 'club_id,report_date'`) — wrapper try/catch par batch + catch table absente (`42P01`)
+4. `createSnapshot(…, 'REPORTING', raw, …)` best-effort
+5. Sanity check vs `portfolio_aggregates` (warning MOLLE si écart > 1 %)
+
+Mettre à jour :
+
+- `SHEET_PREFIXES` dans `syncErrorAlert.ts` (warnings REPORTING optionnels **exclus** des alertes email sync error si seule anomalie)
+- Tests Deno `sync.test.ts` :
+  - fixture REPORTING OK : ordre (après Portefeuille), idempotence, date FR avec jour de semaine
+  - **REPORTING absent** : sync complète des 6 autres feuilles, `success: true`
+  - **table DB absente** : mock Supabase `42P01`, pas de crash
+
+### 4.5 Tests unitaires Vitest
+
+- `packages/utils/src/dates.test.ts` — cas `parseReportingDate` / extension `parseFrDate`
+- `packages/data/src/sheets/mappers/__tests__/reporting.mapper.test.ts` — recalcul D/E, quarantaine, doublons
+
+═══════════════════════════════════════════════════════════════════════════ 5. COUCHE LECTURE — `apps/web/lib/data/dashboard-chart.ts`
+═══════════════════════════════════════════════════════════════════════════
+
+**Ne pas modifier `getDashboardData()`** — créer un module séparé consommé plus tard par DSH-012.
+
+Algorithme `getDashboardChartData` :
+
+1. Query `club_reporting_daily` WHERE `club_id = ?` ORDER BY `report_date ASC` (RLS OK).
+2. Si 0 ligne → `null`.
+3. Filtrer `report_date >= joinedAt` si `joinedAt` parseable (période MAX membre).
+4. Mapper chaque point : `{ date, value: portfolio_value * detentionPct }`.
+5. Calculer variations :
+   - **d1** : dernier point vs avant-dernier (si ≥ 2 points)
+   - **d30** : dernier vs point le plus proche de J-30 (ou premier si historique < 30j)
+   - **max** : dernier vs premier de la série filtrée
+   - `percent = (end - start) / start` si start > 0 ; sinon null → pas de TrendBadge
+6. Jamais retourner NaN — filtrer points invalides.
+
+Helper pur exporté pour tests :
+
+```ts
+export function deriveMemberSeries(
+  clubRows: { report_date: string; portfolio_value: number }[],
+  detentionPct: number,
+  joinedAt: string | null
+): DashboardChartPoint[]
+
+export function computeVariation(
+  series: DashboardChartPoint[],
+  daysBack: number | 'max'
+): DashboardChartVariation | null
+```
+
+Tests Vitest dans `apps/web/lib/data/dashboard-chart.test.ts` (série synthétique, pas de Supabase).
+
+**Ne pas brancher** dans `apps/web/app/(app)/dashboard/page.tsx` dans ce ticket — DSH-012 le fera pour éviter conflit avec l'agent V2 sur `page.tsx`.
+
+═══════════════════════════════════════════════════════════════════════════ 6. ROSTER SUB-AGENTS & PLAN D'EXÉCUTION
+═══════════════════════════════════════════════════════════════════════════
+
+```
+Phase 0 — Lead : lire CLAUDE.md + ce prompt + sync/index.ts + DATA_MODEL.md
+          Gate baseline : make lint typecheck test
+          Vérifier plage readSheet (A1:E2500 suffisant ? ajuster readSheet ou range dédiée REPORTING)
+
+Phase 1 — DB : migration 034 + db push local + make db-types
+
+Phase 2 — Data (parallèle après Phase 1) :
+          A) utils parseReportingDate + tests
+          B) DTO + mapper reporting + tests Vitest
+          C) sheetParsers parseReporting + tests Deno parser
+
+Phase 3 — Sync : intégrer runSheet REPORTING + tests handler Deno (idempotence, ordre, partial)
+
+Phase 4 — Read layer : dashboard-chart.ts + tests purs
+
+Phase 5 — Doc : REC/DATA_MODEL.md §2.10 club_reporting_daily + note design-reference-map (pipeline data)
+
+Phase 6 — Gate technique :
+          make lint typecheck test
+          pnpm vitest run apps/web/lib/data/dashboard-chart.test.ts
+          pnpm vitest run packages/data/src/sheets/mappers/__tests__/reporting.mapper.test.ts
+          deno test supabase/functions/sync/__tests__/sync.test.ts
+          Sync manuel local : avec ET sans onglet REPORTING → pas de crash
+
+Phase 7 — QA E2E & non-régression (sub-agent QA obligatoire, max 3 itérations) :
+          Voir §9 — scorecard bloquant avant « FAIT »
+```
+
+═══════════════════════════════════════════════════════════════════════════ 7. CRITÈRES D'ACCEPTATION (DoD)
+═══════════════════════════════════════════════════════════════════════════
+
+- [ ] Table `club_reporting_daily` créée, RLS lecture membre, écriture service role only
+- [ ] Feuille REPORTING importée quand présente (7ᵉ feuille optionnelle), snapshot audit OK
+- [ ] **Résilience** : onglet REPORTING absent → sync OK (`success: true`), warning explicite, 6 feuilles intactes
+- [ ] **Résilience** : table `club_reporting_daily` absente (pre-migration) → sync OK, warning, pas de throw
+- [ ] Parser gère `"jour, DD/MM/YYYY"` + formats FR numériques
+- [ ] D/E recalculés si absents ; warnings MOLLE sur lignes rejetées
+- [ ] Idempotence : 2 syncs consécutives → même nombre de lignes, valeurs identiques
+- [ ] `getDashboardChartData()` retourne série dérivée membre + variations d1/d30/max
+- [ ] Retourne `null` si table vide (V2 reste en demo sans crash)
+- [ ] Aucun fichier UI dashboard modifié (`DashboardView*`, `page.tsx`, `@evolve/ui` graphe)
+- [ ] `getDashboardData()` inchangé (diff vide ou commentaire doc uniquement)
+- [ ] Tests verts (Vitest + Deno sync, dont scénarios résilience §2.1)
+- [ ] **Gate QA §9** : scorecard CONVERGÉ, E2E dashboard + navigation + PWA/offline OK
+- [ ] **Projet entier fonctionnel** : `make lint typecheck test` vert sur le monorepo touché
+- [ ] `REC/DATA_MODEL.md` mis à jour
+- [ ] Commits atomiques FR, non poussés sauf demande owner
+
+═══════════════════════════════════════════════════════════════════════════ 8. FOLLOW-UP EXPLICITE — DSH-012 (hors scope, pour l'agent Dashboard V2)
+═══════════════════════════════════════════════════════════════════════════
+
+Ticket consommateur à enchaîner **après merge DSH-011** (peut être fait par l'agent V2 rebasé) :
+
+1. Dans `apps/web/app/(app)/dashboard/page.tsx` : appeler `getDashboardChartData` en parallèle de `getDashboardData`
+2. Passer `chartData` à `DashboardViewV2` ; merger demo si null
+3. Remplacer `chart_data_source: 'demo'` par `'live'` quand série présente
+4. Alimenter `TrendBadge` hero (variation 1j) depuis `variations.d1`
+5. Filtrer `series` côté client selon toggle 7J/30J/90J/1A/MAX
+6. Test e2e : seed REPORTING en local → graphe V2 sans label demo
+
+**Fichiers réservés DSH-012 (ne pas toucher dans DSH-011)** :
+
+- `apps/web/components/dashboard/DashboardViewV2.tsx`
+- `apps/web/lib/data/dashboard-chart-demo.ts`
+- `apps/web/app/(app)/dashboard/page.tsx`
+- `docs/analytics/PLAN-DE-TAGGAGE.md`
+
+═══════════════════════════════════════════════════════════════════════════ 9. QA FINALE — PROJET FONCTIONNEL (sub-agent obligatoire)
+═══════════════════════════════════════════════════════════════════════════
+
+Même si DSH-011 est un ticket **data**, la livraison n'est **pas** acceptable si l'app membre
+régresse. L'orchestrateur dispatch un sub-agent **QA** (read + browser + Playwright) en **Phase 7**.
+
+### 9.1 Protocole automatisé (bloquant)
+
+```bash
+make lint typecheck test
+pnpm --filter @evolve/web exec playwright test dashboard.spec.ts --workers=1
+pnpm --filter @evolve/web exec playwright test cursor-pointer.spec.ts --workers=1
+pnpm --filter @evolve/web exec playwright test a11y.spec.ts --workers=1
+# Si V2 déjà sur main au moment du rebase : ajouter dashboard-v2.spec.ts s'il existe
+pnpm --filter @evolve/web exec playwright test pwa-install-banner.spec.ts --workers=1
+```
+
+Smoke navigation (Playwright ou MCP browser) — **0 régression** :
+
+| Route                                             | Vérifier                                                                                                               |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `/dashboard`                                      | Hero + KPIs visibles ; états loading→loaded ; pas de NaN/undefined ; stale banner si mock ; empty state si pas de data |
+| `/dashboard` V2 (si présente sur branche rebasée) | Graphe visible (demo ou live) ; toggles période 30J/MAX mobile, 7J–MAX desktop ; filtres changent la courbe sans crash |
+| `/portfolio`                                      | Liste positions ; pas de régression layout                                                                             |
+| `/contributions`                                  | Timeline ; pas de régression                                                                                           |
+| BottomNav / Sidebar                               | Navigation fluide entre les 3 onglets ; focus clavier OK                                                               |
+
+### 9.2 Dashboard — états à couvrir (QA manuel ou e2e)
+
+- **Loading** : `loading.tsx` ou skeleton — pas de flash de contenu cassé
+- **Loaded** : montants formatés FR (`formatEUR`)
+- **Empty** : membre sans `member_quote_part` → `EmptyState`, pas de crash
+- **Error** : `error.tsx` ou boundary — message FR, retry possible
+- **Stale** : `syncedAt` > 2h → badge sync (existant DSH-007)
+- **Chart sans historique** : `getDashboardChartData` → `null` → UI reste en demo V2 ou sans graphe V1 — **jamais d'écran blanc**
+
+### 9.3 PWA & mode offline
+
+Réf : `apps/web/public/sw.js`, `public/offline.html`, spec `docs/superpowers/specs/2026-06-07-pwa-install-banner-design.md`.
+
+- Vérifier que l'ajout migration/sync **ne casse pas** l'enregistrement SW ni le manifest.
+- **Offline** (prod build ou inspection SW) : navigation vers une URL non cacheable → fallback `/offline.html` ou page shell ; retour online → dashboard recharge sans erreur permanente.
+- Bannière install PWA : toujours dismissable ; pas de chevauchement avec cookie consent.
+- TanStack Query : en offline, le dashboard déjà visité ne crash pas (cache stale acceptable) — pas de boucle d'erreur non gérée.
+
+> Note : Playwright dev n'exécute pas toujours le SW (prod-only) — QA documente ce qu'il a pu vérifier en build preview (`pnpm --filter @evolve/web build && pnpm start`) si nécessaire.
+
+### 9.4 Scorecard QA (verdict bloquant)
+
+Le sub-agent QA produit un **SCORECARD** markdown (dans la réponse ou `docs/qa/`) :
+
+| Critère                                           | Bloquant |
+| ------------------------------------------------- | -------- |
+| Gate `make lint typecheck test` vert              | Oui      |
+| E2E dashboard + cursor-pointer verts              | Oui      |
+| Navigation 3 onglets fluide                       | Oui      |
+| États dashboard (loaded/empty/stale) OK           | Oui      |
+| Sync sans REPORTING ne casse pas l'app            | Oui      |
+| PWA/offline : pas de régression manifest/SW       | Oui      |
+| A11y : pas de nouvelle violation serious/critical | Oui      |
+
+Verdict ∈ { **CONVERGÉ** | À CORRIGER | ARBITRAGE }. Max **3 boucles** dev→QA.
+
+═══════════════════════════════════════════════════════════════════════════ 10. COMMITS ATTENDUS (exemples)
+═══════════════════════════════════════════════════════════════════════════
+
+```
+feat(supabase): table club_reporting_daily avec rls lecture membre
+feat(sheets): dto et mapper feuille reporting
+feat(utils): parseReportingDate pour colonnes date avec jour de semaine
+feat(supabase): sync feuille reporting optionnelle en 7e etape
+test(supabase): sync resilient sans onglet ou table reporting
+feat(web): couche getDashboardChartData derivee du reporting club
+test(sheets): mapper reporting et sync deno reporting
+docs(data): documenter club_reporting_daily dans DATA_MODEL
+```
+
+═══════════════════════════════════════════════════════════════════════════ 11. WORKTREE — DÉMARRAGE RAPIDE
+═══════════════════════════════════════════════════════════════════════════
+
+```bash
+cd /Users/lionel/Documents/OMNIVENTUS/Projects/reseau-evolve-capital
+git fetch origin main
+git worktree add .claude/worktrees/feat-dsh-011-reporting-sync -b feat/dsh-011-reporting-sync origin/main
+cd .claude/worktrees/feat-dsh-011-reporting-sync
+make db-start   # si stack locale absente
+make lint typecheck test   # gate baseline
+# Puis exécuter les phases §6
+```
+
+---
+
+**Roster sub-agents** : Phase 1–4 IMPLEMENTER (data/sync/web) · Phase 7 **QA** (E2E, navigation, PWA, scorecard §9).
+
+**COMMENCE par la Phase 0, présente le plan ordonné avec vérification de la plage Google Sheets REPORTING, PUIS lance les sub-agents. Ne déclare « FAIT » qu'après scorecard QA §9 CONVERGÉ.**

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -6,6 +6,7 @@ export { mapPortefeuilleRows, mapAggregateRows } from './sheets/mappers/portefeu
 export { mapHistoriqueRows } from './sheets/mappers/historique.mapper.ts'
 export { mapCotisationsRows } from './sheets/mappers/cotisations.mapper.ts'
 export { mapDetailsCotisationsRows } from './sheets/mappers/detailsCotisations.mapper.ts'
+export { mapReportingRows } from './sheets/mappers/reporting.mapper.ts'
 export * from './types/sheets.ts'
 export { createBrowserClient } from './supabase/client.ts'
 export { createServerClient } from './supabase/server.ts'

--- a/packages/data/src/sheets/mappers/__tests__/reporting.mapper.test.ts
+++ b/packages/data/src/sheets/mappers/__tests__/reporting.mapper.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { mapReportingRows } from '../reporting.mapper.ts'
+import type { ReportingRowDTO } from '../../../types/sheets.ts'
+
+const CLUB = '11111111-1111-1111-1111-111111111111'
+const SYNCED_AT = '2026-06-12T08:00:00.000Z'
+
+/** Fixture complète : ligne quotidienne valide (tous champs présents). */
+function makeRow(overrides: Partial<ReportingRowDTO> = {}): ReportingRowDTO {
+  return {
+    reportDateRaw: 'dimanche, 03/05/2026',
+    portfolioValue: 697286.83,
+    totalContributions: 311301.24,
+    capitalGain: 385985.59,
+    performanceRatio: 2.24,
+    ...overrides,
+  }
+}
+
+describe('mapReportingRows', () => {
+  it('mappe la date FR avec jour de semaine vers ISO yyyy-mm-dd', () => {
+    const { upserts, skipped } = mapReportingRows([makeRow()], CLUB, SYNCED_AT)
+    expect(skipped).toHaveLength(0)
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0]!.report_date).toBe('2026-05-03')
+    expect(upserts[0]!.portfolio_value).toBe(697286.83)
+    expect(upserts[0]!.total_contributions).toBe(311301.24)
+    // D/E fournis par la feuille → conservés tels quels (la source fait foi).
+    expect(upserts[0]!.capital_gain).toBe(385985.59)
+    expect(upserts[0]!.performance_ratio).toBe(2.24)
+  })
+
+  it('propage club_id et synced_at sur chaque upsert', () => {
+    const { upserts } = mapReportingRows([makeRow()], CLUB, SYNCED_AT)
+    expect(upserts[0]!.club_id).toBe(CLUB)
+    expect(upserts[0]!.synced_at).toBe(SYNCED_AT)
+  })
+
+  it('recalcule la plus-value (D = B − C) quand la colonne D est vide', () => {
+    const { upserts } = mapReportingRows([makeRow({ capitalGain: null })], CLUB, SYNCED_AT)
+    expect(upserts[0]!.capital_gain).toBeCloseTo(385985.59, 2)
+  })
+
+  it('recalcule le ratio de performance (E = B / C) quand E est vide et C > 0', () => {
+    const { upserts } = mapReportingRows([makeRow({ performanceRatio: null })], CLUB, SYNCED_AT)
+    expect(upserts[0]!.performance_ratio).toBeCloseTo(697286.83 / 311301.24, 6)
+  })
+
+  it('garde E null quand E est vide et C = 0 (ratio sans sens)', () => {
+    const { upserts, skipped } = mapReportingRows(
+      [makeRow({ totalContributions: 0, capitalGain: null, performanceRatio: null })],
+      CLUB,
+      SYNCED_AT
+    )
+    // C = 0 est VALIDE (début de série) : pas de quarantaine, mais ratio null.
+    expect(skipped).toHaveLength(0)
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0]!.performance_ratio).toBeNull()
+    // La plus-value, elle, reste calculable (B − 0).
+    expect(upserts[0]!.capital_gain).toBeCloseTo(697286.83, 2)
+  })
+
+  it('met en quarantaine MOLLE une date illisible (raison lisible)', () => {
+    const { upserts, skipped } = mapReportingRows(
+      [makeRow({ reportDateRaw: 'pas une date' }), makeRow({ reportDateRaw: null })],
+      CLUB,
+      SYNCED_AT
+    )
+    expect(upserts).toHaveLength(0)
+    expect(skipped).toHaveLength(2)
+    expect(skipped[0]).toContain('date illisible')
+    expect(skipped[0]).toContain('pas une date')
+  })
+
+  it('met en quarantaine MOLLE une ligne à B ou C manquant', () => {
+    const { upserts, skipped } = mapReportingRows(
+      [makeRow({ portfolioValue: null }), makeRow({ totalContributions: null })],
+      CLUB,
+      SYNCED_AT
+    )
+    expect(upserts).toHaveLength(0)
+    expect(skipped).toHaveLength(2)
+    // La raison porte la date ISO (lisible/actionnable côté warning de sync).
+    expect(skipped[0]).toContain('2026-05-03')
+  })
+
+  it('met en quarantaine MOLLE une ligne à B ou C négatif', () => {
+    const { upserts, skipped } = mapReportingRows(
+      [makeRow({ portfolioValue: -1 }), makeRow({ totalContributions: -0.01 })],
+      CLUB,
+      SYNCED_AT
+    )
+    expect(upserts).toHaveLength(0)
+    expect(skipped).toHaveLength(2)
+  })
+
+  it('doublons de date : la DERNIÈRE ligne de la feuille gagne', () => {
+    const { upserts } = mapReportingRows(
+      [
+        makeRow({ portfolioValue: 100, totalContributions: 50 }),
+        makeRow({ portfolioValue: 200, totalContributions: 80, capitalGain: null }),
+      ],
+      CLUB,
+      SYNCED_AT
+    )
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0]!.report_date).toBe('2026-05-03')
+    expect(upserts[0]!.portfolio_value).toBe(200)
+    expect(upserts[0]!.total_contributions).toBe(80)
+    expect(upserts[0]!.capital_gain).toBe(120)
+  })
+
+  it('feuille vide → aucun upsert, aucune quarantaine', () => {
+    const { upserts, skipped } = mapReportingRows([], CLUB, SYNCED_AT)
+    expect(upserts).toHaveLength(0)
+    expect(skipped).toHaveLength(0)
+  })
+})

--- a/packages/data/src/sheets/mappers/reporting.mapper.ts
+++ b/packages/data/src/sheets/mappers/reporting.mapper.ts
@@ -1,0 +1,61 @@
+import { parseReportingDate } from '@evolve/utils'
+import type { ReportingRowDTO, ClubReportingDailyUpsert } from '../../types/sheets.ts'
+
+/**
+ * Mappe les lignes REPORTING (série quotidienne club, DSH-011) en upserts
+ * `club_reporting_daily`. PURE (Deno-safe), aucune I/O.
+ *
+ * RÈGLES :
+ *  - Date (col A) via parseReportingDate (« dimanche, 03/05/2026 » → Date UTC) puis
+ *    ISO 'yyyy-mm-dd'. Date non parseable → quarantaine MOLLE (skipped[], raison lisible).
+ *  - B (valorisation) ou C (cotisations) manquant (null) ou négatif → quarantaine MOLLE
+ *    (colonnes NOT NULL en DB, migration 034 — on n'invente jamais de valeur).
+ *  - Enrichissement : D (plus-value) absent et B,C valides → capital_gain = B − C ;
+ *    E (ratio) absent et C > 0 → performance_ratio = B / C. C = 0 (B ≥ 0 possible en
+ *    tout début de série) → ratio sans sens, E reste null. Une valeur D/E FOURNIE par
+ *    la feuille est toujours conservée telle quelle (la source fait foi).
+ *  - Doublons de date : la DERNIÈRE ligne de la feuille gagne (Map indexée sur la date,
+ *    écrasement en ordre de lecture) — cohérent avec l'upsert (club_id, report_date).
+ */
+export function mapReportingRows(
+  rows: ReportingRowDTO[],
+  clubId: string,
+  syncedAt: string
+): { upserts: ClubReportingDailyUpsert[]; skipped: string[] } {
+  const byDate = new Map<string, ClubReportingDailyUpsert>()
+  const skipped: string[] = []
+  for (const row of rows) {
+    const date = parseReportingDate(row.reportDateRaw)
+    if (date == null) {
+      skipped.push(`date illisible: "${row.reportDateRaw ?? ''}"`)
+      continue
+    }
+    const reportDate = date.toISOString().slice(0, 10)
+    const portfolioValue = row.portfolioValue
+    const totalContributions = row.totalContributions
+    if (
+      portfolioValue == null ||
+      portfolioValue < 0 ||
+      totalContributions == null ||
+      totalContributions < 0
+    ) {
+      skipped.push(
+        `${reportDate}: valorisation/cotisations manquante(s) ou négative(s) ` +
+          `(B=${portfolioValue ?? '∅'}, C=${totalContributions ?? '∅'})`
+      )
+      continue
+    }
+    byDate.set(reportDate, {
+      club_id: clubId,
+      report_date: reportDate,
+      portfolio_value: portfolioValue,
+      total_contributions: totalContributions,
+      capital_gain: row.capitalGain ?? portfolioValue - totalContributions,
+      performance_ratio:
+        row.performanceRatio ??
+        (totalContributions > 0 ? portfolioValue / totalContributions : null),
+      synced_at: syncedAt,
+    })
+  }
+  return { upserts: [...byDate.values()], skipped }
+}

--- a/packages/data/src/supabase/types.gen.ts
+++ b/packages/data/src/supabase/types.gen.ts
@@ -66,6 +66,53 @@ export type Database = {
           },
         ]
       }
+      club_reporting_daily: {
+        Row: {
+          capital_gain: number | null
+          club_id: string
+          created_at: string
+          id: string
+          performance_ratio: number | null
+          portfolio_value: number
+          report_date: string
+          synced_at: string
+          total_contributions: number
+          updated_at: string
+        }
+        Insert: {
+          capital_gain?: number | null
+          club_id: string
+          created_at?: string
+          id?: string
+          performance_ratio?: number | null
+          portfolio_value: number
+          report_date: string
+          synced_at: string
+          total_contributions: number
+          updated_at?: string
+        }
+        Update: {
+          capital_gain?: number | null
+          club_id?: string
+          created_at?: string
+          id?: string
+          performance_ratio?: number | null
+          portfolio_value?: number
+          report_date?: string
+          synced_at?: string
+          total_contributions?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'club_reporting_daily_club_id_fkey'
+            columns: ['club_id']
+            isOneToOne: false
+            referencedRelation: 'clubs'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       clubs: {
         Row: {
           annual_investment_cap: number | null

--- a/packages/data/src/types/sheets.ts
+++ b/packages/data/src/types/sheets.ts
@@ -83,6 +83,19 @@ export interface CotisationsRowDTO {
   status: string | null
   amountDue: number | null
 }
+/** REPORTING (série quotidienne club, DSH-011) — cols A–E brutes de la matrice. */
+export interface ReportingRowDTO {
+  /** Col A brute, date avec jour de semaine (« dimanche, 03/05/2026 »). */
+  reportDateRaw: string | null
+  /** Col B — valorisation portefeuille. */
+  portfolioValue: number | null
+  /** Col C — cotisations cumulées. */
+  totalContributions: number | null
+  /** Col D — plus-value (= B−C, parfois vide en source). */
+  capitalGain: number | null
+  /** Col E — performance (ratio B/C, PAS un % ; parfois vide en source). */
+  performanceRatio: number | null
+}
 
 // ---- Types métier upsertables ----
 export interface UserUpsert {
@@ -181,6 +194,19 @@ export interface ContributionUpsert {
   net_market_value: number | null
   status: 'ok' | 'pending' | 'late' | 'exempt'
   amount_due: number
+}
+/** Ligne upsertable dans club_reporting_daily (migration 034) — clé (club_id, report_date). */
+export interface ClubReportingDailyUpsert {
+  club_id: string
+  /** Format ISO 'yyyy-mm-dd' pour colonne Postgres DATE. */
+  report_date: string
+  portfolio_value: number
+  total_contributions: number
+  /** Plus-value (col D, recalculée B−C par le mapper si absente en source). */
+  capital_gain: number | null
+  /** Ratio B/C (col E, recalculé par le mapper si absent ET C > 0 ; null si C = 0). */
+  performance_ratio: number | null
+  synced_at: string
 }
 export interface ContributionMonthUpsert {
   membership_id: string

--- a/packages/utils/src/dates.test.ts
+++ b/packages/utils/src/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseFrDate, parseFrMonth, formatRelativeTime } from './dates.ts'
+import { parseFrDate, parseFrMonth, parseReportingDate, formatRelativeTime } from './dates.ts'
 
 describe('parseFrDate', () => {
   it('parse dd/mm/yyyy en Date UTC', () => {
@@ -40,6 +40,54 @@ describe('parseFrMonth', () => {
     expect(parseFrMonth('zorglub 2018')).toBeNull()
     expect(parseFrMonth('')).toBeNull()
     expect(parseFrMonth(null)).toBeNull()
+  })
+})
+
+describe('parseReportingDate', () => {
+  it('parse "dimanche, 03/05/2026" en Date UTC à minuit', () => {
+    const d = parseReportingDate('dimanche, 03/05/2026')!
+    expect(d.getUTCFullYear()).toBe(2026)
+    expect(d.getUTCMonth()).toBe(4)
+    expect(d.getUTCDate()).toBe(3)
+    expect(d.getUTCHours()).toBe(0)
+  })
+  it('parse une date nue "03/05/2026" (sans jour de semaine)', () => {
+    const d = parseReportingDate('03/05/2026')!
+    expect(d.getUTCFullYear()).toBe(2026)
+    expect(d.getUTCMonth()).toBe(4)
+    expect(d.getUTCDate()).toBe(3)
+  })
+  it('tolère l\'absence d\'espace après la virgule et la casse ("Mercredi,01/01/2020")', () => {
+    const d = parseReportingDate('Mercredi,01/01/2020')!
+    expect(d.getUTCFullYear()).toBe(2020)
+    expect(d.getUTCMonth()).toBe(0)
+    expect(d.getUTCDate()).toBe(1)
+  })
+  it('accepte jour/mois à 1 chiffre ("lundi, 1/6/2018")', () => {
+    const d = parseReportingDate('lundi, 1/6/2018')!
+    expect(d.getUTCFullYear()).toBe(2018)
+    expect(d.getUTCMonth()).toBe(5)
+    expect(d.getUTCDate()).toBe(1)
+  })
+  it('tolère les espaces parasites ("  samedi , 25/12/2021  ")', () => {
+    const d = parseReportingDate('  samedi , 25/12/2021  ')!
+    expect(d.getUTCFullYear()).toBe(2021)
+    expect(d.getUTCMonth()).toBe(11)
+    expect(d.getUTCDate()).toBe(25)
+  })
+  it('retourne null sur date impossible ("dimanche, 32/13/2026")', () => {
+    expect(parseReportingDate('dimanche, 32/13/2026')).toBeNull()
+  })
+  it('retourne null sur vide/null/undefined', () => {
+    expect(parseReportingDate('')).toBeNull()
+    expect(parseReportingDate(null)).toBeNull()
+    expect(parseReportingDate(undefined)).toBeNull()
+  })
+  it('retourne null sur une chaîne sans date', () => {
+    expect(parseReportingDate('pas une date')).toBeNull()
+  })
+  it('29/02/2023 (non-bissextile) retourne null — cohérence parseFrDate', () => {
+    expect(parseReportingDate('29/02/2023')).toBeNull()
   })
 })
 

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -18,6 +18,15 @@ export function parseFrDate(input: string | null | undefined): Date | null {
   return d
 }
 
+/** "dimanche, 03/05/2026" | "03/05/2026" → Date UTC à minuit (extrait la première
+ *  date dd/MM/yyyy de la chaîne puis délègue à parseFrDate). null si invalide. */
+export function parseReportingDate(input: string | null | undefined): Date | null {
+  if (input == null) return null
+  const m = input.match(/\d{1,2}[/-]\d{1,2}[/-]\d{4}/)
+  if (!m) return null
+  return parseFrDate(m[0])
+}
+
 const FR_MONTHS: Record<string, number> = {
   janvier: 1,
   fevrier: 2,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
 export { formatEUR, formatPct, formatDate, formatDateLong, formatMonth } from './format.ts'
-export { parseFrDate, parseFrMonth, formatRelativeTime } from './dates.ts'
+export { parseFrDate, parseFrMonth, parseReportingDate, formatRelativeTime } from './dates.ts'
 export { toNum, toNumOrNull, toInt } from './numeric.ts'
 export { stripAccents, slugify } from './strings.ts'

--- a/supabase/functions/sync/__tests__/sync.test.ts
+++ b/supabase/functions/sync/__tests__/sync.test.ts
@@ -22,17 +22,19 @@
 //    (seam d'injection), ce qui rend les 5 tests handler RUNNABLES sans stack
 //    Supabase locale ni `functions serve`.
 //
-// Les 5 tests handler couvrent : sync complète (200, 6 feuilles), idempotence
-// (2 syncs → même état), panne partielle (HISTORIQUE throw → snapshot failed,
-// les autres feuilles passent), club introuvable (404), ordre impératif
-// (PARAMETRAGES traité avant Base).
+// Les tests handler couvrent : sync complète (200, 7 feuilles dont REPORTING),
+// idempotence (2 syncs → même état), panne partielle (HISTORIQUE throw → snapshot
+// failed, les autres feuilles passent), club introuvable (404), ordre impératif
+// (PARAMETRAGES traité avant Base), et la feuille OPTIONNELLE REPORTING (DSH-011 :
+// tout échec → warnings[], jamais errors[], success reste true).
 
-import { assert, assertEquals, assertNotEquals } from 'jsr:@std/assert@^1'
+import { assert, assertAlmostEquals, assertEquals, assertNotEquals } from 'jsr:@std/assert@^1'
 
 import {
   parseParametrages,
   parseBase,
   parsePortefeuille,
+  parseReporting,
   parseHistorique,
   parseCotisations,
 } from '../sheetParsers.ts'
@@ -266,6 +268,31 @@ Deno.test(
   }
 )
 
+Deno.test(
+  'parseReporting : seules les lignes datées passent (titre/en-têtes écartés sans warning)',
+  () => {
+    const raw: string[][] = [
+      ['REPORTING — Évolve Capital', '', '', '', ''], // ligne 0 : titre matrice
+      ['Date', 'Valorisation', 'Cotisations', 'Plus-value', 'Performance'], // ligne 1 : en-têtes
+      ['dimanche, 03/05/2026', '697 286,83', '311 301,24', '385 985,59', '2,24'],
+      ['lundi, 04/05/2026', '698 000,00', '311 301,24', '', ''], // D/E vides → null
+      ['', '', '', '', ''], // ligne vide → écartée
+    ]
+    const rows = parseReporting(raw)
+    // Titre + en-têtes + ligne vide écartés ICI (pas de quarantaine côté mapper).
+    assertEquals(rows.length, 2)
+    assertEquals(rows[0].reportDateRaw, 'dimanche, 03/05/2026')
+    // Numériques FR (espace milliers + virgule décimale) normalisés par toNumOrNull.
+    assertEquals(rows[0].portfolioValue, 697286.83)
+    assertEquals(rows[0].totalContributions, 311301.24)
+    assertEquals(rows[0].capitalGain, 385985.59)
+    assertEquals(rows[0].performanceRatio, 2.24)
+    // Cols D/E vides → null (le recalcul est l'affaire du mapper, pas du parser).
+    assertEquals(rows[1].capitalGain, null)
+    assertEquals(rows[1].performanceRatio, null)
+  }
+)
+
 // ===========================================================================
 // 2. CHECKSUM SNAPSHOT (sha256Hex) — déterministe & sensible
 // ===========================================================================
@@ -338,6 +365,14 @@ const SHEETS: Readonly<Record<string, readonly (readonly string[])[]>> = Object.
     ['Nom', 'Symbole', 'Catégorie', 'Parts', 'Devise', 'Cours'],
     ['Apple', 'AAPL', 'Action', '10', 'EUR', '1 234,56'],
     ['TOTAL', '', 'Agrégat', '', '', '5 000,00'],
+  ]),
+  // Série quotidienne REPORTING (DSH-011) : ligne 0 = titre matrice, ligne 1 = en-têtes,
+  // puis lignes datées. La 2e ligne de données a D/E VIDES → recalcul attendu du mapper.
+  REPORTING: Object.freeze([
+    ['REPORTING — Évolve Capital', '', '', '', ''],
+    ['Date', 'Valorisation', 'Cotisations', 'Plus-value', 'Performance'],
+    ['samedi, 02/05/2026', '697 000,00', '311 301,24', '385 698,76', '2,24'],
+    ['dimanche, 03/05/2026', '697 286,83', '311 301,24', '', ''],
   ]),
   // Layout RÉEL : col 0 = n° de ligne, type=1, qté=2, nom=3, ticker=4, typo=5, prix=6, coût=7, date=8, justif=9.
   HISTORIQUE: Object.freeze([
@@ -416,6 +451,7 @@ interface Store {
   transactions: Row[]
   contributions: Row[]
   contribution_months: Row[]
+  club_reporting_daily: Row[]
   sheet_snapshots: Row[]
 }
 
@@ -430,6 +466,8 @@ function emptyStore(seedClub: boolean): Store {
     transactions: [],
     contributions: [],
     contribution_months: [],
+    // Série quotidienne club (REPORTING, DSH-011) — migration 034.
+    club_reporting_daily: [],
     sheet_snapshots: [],
   }
 }
@@ -484,7 +522,14 @@ interface RpcCalls {
   names: string[]
 }
 
-function makeMockClient(store: Store, rpcCalls?: RpcCalls): { client: SupabaseLike } {
+/** Erreur Postgrest injectée sur les upserts d'une table (ex. 42P01 = table absente). */
+type TableErrors = Partial<Record<keyof Store, { code: string; message: string }>>
+
+function makeMockClient(
+  store: Store,
+  rpcCalls?: RpcCalls,
+  tableErrors?: TableErrors
+): { client: SupabaseLike } {
   // Builder par requête : accumule la table, l'opération et les filtres, puis
   // calcule le résultat au moment du `await` (then).
   class QueryBuilder implements PromiseLike<{ data: unknown; error: unknown }> {
@@ -568,7 +613,11 @@ function makeMockClient(store: Store, rpcCalls?: RpcCalls): { client: SupabaseLi
       switch (this.op) {
         case 'select':
           return { data: this.computeSelectData(), error: null }
-        case 'upsert':
+        case 'upsert': {
+          // Erreur injectée (ex. 42P01 « relation does not exist ») : le vrai client
+          // renvoie { error } SANS throw — le store n'est pas muté.
+          const injected = tableErrors?.[this.table]
+          if (injected) return { data: null, error: injected }
           upsertRows(
             table,
             this.withUserIds(this.payload),
@@ -576,6 +625,7 @@ function makeMockClient(store: Store, rpcCalls?: RpcCalls): { client: SupabaseLi
             this.table === 'memberships' ? { role: 'member' } : {}
           )
           return { data: null, error: null }
+        }
         case 'insert':
           for (const row of this.withUserIds(this.payload)) table.push({ ...row })
           return { data: null, error: null }
@@ -702,10 +752,19 @@ function buildHandler(
     overrides?: Record<string, string[][]>
     rpcCalls?: RpcCalls
     emailSends?: EmailSends
+    /** Erreur Postgrest injectée sur les upserts d'une table (cf. TableErrors). */
+    tableErrors?: TableErrors
+    /** Capture les plages A1 demandées par feuille (vérifie A1:E10000 pour REPORTING). */
+    ranges?: Record<string, string | undefined>
   }
 ): (req: Request) => Promise<Response> {
-  const mockReadSheet: SyncDeps['readSheet'] = (_sheetId: string, sheetName: string) => {
+  const mockReadSheet: SyncDeps['readSheet'] = (
+    _sheetId: string,
+    sheetName: string,
+    range?: string
+  ) => {
     opts?.order?.push(sheetName)
+    if (opts?.ranges) opts.ranges[sheetName] = range
     if (opts?.throwOn && sheetName === opts.throwOn) {
       return Promise.reject(new Error(`lecture ${sheetName} indisponible (stub)`))
     }
@@ -713,7 +772,7 @@ function buildHandler(
     if (override) return Promise.resolve(override.map((row) => [...row]))
     return Promise.resolve(cloneSheet(sheetName))
   }
-  const { client } = makeMockClient(store, opts?.rpcCalls)
+  const { client } = makeMockClient(store, opts?.rpcCalls, opts?.tableErrors)
   const sendSyncErrorEmail: SyncDeps['sendSyncErrorEmail'] = (ctx) => {
     opts?.emailSends?.calls.push({
       clubName: ctx.clubName,
@@ -753,10 +812,12 @@ interface SyncResponseBody {
 
 // Étiquettes internes des feuilles (= valeurs de body.synced_sheets et clés de snapshots).
 // L'étiquette « Portefeuille » est conservée même si l'onglet réel lu est « POSITIONS ».
+// REPORTING (optionnelle, DSH-011) s'intercale entre Portefeuille et HISTORIQUE.
 const SHEET_ORDER = [
   'PARAMETRAGES',
   'Base',
   'Portefeuille',
+  'REPORTING',
   'HISTORIQUE',
   'COTISATIONS',
   'Details cotisations',
@@ -767,13 +828,14 @@ const READ_ORDER = [
   'PARAMETRAGES',
   'Base',
   'POSITIONS',
+  'REPORTING',
   'HISTORIQUE',
   'COTISATIONS',
   'Details cotisations',
 ]
 
-// Test 1 — sync complète : 200, success=true, les 6 feuilles synchronisées.
-Deno.test('handler : sync complète → 200, success=true, 6 feuilles synchronisées', async () => {
+// Test 1 — sync complète : 200, success=true, les 7 feuilles synchronisées.
+Deno.test('handler : sync complète → 200, success=true, 7 feuilles synchronisées', async () => {
   const store = emptyStore(true)
   const rpcCalls: RpcCalls = { names: [] }
   const handler = buildHandler(store, { rpcCalls })
@@ -784,15 +846,16 @@ Deno.test('handler : sync complète → 200, success=true, 6 feuilles synchronis
   assertEquals(body.errors.length, 0)
   // Fixtures propres : aucun warning non plus.
   assertEquals(body.warnings.length, 0)
-  assertEquals(body.synced_sheets.length, 6)
+  assertEquals(body.synced_sheets.length, 7)
   assertEquals(body.synced_sheets, SHEET_ORDER)
   // Données effectivement importées dans le store.
   assertEquals(store.users.length, 2)
   assertEquals(store.memberships.length, 2)
   assertEquals(store.positions.length, 1) // AAPL ; la ligne d'agrégat (symbole vide) exclue
   assertEquals(store.transactions.length, 1)
+  assertEquals(store.club_reporting_daily.length, 2) // titre + en-têtes REPORTING écartés
   // Un snapshot par feuille, tous en succès.
-  assertEquals(Object.keys(body.snapshots).length, 6)
+  assertEquals(Object.keys(body.snapshots).length, 7)
   for (const name of SHEET_ORDER) {
     assertEquals(body.snapshots[name].status, 'success')
   }
@@ -821,6 +884,7 @@ Deno.test('handler : idempotence → 2 syncs produisent le même état final', a
     transactions: stripVolatile(structuredClone(store.transactions)),
     contributions: stripVolatile(structuredClone(store.contributions)),
     contribution_months: stripVolatile(structuredClone(store.contribution_months)),
+    club_reporting_daily: stripVolatile(structuredClone(store.club_reporting_daily)),
   })
 
   const res1 = await handler(syncRequest(CLUB_ID))
@@ -837,6 +901,7 @@ Deno.test('handler : idempotence → 2 syncs produisent le même état final', a
   assertEquals(store.memberships.length, 2)
   assertEquals(store.positions.length, 1)
   assertEquals(store.transactions.length, 1) // delete+insert : pas d'accumulation
+  assertEquals(store.club_reporting_daily.length, 2) // onConflict (club_id, report_date)
 })
 
 // Test 3 — erreur DURE : HISTORIQUE.readSheet throw → exception attrapée par runSheet →
@@ -1170,6 +1235,122 @@ Deno.test('handler : agrégats portefeuille persistés + agrégat fantôme désa
   assert(ghost !== undefined)
   assertEquals(ghost.is_active, false)
 })
+
+// ===========================================================================
+// 3quater. REPORTING (DSH-011) — feuille OPTIONNELLE, série quotidienne club
+// ===========================================================================
+// RÈGLE D'OR testée ici : AUCUN scénario REPORTING ne fait success=false ni ne
+// crashe le run — tout échec part dans warnings[], jamais errors[].
+
+// Test R1 — sync complète avec REPORTING OK : lignes en base, D/E recalculés, ordre respecté.
+Deno.test(
+  'handler : REPORTING ok → lignes upsertées, D/E recalculés, plage A1:E10000',
+  async () => {
+    const store = emptyStore(true)
+    const ranges: Record<string, string | undefined> = {}
+    const handler = buildHandler(store, { ranges })
+    const res = await handler(syncRequest(CLUB_ID))
+    assertEquals(res.status, 200)
+    const body = (await res.json()) as SyncResponseBody
+    assertEquals(body.success, true)
+    // REPORTING figure dans synced_sheets APRÈS Portefeuille et AVANT HISTORIQUE.
+    const idxPortefeuille = body.synced_sheets.indexOf('Portefeuille')
+    const idxReporting = body.synced_sheets.indexOf('REPORTING')
+    const idxHistorique = body.synced_sheets.indexOf('HISTORIQUE')
+    assert(idxReporting >= 0)
+    assert(idxPortefeuille < idxReporting, 'REPORTING doit suivre Portefeuille')
+    assert(idxReporting < idxHistorique, 'REPORTING doit précéder HISTORIQUE')
+    // La plage élargie est bien demandée (la série déborderait du défaut A1:AZ2000).
+    assertEquals(ranges['REPORTING'], 'A1:E10000')
+    // Les 2 lignes datées sont en base (titre + en-têtes écartés par le parser).
+    assertEquals(store.club_reporting_daily.length, 2)
+    const d1 = store.club_reporting_daily.find((r) => r.report_date === '2026-05-02')
+    const d2 = store.club_reporting_daily.find((r) => r.report_date === '2026-05-03')
+    assert(d1 !== undefined)
+    assert(d2 !== undefined)
+    assertEquals(d1.club_id, CLUB_ID)
+    // Ligne 1 : D/E fournis par la feuille → conservés tels quels.
+    assertEquals(d1.portfolio_value, 697000)
+    assertEquals(d1.capital_gain, 385698.76)
+    assertEquals(d1.performance_ratio, 2.24)
+    // Ligne 2 : cols D/E VIDES en source → recalculées (D = B−C ; E = B/C, C > 0).
+    assertAlmostEquals(d2.capital_gain as number, 697286.83 - 311301.24, 1e-6)
+    assertAlmostEquals(d2.performance_ratio as number, 697286.83 / 311301.24, 1e-9)
+    // Snapshot REPORTING en succès (fixture propre, aucune quarantaine).
+    assertEquals(body.snapshots['REPORTING'].status, 'success')
+  }
+)
+
+// Test R2 — idempotence : 2 syncs consécutives → mêmes lignes, mêmes valeurs.
+Deno.test('handler : REPORTING idempotent → 2 syncs, mêmes lignes et valeurs', async () => {
+  const store = emptyStore(true)
+  const handler = buildHandler(store)
+  const strip = (rows: Row[]): Row[] =>
+    rows.map((r) => {
+      const { synced_at: _omit, ...rest } = r as Row & { synced_at?: unknown }
+      return rest
+    })
+
+  await handler(syncRequest(CLUB_ID))
+  const first = strip(structuredClone(store.club_reporting_daily))
+  await handler(syncRequest(CLUB_ID))
+  const second = strip(structuredClone(store.club_reporting_daily))
+
+  // Même nombre de lignes (onConflict club_id,report_date) et valeurs identiques.
+  assertEquals(second.length, first.length)
+  assertEquals(second, first)
+})
+
+// Test R3 — readSheet throw UNIQUEMENT pour REPORTING (onglet absent / HTTP 400) :
+// la sync reste un SUCCÈS, warning explicite, les 6 feuilles vitales passent.
+Deno.test('handler : REPORTING illisible → warning MOLLE, success reste true', async () => {
+  const store = emptyStore(true)
+  const handler = buildHandler(store, { throwOn: 'REPORTING' })
+  const res = await handler(syncRequest(CLUB_ID))
+  assertEquals(res.status, 200)
+  const body = (await res.json()) as SyncResponseBody
+  // RÈGLE D'OR : l'échec d'une feuille optionnelle ne fait JAMAIS success=false.
+  assertEquals(body.success, true)
+  assert(!body.errors.some((e) => e.includes('REPORTING')))
+  assert(body.warnings.some((w) => w.includes('REPORTING (optionnelle)')))
+  // Les 6 feuilles vitales sont toutes synchronisées ; REPORTING absente.
+  for (const name of SHEET_ORDER.filter((s) => s !== 'REPORTING')) {
+    assert(body.synced_sheets.includes(name))
+  }
+  assert(!body.synced_sheets.includes('REPORTING'))
+  assertEquals(store.club_reporting_daily.length, 0)
+  // Snapshot d'échec posé pour l'audit (best-effort).
+  assertEquals(body.snapshots['REPORTING'].status, 'failed')
+})
+
+// Test R4 — table club_reporting_daily absente (migration 034 non déployée) : l'upsert
+// renvoie { error: { code: '42P01' } } → warning explicite, pas de crash, success=true.
+Deno.test(
+  'handler : table club_reporting_daily absente (42P01) → warning, pas de crash',
+  async () => {
+    const store = emptyStore(true)
+    const handler = buildHandler(store, {
+      tableErrors: {
+        club_reporting_daily: {
+          code: '42P01',
+          message: 'relation "club_reporting_daily" does not exist',
+        },
+      },
+    })
+    const res = await handler(syncRequest(CLUB_ID))
+    assertEquals(res.status, 200)
+    const body = (await res.json()) as SyncResponseBody
+    assertEquals(body.success, true)
+    assert(!body.errors.some((e) => e.includes('REPORTING')))
+    assert(!body.errors.some((e) => e.includes('club_reporting_daily')))
+    // Warning explicite pointant la migration manquante.
+    assert(body.warnings.some((w) => w.includes('migration 034')))
+    // Rien n'a été écrit (l'erreur injectée ne mute pas le store) ; les autres feuilles passent.
+    assertEquals(store.club_reporting_daily.length, 0)
+    assertEquals(store.positions.length, 1)
+    assertEquals(store.transactions.length, 1)
+  }
+)
 
 // ===========================================================================
 // 4. ALERTE EMAIL TRÉSORIERS (NTF-003) — seuil anti-spam 4h

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -1,8 +1,10 @@
 // Edge Function `sync` — ingestion d'une matrice Google Sheets vers Postgres.
 //
-// Contrat (SHE-006) :
-//   POST { club_id }  →  lit clubs.sheet_id  →  importe 6 feuilles dans l'ORDRE IMPÉRATIF
-//   PARAMETRAGES → Base → Portefeuille → HISTORIQUE → COTISATIONS → Details cotisations.
+// Contrat (SHE-006, étendu DSH-011) :
+//   POST { club_id }  →  lit clubs.sheet_id  →  importe 7 feuilles dans l'ORDRE IMPÉRATIF
+//   PARAMETRAGES → Base → Portefeuille → REPORTING → HISTORIQUE → COTISATIONS → Details cotisations.
+//   REPORTING est OPTIONNELLE (enrichissante) : son échec ne produit que des warnings,
+//   jamais d'erreur dure (success reste true). Les 6 autres feuilles sont bloquantes.
 //   Chaque feuille : readSheet → parse → map → upsert → snapshot. Aucun parallélisme.
 //   Tolérance aux pannes partielles : une feuille en échec n'interrompt pas les suivantes.
 //   Idempotence : upserts onConflict (sauf transactions : delete+insert, cf. plus bas).
@@ -25,6 +27,7 @@ import {
   parseParametrages,
   parseBase,
   parsePortefeuille,
+  parseReporting,
   parseHistorique,
   parseCotisations,
 } from './sheetParsers.ts'
@@ -41,6 +44,7 @@ import {
   mapPortefeuilleRows,
   mapAggregateRows,
 } from '../../../packages/data/src/sheets/mappers/portefeuille.mapper.ts'
+import { mapReportingRows } from '../../../packages/data/src/sheets/mappers/reporting.mapper.ts'
 import { mapHistoriqueRows } from '../../../packages/data/src/sheets/mappers/historique.mapper.ts'
 import { mapCotisationsRows } from '../../../packages/data/src/sheets/mappers/cotisations.mapper.ts'
 import { mapDetailsCotisationsRows } from '../../../packages/data/src/sheets/mappers/detailsCotisations.mapper.ts'
@@ -205,6 +209,44 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
           )
         } catch {
           // ignore : l'échec de snapshot ne doit pas masquer l'erreur d'origine.
+        }
+      }
+    }
+
+    /**
+     * Exécute une feuille OPTIONNELLE (enrichissante) — même structure que runSheet,
+     * mais TOUTE exception devient un warning MOLLE, JAMAIS une entrée errors[].
+     * DISTINCTION : une feuille BLOQUANTE (runSheet) porte des données vitales — son
+     * échec doit faire success=false et déclencher les alertes (Sentry, email trésoriers).
+     * Une feuille ENRICHISSANTE (ex. REPORTING, série historique du dashboard) ne doit
+     * ni faire échouer le run ni alerter : onglet absent, plage illisible ou table non
+     * migrée → la sync des 6 feuilles vitales reste un succès. Snapshot 'failed'
+     * best-effort pour l'audit, puis on continue.
+     */
+    async function runOptionalSheet(
+      sheetName: string,
+      handler: () => Promise<void>
+    ): Promise<void> {
+      try {
+        await handler()
+        syncedSheets.push(sheetName)
+      } catch (e) {
+        const message = errMsg(e)
+        // MOLLE uniquement : jamais errors[] pour une feuille optionnelle.
+        warnings.push(`${sheetName} (optionnelle): ${message}`)
+        // Snapshot d'échec (best-effort — on n'aggrave pas une panne par une 2e exception).
+        try {
+          snapshots[sheetName] = await createSnapshot(
+            supabase,
+            clubId,
+            sheetName,
+            { error: message },
+            0,
+            'failed',
+            message
+          )
+        } catch {
+          // ignore : l'échec de snapshot ne doit pas masquer l'anomalie d'origine.
         }
       }
     }
@@ -498,6 +540,139 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
         status,
         note
       )
+    })
+
+    // 3bis) REPORTING → club_reporting_daily (feuille OPTIONNELLE/enrichissante, DSH-011)
+    // Série quotidienne (~2 900+ lignes depuis 2018) pour le graphe d'évolution du
+    // dashboard. RÈGLE D'OR : aucun scénario REPORTING ne fait success=false ni ne
+    // crashe le run — tout échec part dans warnings[] (cf. runOptionalSheet).
+    await runOptionalSheet('REPORTING', async () => {
+      // Plage explicite A1:E10000 : la série dépasse le défaut A1:AZ2000 de readSheet
+      // (qui la tronquerait silencieusement) ; seules les colonnes A–E sont utiles.
+      const raw = await deps.readSheet(sheetId, 'REPORTING', 'A1:E10000')
+      const rows = parseReporting(raw)
+      // Un SEUL horodatage pour tout le run REPORTING (cohérence des ~2 900 lignes).
+      const synced_at = new Date().toISOString()
+      const { upserts, skipped } = mapReportingRows(rows, clubId, synced_at)
+
+      // Feuille vide / aucune ligne exploitable : warning MOLLE + snapshot 'partial',
+      // return SANS exception (une absence de données n'est pas un échec de feuille).
+      if (upserts.length === 0) {
+        const emptyNote = 'feuille REPORTING vide ou sans lignes exploitables'
+        warnings.push(`REPORTING (optionnelle): ${emptyNote}`)
+        try {
+          snapshots['REPORTING'] = await createSnapshot(
+            supabase,
+            clubId,
+            'REPORTING',
+            raw,
+            raw.length,
+            'partial',
+            emptyNote
+          )
+        } catch {
+          // best-effort : un snapshot raté n'aggrave pas le cas.
+        }
+        return
+      }
+
+      // Upsert par paquets de 500 (la série complète serait un POST trop volumineux).
+      // Idempotence : onConflict (club_id, report_date) — cf. migration 034.
+      const BATCH_SIZE = 500
+      let upsertedCount = 0
+      for (let i = 0; i < upserts.length; i += BATCH_SIZE) {
+        const batch = upserts.slice(i, i + BATCH_SIZE)
+        const { error } = await supabase
+          .from('club_reporting_daily')
+          .upsert(batch, { onConflict: 'club_id,report_date' })
+        if (error) {
+          if (error.code === '42P01') {
+            // Table absente (migration 034 non déployée sur cet environnement) :
+            // inutile d'insister sur les paquets restants — warning explicite,
+            // snapshot 'failed' best-effort, return PROPRE (jamais de throw).
+            const missingNote =
+              'table club_reporting_daily absente (migration 034 non déployée) — import ignoré'
+            warnings.push(`REPORTING (optionnelle): ${missingNote}`)
+            try {
+              snapshots['REPORTING'] = await createSnapshot(
+                supabase,
+                clubId,
+                'REPORTING',
+                raw,
+                raw.length,
+                'failed',
+                missingNote
+              )
+            } catch {
+              // best-effort.
+            }
+            return
+          }
+          // Autre erreur : ce paquet est perdu mais les précédents restent acquis
+          // (idempotence : la prochaine sync les re-tentera). On continue.
+          warnings.push(
+            `REPORTING (optionnelle): échec upsert paquet ${Math.floor(i / BATCH_SIZE) + 1}: ${error.message}`
+          )
+          continue
+        }
+        upsertedCount += batch.length
+      }
+
+      // MOLLE : lignes en quarantaine (date illisible, B/C manquant ou négatif) →
+      // warnings[] (pattern Portefeuille). Raisons tronquées aux 10 premières pour ne
+      // pas générer un warning pathologique sur une feuille massivement malformée.
+      const MAX_SKIPPED_SHOWN = 10
+      const skippedNote =
+        skipped.length > 0
+          ? `${skipped.length} ligne(s) en quarantaine: ${skipped
+              .slice(0, MAX_SKIPPED_SHOWN)
+              .join(' | ')}${skipped.length > MAX_SKIPPED_SHOWN ? ' | …' : ''}`
+          : null
+      const status: SnapshotStatus = skippedNote ? 'partial' : 'success'
+      if (skippedNote) warnings.push(`REPORTING (lignes ignorées): ${skippedNote}`)
+      // Snapshot best-effort (try/catch) : contrairement aux feuilles bloquantes, un
+      // échec de snapshot ne doit pas requalifier la feuille optionnelle en échec.
+      try {
+        snapshots['REPORTING'] = await createSnapshot(
+          supabase,
+          clubId,
+          'REPORTING',
+          raw,
+          raw.length,
+          status,
+          skippedNote
+        )
+      } catch {
+        // best-effort.
+      }
+
+      // SANITY CHECK (warning MOLLE, jamais bloquant) : la valorisation la plus récente
+      // de REPORTING doit rester proche de l'agrégat « Portefeuille » importé à l'étape 3
+      // (même matrice, deux feuilles — un écart > 1 % signale une feuille désynchronisée).
+      try {
+        if (upsertedCount > 0) {
+          const latest = upserts.reduce((a, b) => (a.report_date > b.report_date ? a : b))
+          const { data: agg } = await supabase
+            .from('portfolio_aggregates')
+            .select('market_value')
+            .eq('club_id', clubId)
+            .eq('label', 'Portefeuille')
+            .eq('is_active', true)
+            .maybeSingle()
+          const aggValue = (agg as { market_value: number | null } | null)?.market_value
+          if (aggValue != null && aggValue > 0) {
+            const drift = Math.abs(latest.portfolio_value - aggValue) / aggValue
+            if (drift > 0.01) {
+              warnings.push(
+                `REPORTING: écart de ${(drift * 100).toFixed(1)} % entre la dernière valorisation ` +
+                  `REPORTING (${latest.portfolio_value}) et l'agrégat Portefeuille (${aggValue}).`
+              )
+            }
+          }
+        }
+      } catch {
+        // Sanity check best-effort : jamais bloquant.
+      }
     })
 
     // 4) HISTORIQUE → transactions

--- a/supabase/functions/sync/readSheet.ts
+++ b/supabase/functions/sync/readSheet.ts
@@ -119,19 +119,29 @@ async function fetchAccessToken(jwt: string): Promise<string> {
 }
 
 /**
- * Lit une plage A1:AZ2000 d'une feuille et renvoie une matrice string[][].
+ * Lit une plage d'une feuille et renvoie une matrice string[][].
+ * `range` est optionnel et vaut 'A1:AZ2000' par défaut — INCHANGÉ pour les 6 feuilles
+ * historiques. Raison du paramètre : la feuille REPORTING (série quotidienne, ~2 900+
+ * lignes depuis 2018) DÉPASSE cette plage par défaut, qui tronquerait silencieusement
+ * la série — elle est donc lue avec une plage explicite plus large ('A1:E10000').
  * Chaque cellule est coercée en string (null/absente → '') pour coller au contrat
  * des parsers/mappers (qui attendent tous des string).
  */
-export async function readSheet(sheetId: string, sheetName: string): Promise<string[][]> {
+export async function readSheet(
+  sheetId: string,
+  sheetName: string,
+  range = 'A1:AZ2000'
+): Promise<string[][]> {
   const sa = loadServiceAccount()
   const jwt = await buildSignedJwt(sa)
   const token = await fetchAccessToken(jwt)
 
-  const range = `${encodeURIComponent(sheetName)}!A1:AZ2000`
+  // Le nom d'onglet est encodé (espaces, accents) ; la notation A1 reste brute
+  // (`!`, `:` sont légaux en path segment — URL byte-identique à l'historique).
+  const encodedRange = `${encodeURIComponent(sheetName)}!${range}`
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(
     sheetId
-  )}/values/${range}`
+  )}/values/${encodedRange}`
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } })
   if (!res.ok) {
     throw new Error(

--- a/supabase/functions/sync/sheetParsers.ts
+++ b/supabase/functions/sync/sheetParsers.ts
@@ -11,6 +11,7 @@ import type {
   PortefeuilleRowDTO,
   HistoriqueRowDTO,
   CotisationsRowDTO,
+  ReportingRowDTO,
 } from '../../../packages/data/src/types/sheets.ts'
 
 /** Cellule à l'index `i` → string trimée, ou '' si hors limites. */
@@ -185,4 +186,28 @@ export function parseCotisations(rows: string[][]): CotisationsRowDTO[] {
     status: cellOrNull(row, 7), // Statut (≠ col 6 "Nb normal")
     amountDue: toNumOrNull(cell(row, 8)), // Montant dû
   }))
+}
+
+/** Motif date jj/mm/aaaa (ou j-m-aaaa) — discrimine les lignes de données REPORTING. */
+const REPORTING_DATE_PATTERN = /\d{1,2}[/-]\d{1,2}[/-]\d{4}/
+
+/**
+ * REPORTING → ReportingRowDTO[] (série quotidienne club, DSH-011).
+ * Layout RÉEL : ligne 0 = titre de la matrice, ligne 1 = en-têtes, puis ~2 900+
+ * lignes quotidiennes depuis 2018. Plutôt que de sauter 2 lignes « en dur »
+ * (fragile si la mise en page bouge), on ne garde que les lignes dont la col A
+ * contient un motif de date jj/mm/aaaa : titres/en-têtes/lignes vides sont écartés
+ * ICI et ne génèrent donc JAMAIS de warnings de quarantaine côté mapper.
+ * Aucune logique métier (recalculs D/E, doublons) : projection pure colonne → champ.
+ */
+export function parseReporting(rows: string[][]): ReportingRowDTO[] {
+  return rows
+    .filter((row) => REPORTING_DATE_PATTERN.test(cell(row, 0)))
+    .map((row) => ({
+      reportDateRaw: cellOrNull(row, 0), // A Date avec jour de semaine («dimanche, 03/05/2026»)
+      portfolioValue: toNumOrNull(cell(row, 1)), // B Valorisation portefeuille
+      totalContributions: toNumOrNull(cell(row, 2)), // C Cotisations cumulées
+      capitalGain: toNumOrNull(cell(row, 3)), // D Plus-value (= B−C, parfois vide)
+      performanceRatio: toNumOrNull(cell(row, 4)), // E Performance (ratio B/C, parfois vide)
+    }))
 }

--- a/supabase/functions/sync/syncErrorAlert.ts
+++ b/supabase/functions/sync/syncErrorAlert.ts
@@ -26,11 +26,15 @@ export const ALERT_THROTTLE_MS = 4 * 60 * 60 * 1000
 /** Rôles habilités à recevoir l'alerte (staff du club). */
 const TREASURER_ROLES = ['treasurer', 'president', 'network_admin'] as const
 
-/** Noms de feuilles dont runSheet préfixe le message d'erreur (« <Feuille>: … »). */
+/** Noms de feuilles dont runSheet préfixe le message d'erreur (« <Feuille>: … »).
+ *  NB : REPORTING (optionnelle, DSH-011) ne produit QUE des warnings — jamais
+ *  d'entrée errors[] — donc jamais d'email d'alerte ; le préfixe n'est là que par
+ *  cohérence de nettoyage si un message REPORTING transite un jour par ici. */
 const SHEET_PREFIXES = [
   'PARAMETRAGES',
   'Base',
   'Portefeuille',
+  'REPORTING',
   'HISTORIQUE',
   'COTISATIONS',
   'Details cotisations',

--- a/supabase/migrations/034_club_reporting_daily.sql
+++ b/supabase/migrations/034_club_reporting_daily.sql
@@ -1,0 +1,39 @@
+-- 034_club_reporting_daily.sql — Série quotidienne club (DSH-011).
+--
+-- Série quotidienne club — source : feuille REPORTING (cols A–E de la matrice Google Sheets).
+-- Alimentation : Edge Function sync (service role, bypass RLS). Lecture : membres du club (RLS).
+-- Append-only / upsert par (club_id, report_date) : PAS de soft-delete par synced_at
+-- (contrairement à positions) — une ligne absente de la feuille n'est jamais supprimée
+-- automatiquement en V0 (évite un effacement accidentel si la plage lue est tronquée).
+-- Purge manuelle trésorier = V1+. Réf : docs/tickets/PROMPT-DEV-DSH-011-REPORTING-SYNC.md §3.
+
+CREATE TABLE IF NOT EXISTS club_reporting_daily (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id               UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+  report_date           DATE NOT NULL,
+  portfolio_value       NUMERIC(18,2) NOT NULL,   -- col B
+  total_contributions   NUMERIC(18,2) NOT NULL,   -- col C
+  capital_gain          NUMERIC(18,2),            -- col D (nullable, recalculé B−C si absent)
+  performance_ratio     NUMERIC(12,6),            -- col E (= B/C si C>0, recalculé si absent)
+  synced_at             TIMESTAMPTZ NOT NULL,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (club_id, report_date)
+);
+
+-- Index de lecture dashboard : « les N derniers points du club » (ORDER BY report_date DESC).
+CREATE INDEX club_reporting_daily_club_date_idx
+  ON club_reporting_daily (club_id, report_date DESC);
+
+-- ============================================================
+-- RLS — lecture membre du club (helper get_user_club_ids(), migration 010) ;
+-- écriture service role uniquement (aucune policy write). Cohérent avec
+-- positions (011) et portfolio_aggregates (029).
+-- ============================================================
+ALTER TABLE club_reporting_daily ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "club_reporting_daily: club member read"
+  ON club_reporting_daily FOR SELECT
+  USING (club_id IN (SELECT get_user_club_ids()));
+
+-- Écriture : service role uniquement (sync) — AUCUNE policy INSERT/UPDATE/DELETE authenticated.


### PR DESCRIPTION
> **👋 Tu es l'agent Dashboard V2 (graphe « Évolution », A/B, données demo) ?**
> Cette PR livre le **pipeline data réel** que ton graphe doit consommer. Lis la section « 🔌 Guide d'intégration » ci-dessous : elle contient le contrat exact, le snippet de branchement et les pièges. Ton chantier est le ticket suiveur **DSH-012** ; cette PR est **DSH-011**.

## Résumé

Pipeline data **feuille Google Sheets `REPORTING`** (série quotidienne club : valorisation, cotisations cumulées, plus-value, ratio) **→ table Postgres `club_reporting_daily`** (migration 034, RLS) **→ couche lecture serveur `getDashboardChartData()`** (`apps/web/lib/data/dashboard-chart.ts`). Périmètre strict data : **aucun fichier UI touché** — le graphe V2 reste en demo tant que DSH-012 ne l'a pas branché.

---

## 🔌 Guide d'intégration pour le graphe V2 (= DSH-012)

### Ce qui existe désormais (cette PR)

- **`apps/web/lib/data/dashboard-chart.ts`** — module serveur **séparé de `getDashboardData()`** (volontairement : zéro conflit avec ta branche). Contrat **stable**, ne pas le modifier :

```ts
export type DashboardChartPeriod = '7d' | '30d' | '90d' | '1y' | 'max'

export interface DashboardChartPoint {
  date: string   // ISO YYYY-MM-DD, UTC midnight
  value: number  // quote-part membre dérivée (EUR) — DÉJÀ multipliée par detention_pct
}

export interface DashboardChartVariation {
  amount: number  // delta EUR sur la période
  percent: number // FRACTION (0.0455 = +4,55 %) → directement compatible formatPct / TrendBadge
}

export interface DashboardChartData {
  source: 'live'
  series: DashboardChartPoint[]   // série COMPLÈTE triée ASC — le client filtre par période
  variations: {
    d1: DashboardChartVariation | null   // dernier vs ~J-1
    d30: DashboardChartVariation | null  // dernier vs point le plus proche de J-30
    max: DashboardChartVariation | null  // dernier vs premier
  }
  meta: { clubId: string; pointCount: number; firstDate: string | null; lastDate: string | null; detentionPctUsed: number; joinedAtCutoff: string | null } // debug/QA — ne PAS exposer à GA4
}

/** Retourne NULL si aucune ligne REPORTING en base → ton graphe reste en mode demo. */
export async function getDashboardChartData(
  supabase: ServerClient,
  userId: string,
  clubId: string,
  opts: { detentionPct: number; joinedAt: string | null }
): Promise<DashboardChartData | null>
```

### Comment brancher (dans `apps/web/app/(app)/dashboard/page.tsx` — fichier réservé à TOI)

```ts
import { getDashboardChartData } from '@/lib/data/dashboard-chart'

const chartLive = await getDashboardChartData(supabase, userId, clubId, {
  detentionPct: initialData.detentionPct,        // fraction 0..1 issue de getDashboardData
  joinedAt: initialData.member.joinedAt,
})
const chart = chartLive ?? mergeDemoChart(initialData) // ton module demo existant
const chartDataSource = chartLive ? 'live' : 'demo'    // remplace chart_data_source: 'demo'
```

Puis côté toi : passer `chart` à `DashboardViewV2`, alimenter le `TrendBadge` hero depuis `variations.d1`, et filtrer `series` **côté client** selon le toggle 7J/30J/90J/1A/MAX (la série arrive complète, ASC).

### Garanties que tu peux exploiter sans re-vérifier

- **Jamais de NaN/Infinity** : points non finis écartés, `percent` calculé seulement si `start > 0`, sinon la variation entière est `null` → pas de TrendBadge.
- **`null` global = pas de data** (table vide, ou série vide après cutoff `joinedAt`) → garde ta demo, **aucun crash possible** : la sync importe REPORTING en feuille *optionnelle* (échec → simple warning, l'app vit très bien sans).
- **`value` est déjà la quote-part membre** (`portfolio_value × detention_pct` actuel, approximation V0 documentée) — pas de re-multiplication côté UI. Formatage via `formatEUR`/`formatPct` de `@evolve/utils` comme d'habitude.
- La période MAX est déjà bornée à `joined_at` du membre (cutoff appliqué côté serveur, visible dans `meta.joinedAtCutoff`).
- RLS : la lecture passe par le client serveur session (`createServerClient`) — un membre ne voit que les lignes de ses clubs. Pas de service-role côté web.

### Avoir de la data live en local (pour tes tests/e2e)

```bash
make db-migrate   # applique la migration 034 si pas déjà fait (ou make db-reset)
supabase functions serve --env-file supabase/functions/.env   # terminal séparé
make db-sync      # importe la vraie matrice → ~1 066 lignes dans club_reporting_daily
```
Vérifié en réel : 2 syncs consécutives → données strictement identiques (idempotent). Sans sync (table vide), `getDashboardChartData` → `null` → ta demo s'affiche : les deux chemins sont testables.
Alternative e2e sans Google : `INSERT INTO club_reporting_daily (club_id, report_date, portfolio_value, total_contributions, synced_at) VALUES (...)` en seed local.

### Pièges connus

- **La feuille REPORTING peut être en retard** sur POSITIONS (constaté en réel : dernier point au 2026-04-17). Ne suppose jamais `meta.lastDate = aujourd'hui`.
- `types.gen.ts` contient désormais `club_reporting_daily` : si ta branche a divergé dessus, **rebase sur `main` après merge de cette PR** puis `make db-types`.
- `variations.percent` est une **fraction**, pas un pourcentage (0.0455, pas 4.55).

### Partage des responsabilités (rappel)

| Zone | Cette PR (DSH-011) | Toi (V2 / DSH-012) |
|---|:---:|:---:|
| Migration + sync REPORTING + couche `dashboard-chart.ts` | ✅ | ❌ ne pas modifier |
| `getDashboardData()` existant | ❌ intouché (diff vide) | gel (sauf analytics mineur) |
| `page.tsx`, `DashboardViewV2`, `dashboard-chart-demo.ts`, `PLAN-DE-TAGGAGE.md` | ❌ volontairement intouchés | ✅ à toi |
| `chart_data_source: 'demo'` → `'live'`, TrendBadge hero, toggles période | ❌ | ✅ |
| Test e2e « seed REPORTING → graphe sans label demo » | ❌ | ✅ |

---

## Contexte

Pas une étape du MIGRATION_PLAN.md — ticket **DSH-011** (`docs/tickets/PROMPT-DEV-DSH-011-REPORTING-SYNC.md`, commité dans cette branche).

## Changements

- **Migration 034** : table `club_reporting_daily` (clé `(club_id, report_date)`, index DESC, RLS lecture membre via `get_user_club_ids()`, écriture service-role uniquement, append-only sans soft-delete).
- **Sync Edge Function** : `REPORTING` importée en **7ᵉ feuille OPTIONNELLE** (entre Portefeuille et HISTORIQUE) via le nouveau `runOptionalSheet` — tout échec (onglet absent, table non migrée `42P01`, feuille vide) → **warning MOLLE, jamais `success: false`**. Batchs de 500, snapshot audit, sanity check vs agrégat Portefeuille (écart > 1 % → warning).
- **`readSheet`** : paramètre de plage optionnel (défaut `A1:AZ2000` inchangé) ; REPORTING lue en `A1:E10000` (~2 900+ lignes, la plage par défaut tronquerait la série).
- **`@evolve/utils`** : `parseReportingDate` (« dimanche, 03/05/2026 » → Date UTC), délègue à `parseFrDate`.
- **`@evolve/data`** : `ReportingRowDTO` + `ClubReportingDailyUpsert` + `mapReportingRows` (quarantaine MOLLE, recalcul `D = B−C`, `E = B/C` si C>0, doublons dernière-gagne).
- **`apps/web/lib/data/dashboard-chart.ts`** : cf. guide d'intégration ci-dessus (pagination PostgREST incluse — plafond 1 000 lignes par requête).
- **Doc** : `REC/DATA_MODEL.md` §2.10 (dépôt voisin) + arbitrages dans `docs/audits/design-reference-map.md`.

## Test plan

- [x] `pnpm install` sans erreur
- [x] Gate `make lint typecheck test` vert **×2** (baseline avant travaux + passe QA finale — ui 391, web 237 dont 26 nouveaux)
- [x] Tests ticket : mapper REPORTING **10/10** (Vitest), `dashboard-chart` **26/26** (Vitest), sync Deno **34/34** dont 4 scénarios de résilience (ordre, idempotence, onglet absent → warning, table absente 42P01 → pas de crash)
- [x] **Runtime réel** : 2 syncs consécutives sur la vraie matrice → 1 066 lignes (2023-05-17 → 2026-04-17), checksums md5 **identiques** (idempotence), zéro D/E null, sanity check déclenché en réel (écart 1,7 % détecté → warning MOLLE)
- [x] E2E `--workers=1` : dashboard **7/7**, cursor-pointer **13/13**, pwa-install-banner **8/8**, navigation 3 onglets sans NaN/undefined ; a11y 4/5 (l'échec `/portfolio` est **préexistant** : seed sans positions, spec byte-identique à `main` ; scan axe compensatoire = 0 violation)
- [x] App **100 % fonctionnelle avec `club_reporting_daily` vide** (post `db-reset`, migrations 001→034)
- [x] Vitrine non touchée (aucun fichier `apps/vitrine/`)

## Checklist

- [x] Commits en Conventional Commits format (8 commits atomiques FR)
- [x] Aucun fichier .env commité
- [x] Prettier + ESLint OK (husky lint-staged sur chaque commit)
- [x] Pas de breaking change API publique (signature `readSheet` étendue par paramètre optionnel, défaut inchangé)

## ⚠️ Risk

| Level | File |
|-------|------|
| High | `supabase/migrations/034_club_reporting_daily.sql` (nouvelle table + RLS — additive, aucune table existante modifiée) |

**Notes déploiement (owner)** : appliquer la migration 034 sur le projet Supabase prod + redéployer l'Edge Function `sync` (`deploy --use-api`). Tant que ce n'est pas fait, la sync prod continue de fonctionner (warning MOLLE « table absente », `success: true` — testé).

**Suivi** : DSH-012 (= le branchement décrit dans le guide ci-dessus) ; dette fixture e2e : seeder ≥ 1 position pour `a11y.spec.ts` `/portfolio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
