### PR TITLE
fix: cotisations sur une ligne + photo profil + redirect Safari PWA

### DIFF
--- a/apps/web/app/(app)/profil/InstallSection.tsx
+++ b/apps/web/app/(app)/profil/InstallSection.tsx
@@ -15,6 +15,39 @@ const IosInstallInstructions = dynamic(
   { ssr: false }
 )
 
+const HANDOFF_ENDPOINT = '/api/auth/handoff-link'
+
+/**
+ * Ouvre le lien de connexion directement dans Safari via le scheme x-safari-https://.
+ * Sur iOS, cette redirection force l'ouverture du lien dans Safari (peu importe le navigateur courant),
+ * ce qui permet à l'utilisateur d'être connecté automatiquement et d'installer la PWA depuis Safari.
+ * Fallback sur la copie dans le presse-papier si la redirection échoue.
+ */
+async function openHandoffInSafari(): Promise<'redirected' | 'copied' | 'failed'> {
+  try {
+    const r = await fetch(HANDOFF_ENDPOINT, { method: 'POST' })
+    if (!r.ok) return 'failed'
+    const { url } = (await r.json()) as { url: string }
+    // x-safari-https:// force Safari à s'ouvrir sur iOS (Chrome, Firefox, etc.).
+    const safariUrl = url.replace(/^https:\/\//, 'x-safari-https://')
+    window.location.href = safariUrl
+    return 'redirected'
+  } catch {
+    // Dernier recours : copie dans le presse-papier (ancien comportement).
+    try {
+      const r = await fetch(HANDOFF_ENDPOINT, { method: 'POST' })
+      if (r.ok) {
+        const { url } = (await r.json()) as { url: string }
+        await navigator.clipboard.writeText(url)
+        return 'copied'
+      }
+    } catch {
+      /* noop */
+    }
+    return 'failed'
+  }
+}
+
 /**
  * Section « Installer l'app sur ton téléphone » de /profil (PWA-001). Entrée permanente
  * pour (ré)installer à la demande — utile notamment après 3 refus (migration permanente de
@@ -29,7 +62,6 @@ export function InstallSection() {
     promptInstall,
     openInstructionModal,
     closeInstructionModal,
-    copyHandoffLink,
   } = usePwaActions()
 
   // SSR-safe : pwaCase = 'unsupported' au render serveur + hydratation → promptable false → null.
@@ -47,20 +79,16 @@ export function InstallSection() {
       openInstructionModal()
       return
     }
-    // ios-other : lien de connexion portable (auto-login en Safari), fallback URL courante.
-    const { ok, usedHandoff } = await copyHandoffLink()
-    if (ok) {
+    // ios-other (Chrome, Firefox iOS…) : ouvre Safari directement avec le lien de handoff.
+    // L'utilisateur atterrit sur Safari connecté et peut installer la PWA depuis l'écran d'accueil.
+    const outcome = await openHandoffInSafari()
+    if (outcome === 'redirected') {
+      analyticsEvents.pwa.ctaClicked('ios-other')
+    } else if (outcome === 'copied') {
       analyticsEvents.pwa.clipboardCopied()
-      if (usedHandoff) {
-        toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
-      } else {
-        toast.success({
-          title: t('toastCopiedPlain.title'),
-          message: t('toastCopiedPlain.message'),
-        })
-      }
+      toast.success({ title: t('toastCopied.title'), message: t('toastCopied.message') })
     }
-  }, [pwaCase, promptInstall, openInstructionModal, copyHandoffLink, toast, t])
+  }, [pwaCase, promptInstall, openInstructionModal, toast, t])
 
   if (!promptable) return null
 
@@ -86,7 +114,7 @@ export function InstallSection() {
       <button
         type="button"
         onClick={() => void handleClick()}
-        className="mt-4 inline-flex h-12 items-center justify-center rounded-[var(--r-md)] bg-accent px-6 font-body text-[16px] font-semibold text-accent-ink transition-opacity hover:opacity-90"
+        className="mt-4 inline-flex h-12 items-center justify-center rounded-(--r-md) bg-accent px-6 font-body text-[16px] font-semibold text-accent-ink transition-opacity hover:opacity-90"
       >
         {pwaCase === 'ios-other' ? t('iosOther.cta') : t('profileSection.button')}
       </button>

--- a/apps/web/app/(app)/profil/ProfileAvatarUpload.tsx
+++ b/apps/web/app/(app)/profil/ProfileAvatarUpload.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
+
+import { AvatarUpload, useToast } from '@evolve/ui'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
+import { resizeAndUploadAvatar } from '@/lib/upload/avatar'
+
+/**
+ * Wrapper client autour de AvatarUpload pour la page /profil.
+ * Upload dans le bucket `avatars`, puis MAJ de `users.avatar_url` (RLS self-update).
+ */
+export function ProfileAvatarUpload({
+  initialUrl,
+  name,
+}: {
+  initialUrl: string | null
+  name: string
+}) {
+  const t = useTranslations('profile')
+  const toast = useToast()
+  const supabase = useSupabase()
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(initialUrl)
+  const [isUploading, setIsUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | undefined>()
+  const localPreviewRef = useRef<string | null>(null)
+
+  async function handleFileSelected(file: File) {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return
+
+    // Aperçu optimiste local avant l'upload.
+    if (localPreviewRef.current) URL.revokeObjectURL(localPreviewRef.current)
+    const localUrl = URL.createObjectURL(file)
+    localPreviewRef.current = localUrl
+    setPreviewUrl(localUrl)
+
+    setIsUploading(true)
+    setUploadError(undefined)
+    try {
+      const url = await resizeAndUploadAvatar(supabase, user.id, file)
+      // MAJ directe via RLS « users: self update » (auth.uid() = user.id).
+      const { error } = await supabase.from('users').update({ avatar_url: url }).eq('id', user.id)
+      if (error) throw new Error(t('avatarError'))
+      setPreviewUrl(url)
+      toast.success({ title: t('avatarUpdated') })
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : t('avatarError'))
+      setPreviewUrl(initialUrl)
+    } finally {
+      if (localPreviewRef.current) {
+        URL.revokeObjectURL(localPreviewRef.current)
+        localPreviewRef.current = null
+      }
+      setIsUploading(false)
+    }
+  }
+
+  return (
+    <AvatarUpload
+      previewUrl={previewUrl}
+      onFileSelected={handleFileSelected}
+      isUploading={isUploading}
+      error={uploadError}
+      uploadAriaLabel={t('avatarUploadAria', { name })}
+      emptyLabel={t('avatarEmpty')}
+      uploadingLabel={t('avatarUploading')}
+      uploadingAriaLabel={t('avatarUploadingAria')}
+    />
+  )
+}

--- a/apps/web/app/(app)/profil/ProfileView.tsx
+++ b/apps/web/app/(app)/profil/ProfileView.tsx
@@ -1,8 +1,9 @@
 import { getTranslations } from 'next-intl/server'
-import { Avatar, Badge, Heading } from '@evolve/ui'
+import { Badge, Heading } from '@evolve/ui'
 import { formatDate } from '@evolve/utils'
 import type { MemberRole, ProfileData } from '@/lib/data/profile'
 import { InstallSection } from './InstallSection'
+import { ProfileAvatarUpload } from './ProfileAvatarUpload'
 
 const DASH = '—'
 
@@ -42,7 +43,8 @@ export async function ProfileView({ data }: { data: ProfileData }) {
 
       <section className="rounded-lg border border-border bg-card p-6 shadow-card">
         <div className="flex items-center gap-4">
-          <Avatar name={displayName} src={data.avatarUrl ?? undefined} size="lg" />
+          {/* Avatar cliquable — ouvre le sélecteur de fichier (ProfileAvatarUpload est client). */}
+          <ProfileAvatarUpload initialUrl={data.avatarUrl} name={displayName} />
           <div className="flex min-w-0 flex-col gap-1.5">
             <p className="truncate font-display text-[18px] font-bold text-text">{displayName}</p>
             {roleLabel && data.role ? (
@@ -66,7 +68,7 @@ export async function ProfileView({ data }: { data: ProfileData }) {
         </dl>
       </section>
 
-      <p className="font-body text-[13px] text-text-ter">{t('editHint')}</p>
+      <p className="font-body text-[13px] text-text-ter">{t('avatarHint')}</p>
 
       {/* PWA-001 : (ré)installer l'app à la demande (entrée permanente, surtout utile après
           3 refus de la bannière). Masquée si déjà installée (standalone) ou sur desktop. */}

--- a/apps/web/components/chrome/AppChrome.tsx
+++ b/apps/web/components/chrome/AppChrome.tsx
@@ -25,8 +25,9 @@ import { useSupabase } from '@/components/providers/SupabaseProvider'
 import { LocaleSwitcherClient } from '@/components/i18n/LocaleSwitcherClient'
 import { clearPwaDataCaches } from '@/lib/pwa/register-sw'
 
-/** Logo de marque servi par l'app (apps/web/public/logo.jpg). */
-const LOGO_SRC = '/logo.jpg'
+// icon-192.png : icône PWA générée (fond crème #F4F4F2, artwork centré).
+// Remplace logo.jpg (fond noir opaque) pour la topbar et la sidebar web.
+const LOGO_SRC = '/icons/icon-192.png'
 
 /**
  * Type des libellés de nav traduits, indexé par fonction `t` du namespace `nav`.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -806,7 +806,6 @@
     "title": "My profile",
     "subtitle": "Your member information.",
     "unknownName": "Member",
-    "editHint": "Editing your profile is coming soon. To correct any information, contact your treasurer.",
     "fields": {
       "email": "Email",
       "phone": "Phone",
@@ -819,7 +818,14 @@
       "treasurer": "Treasurer",
       "president": "President",
       "network_admin": "Network admin"
-    }
+    },
+    "avatarUpdated": "Profile photo updated",
+    "avatarError": "Failed to update profile photo.",
+    "avatarUploadAria": "Change profile photo for {name}",
+    "avatarEmpty": "Photo",
+    "avatarUploading": "Uploading…",
+    "avatarUploadingAria": "Uploading",
+    "avatarHint": "Click your photo to update it. Other information is synced from your club spreadsheet."
   },
   "accessSuspended": {
     "metaTitle": "Access suspended — Evolve Capital",
@@ -969,8 +975,8 @@
     },
     "iosOther": {
       "headline": "Install Evolve on your home screen.",
-      "subline": "We'll copy a sign-in link. Open Safari, paste it — you'll already be signed in, ready to install.",
-      "cta": "Install the app"
+      "subline": "One tap and we open Safari with your session — ready to install from the home screen.",
+      "cta": "Open in Safari"
     },
     "toastCopied": {
       "title": "Link copied",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -806,7 +806,6 @@
     "title": "Mon profil",
     "subtitle": "Tes informations de membre.",
     "unknownName": "Membre",
-    "editHint": "L’édition de ton profil arrive bientôt. Pour corriger une information, contacte ton trésorier.",
     "fields": {
       "email": "Email",
       "phone": "Téléphone",
@@ -819,7 +818,14 @@
       "treasurer": "Trésorier",
       "president": "Président",
       "network_admin": "Administrateur réseau"
-    }
+    },
+    "avatarUpdated": "Photo mise à jour",
+    "avatarError": "Échec de la mise à jour de la photo.",
+    "avatarUploadAria": "Modifier la photo de profil de {name}",
+    "avatarEmpty": "Photo",
+    "avatarUploading": "Envoi…",
+    "avatarUploadingAria": "Envoi en cours",
+    "avatarHint": "Clique sur ta photo pour la modifier. Les autres informations sont synchronisées depuis les feuilles du club."
   },
   "accessSuspended": {
     "metaTitle": "Accès suspendu — Evolve Capital",
@@ -968,9 +974,9 @@
       "cta": "Voir comment"
     },
     "iosOther": {
-      "headline": "Installe Evolve sur ton écran d'accueil.",
-      "subline": "On copie un lien de connexion. Ouvre Safari, colle-le : tu seras déjà connecté(e), prêt(e) à l'installer.",
-      "cta": "Installer l'application"
+      "headline": "Installe Evolve sur ton écran d’accueil.",
+      "subline": "En un clic, on ouvre Safari avec ta session — prêt(e) à installer l’app depuis l’écran d’accueil.",
+      "cta": "Ouvrir dans Safari"
     },
     "toastCopied": {
       "title": "Lien copié",

--- a/packages/ui/src/molecules/CotisationMonth/CotisationMonth.tsx
+++ b/packages/ui/src/molecules/CotisationMonth/CotisationMonth.tsx
@@ -14,6 +14,39 @@ const variantClasses: Record<CotisationVariant, string> = {
   exempt: 'bg-neutral-100 opacity-50',
 }
 
+/** Icône textuelle centrée dans la cellule (md uniquement, trop petit pour sm). */
+function CellIcon({ variant }: { variant: CotisationVariant }) {
+  if (variant === 'paid') {
+    return (
+      <span
+        aria-hidden="true"
+        className="pointer-events-none select-none text-[10px] font-bold leading-none text-neutral-900/70"
+      >
+        ✓
+      </span>
+    )
+  }
+  if (variant === 'late') {
+    return (
+      <span
+        aria-hidden="true"
+        className="pointer-events-none select-none text-[10px] font-bold leading-none text-white/90"
+      >
+        !
+      </span>
+    )
+  }
+  if (variant === 'pending') {
+    return (
+      <span
+        aria-hidden="true"
+        className="pointer-events-none block h-1.5 w-1.5 rounded-full bg-text-ter/60"
+      />
+    )
+  }
+  return null
+}
+
 export interface CotisationMonthProps {
   variant: CotisationVariant
   tooltip: string
@@ -42,10 +75,12 @@ export function CotisationMonth({
               ? 'h-3 w-3'
               : // Cible tactile ≥ 44×44px sur mobile (24px de pastille + 2×10px de padding).
                 // Sur ≥ sm (pointeur fin), on revient au rendu compact 24px sans padding.
-                'h-6 w-6 min-h-[24px] min-w-[24px] p-2.5 sm:p-0',
+                'inline-flex h-6 w-6 min-h-[24px] min-w-[24px] items-center justify-center p-2.5 sm:p-0',
             variantClasses[variant]
           )}
-        />
+        >
+          {size === 'md' && <CellIcon variant={variant} />}
+        </button>
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content

--- a/packages/ui/src/organisms/ContributionsTimeline/ContributionsTimeline.tsx
+++ b/packages/ui/src/organisms/ContributionsTimeline/ContributionsTimeline.tsx
@@ -117,9 +117,9 @@ export function ContributionsTimeline({
         {[0, 1].map((y) => (
           <div key={y} className="flex flex-col gap-2">
             <Skeleton height={16} width="64px" radius="6px" />
-            <div className="flex flex-wrap gap-1.5">
+            <div className="grid grid-cols-12 gap-1">
               {Array.from({ length: 12 }).map((_, i) => (
-                <Skeleton key={i} height={24} width={24} radius="4px" />
+                <Skeleton key={i} height={24} width="100%" radius="4px" />
               ))}
             </div>
           </div>
@@ -162,7 +162,10 @@ export function ContributionsTimeline({
             <h3 className="sticky top-0 z-10 bg-bg py-1 font-display font-bold text-[14px] text-text">
               {group.year}
             </h3>
-            <div className="flex flex-wrap gap-2">
+            {/* 12 colonnes fixes : tous les mois d'une année tiennent sur UNE seule ligne.
+                Les touch-areas (p-2.5 mobile) des cellules adjacentes se chevauchent légèrement
+                dans le gap=0 — comportement accepté (même pattern que les claviers mobiles). */}
+            <div className="grid grid-cols-12">
               {/* Ordre d'affichage ASCENDANT (janvier → décembre), quel que soit l'ordre
                   d'entrée. On trie une COPIE (pas de mutation de la prop). Le mapping
                   mois→statut/tooltip/aria-label suit chaque cellule par sa clé `month`. */}
@@ -171,7 +174,7 @@ export function ContributionsTimeline({
                 .map((m) => (
                   <div
                     key={`${group.year}-${m.month}`}
-                    className="flex flex-col items-center gap-1"
+                    className="flex flex-col items-center gap-0.5"
                   >
                     <CotisationMonth
                       variant={m.variant}
@@ -179,7 +182,7 @@ export function ContributionsTimeline({
                       aria-label={m.ariaLabel}
                       size="md"
                     />
-                    <span aria-hidden="true" className="text-[10px] leading-none text-text-ter">
+                    <span aria-hidden="true" className="text-[9px] leading-none text-text-ter">
                       {monthInitials[m.month - 1]}
                     </span>
                   </div>


### PR DESCRIPTION
## Contexte
Corrections UX suite aux retours de test mobile (juin 2026) — aucune étape MIGRATION_PLAN.md impliquée.

## Summary
Trois correctifs indépendants :

1. **Cotisations — grille 12 colonnes** : les mois wrappaient sur plusieurs lignes sur mobile. Le composant passe en `grid-cols-12` (une ligne fixe par année) + icônes ✓/!/• dans chaque cellule selon le statut.

2. **Photo de profil modifiable** : l'avatar de `/profil` était en lecture seule. Un clic ouvre maintenant le sélecteur de fichier ; l'image est redimensionnée en 200×200 WebP côté client puis uploadée dans le bucket `avatars`, et `users.avatar_url` est mis à jour directement via RLS self-update.

3. **PWA ios-other → redirect Safari** : sur Chrome iOS, le bouton d'installation redirige maintenant vers `x-safari-https://` (force l'ouverture de Safari) avec le lien de handoff. L'utilisateur arrive connecté dans Safari et peut installer l'app depuis l'écran d'accueil. Fallback clipboard si la redirection échoue.

## Changes
- `CotisationMonth` : composant `CellIcon` + `inline-flex` pour centrer l'icône
- `ContributionsTimeline` : `grid grid-cols-12` (mois) + skeleton cohérent
- `ProfileAvatarUpload` : nouveau composant client, réutilise `AvatarUpload` + `resizeAndUploadAvatar`
- `ProfileView` : remplace `<Avatar>` statique par `<ProfileAvatarUpload>`
- `InstallSection` : `openHandoffInSafari()` avec `x-safari-https://` + fallback copie
- i18n fr/en : clés `profile.avatar*`, `profile.avatarHint`, textes `pwa.iosOther` mis à jour

## Test plan
- [x] `pnpm turbo typecheck` — 6/6 ✅
- [x] `pnpm turbo test --filter=@evolve/ui` — 437/437 ✅
- [x] `pnpm turbo test --filter=@evolve/web` — 292/292 ✅
- [x] `pnpm turbo lint --filter=@evolve/web` — 0 warnings ✅
- [ ] Vitrine toujours accessible sur https://reseauevolvecapital.com

## Checklist
- [x] Commits en Conventional Commits format
- [x] Aucun fichier .env commité
- [x] Prettier + ESLint OK
- [x] Pas de breaking change API publique