### PR TITLE
docs: specs design feedback widget + vote anonyme

### DIFF
--- a/docs/superpowers/specs/2026-06-13-feedback-widget-design.md
+++ b/docs/superpowers/specs/2026-06-13-feedback-widget-design.md
@@ -1,0 +1,326 @@
+# Feedback Widget — Spec Design
+
+**Date** : 2026-06-13  
+**Statut** : Approuvé — prêt pour implémentation  
+**Scope** : V0 uniquement (V1/V2 documentées en roadmap, non planifiées)
+
+---
+
+## Contexte et objectif
+
+Permettre aux membres authentifiés de signaler un bug, soumettre une idée de fonctionnalité ou poser une question, directement depuis l'application web, sans friction. Les feedbacks sont stockés en Supabase (source de vérité), triés par IA, puis dispatchés vers Discord, Notion, GitHub Issues et Brevo selon leur type.
+
+**Non inclus dans ce spec** : feature NPS/satisfaction (feature séparée, déclenchée par événements produit, ticket à créer quand V0 est livré).
+
+---
+
+## 1. Point d'entrée (placement UI)
+
+### Desktop
+
+Icône `MessageCircle` (Lucide) dans l'`AppTopbar`, à droite, entre `localeSwitcher` et `themeToggle`.
+
+### Mobile
+
+- Même icône `MessageCircle` dans l'`AppTopbar`, visible à côté de l'avatar.
+- Le `themeToggle` est masqué sur mobile (`hidden md:inline-flex`) et déplacé dans le dropdown avatar — même pattern que `localeSwitcher` aujourd'hui.
+
+### Modifications `AppTopbar` (`packages/ui`)
+
+Deux nouvelles props ajoutées, rien de destructif :
+
+```tsx
+onFeedback?: () => void     // ouvre le FeedbackSheet
+feedbackLabel?: string      // i18n, défaut "Retour"
+```
+
+Câblage dans `AppChrome` (`apps/web/components/chrome/AppChrome.tsx`) :
+
+```tsx
+<AppChromeTopbar
+  ...
+  onFeedback={() => setFeedbackOpen(true)}
+  feedbackLabel={t('nav.topbar.feedback')}
+/>
+<FeedbackSheet
+  open={feedbackOpen}
+  onOpenChange={setFeedbackOpen}
+  currentRoute={pathname}
+  onSubmit={handleFeedbackSubmit}
+  labels={t('feedback')}
+/>
+```
+
+---
+
+## 2. Composant `FeedbackSheet` (`packages/ui`)
+
+### API
+
+```tsx
+interface FeedbackSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentRoute: string // pathname Next.js, capturé automatiquement
+  onSubmit: (data: FeedbackSubmission) => Promise<void>
+  labels: FeedbackLabels // i18n complet
+}
+
+interface FeedbackSubmission {
+  type: 'bug' | 'feature' | 'question'
+  message: string
+  screenshotDataUrl?: string // base64, présent uniquement si l'utilisateur a cliqué "Joindre"
+  pageUrl: string // window.location.href
+  pageRoute: string // currentRoute prop
+  userAgent: string // navigator.userAgent
+}
+```
+
+### 5 états du composant
+
+| État                   | Condition            | Description                                                                            |
+| ---------------------- | -------------------- | -------------------------------------------------------------------------------------- |
+| **idle**               | initial              | Sélecteur de type + textarea + bouton "Joindre une capture" discret                    |
+| **screenshot-preview** | après clic "Joindre" | Prévisualisation de la capture + mention vie privée + bouton "Retirer"                 |
+| **loading**            | après submit         | Formulaire désactivé + spinner                                                         |
+| **success**            | après réponse OK     | Confirmation + mention email envoyé                                                    |
+| **error**              | après réponse KO     | Message d'erreur + bouton "Réessayer" (re-passe en idle avec les données pré-remplies) |
+
+### Comportement screenshot (opt-in strict)
+
+1. L'utilisateur clique "Joindre une capture d'écran (optionnel)"
+2. Le sheet est masqué temporairement (opacity 0, pointeur désactivé) pour que `html2canvas` capture la page derrière, pas le formulaire lui-même
+3. `html2canvas` capture l'écran courant
+4. Le sheet est réaffiché
+5. Une **prévisualisation** s'affiche dans le formulaire
+6. La mention **"Cette capture sera partagée uniquement avec l'équipe technique"** est visible
+7. L'utilisateur peut cliquer "Retirer" pour supprimer la capture avant envoi
+8. Si l'utilisateur ne clique pas le bouton, **aucun screenshot n'est pris**
+
+### Contexte capturé automatiquement (sans action utilisateur)
+
+- `pageUrl` : `window.location.href`
+- `pageRoute` : pathname Next.js injecté via prop `currentRoute`
+- `userAgent` : `navigator.userAgent`
+
+### Aucune logique métier dans le composant
+
+Le composant remonte les données via `onSubmit`. Toute la logique (upload Storage, insert Supabase) vit dans la Server Action `apps/web`.
+
+---
+
+## 3. Schéma Supabase
+
+### Table `feedback`
+
+```sql
+CREATE TABLE feedback (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at      timestamptz DEFAULT now(),
+
+  -- Auteur
+  user_id         uuid REFERENCES auth.users NOT NULL,
+  user_email      text NOT NULL,
+
+  -- Contenu
+  type            text CHECK (type IN ('bug','feature','question')) NOT NULL,
+  message         text NOT NULL,
+  screenshot_url  text,                    -- null si pas de screenshot
+
+  -- Contexte auto
+  page_url        text NOT NULL,
+  page_route      text NOT NULL,
+  user_agent      text,
+
+  -- IA (rempli par l'Edge Function après INSERT)
+  ai_title        text,
+  ai_severity     text CHECK (ai_severity IN ('blocking','annoying','minor')),
+  ai_summary      text,
+  ai_category     text,
+
+  -- Destinations externes
+  github_issue_url  text,
+  notion_page_id    text,
+  discord_notified  boolean DEFAULT false,
+  email_sent        boolean DEFAULT false,
+
+  -- Statut (pour V2 tracker in-app)
+  status          text DEFAULT 'received'
+                  CHECK (status IN ('received','in_progress','done','closed'))
+);
+```
+
+### RLS
+
+- Membre : `SELECT` uniquement sur ses propres feedbacks (`user_id = auth.uid()`)
+- Staff (trésorier) : `SELECT` sur tous les feedbacks
+- `INSERT` : tout membre authentifié
+- `UPDATE` : service_role uniquement (Edge Function)
+
+### Supabase Storage
+
+Bucket `screenshots` (privé). Les screenshots sont uploadés **avant** l'INSERT en table — si l'upload échoue, le feedback est quand même soumis sans screenshot (`screenshot_url = null`).
+
+---
+
+## 4. Server Action (`apps/web`)
+
+```
+POST /api/feedback  (Server Action Next.js)
+
+1. Authentification : vérifie la session Supabase (rejet 401 si absent)
+2. Si screenshotDataUrl présent :
+   a. Upload dans Supabase Storage bucket `screenshots/`
+   b. Récupère l'URL publique signée
+3. INSERT dans table `feedback` avec toutes les données + screenshot_url
+4. Retourne { success: true }
+
+L'Edge Function est déclenchée par trigger Postgres — la Server Action n'appelle pas l'Edge Function directement.
+```
+
+---
+
+## 5. Edge Function `feedback-dispatch`
+
+### Déclenchement
+
+Trigger Postgres sur `INSERT INTO feedback` → appelle l'Edge Function `feedback-dispatch` avec le row complet. La Server Action n'appelle pas l'Edge Function — le découplage garantit qu'un feedback est toujours dispatché même si le client coupe la connexion.
+
+### Séquence interne
+
+```
+1. Reçoit le row feedback + screenshot_url
+
+2. Appelle Claude Haiku (claude-haiku-4-5) :
+   Input : type, message, page_route, user_agent, screenshot_url
+   Prompt selon type :
+     bug     → titre structuré (max 80 chars), sévérité (blocking/annoying/minor),
+                diagnostic préliminaire (2-3 phrases)
+     feature → titre, résumé, catégorie (UX/données/perf/admin/autre)
+     question → titre, résumé, intention (technique/métier/facturation/autre)
+   Output JSON : { title, severity?, summary, category? }
+
+3. UPDATE feedback SET ai_title, ai_severity, ai_summary, ai_category
+
+4. Fan-out parallèle (Promise.all, chaque branche dans try/catch indépendant) :
+
+   a. Discord webhook (tous types)
+      Embed : type pill + titre IA + page_route + lien Supabase admin
+      Couleur : rouge=bug, bleu=feature, gris=question
+
+   b. Notion API (tous types)
+      DB `feedback` : titre IA, type, sévérité, catégorie, message, lien screenshot, date
+
+   c. GitHub Issues API (type=bug uniquement)
+      Titre : ai_title
+      Body :
+        - Sévérité estimée
+        - Page : page_route · user_agent résumé
+        - Description utilisateur (verbatim)
+        - Diagnostic IA
+        - Screenshot (lien URL si présent)
+        - Lien Supabase feedback row
+      Labels : ["bug", "user-reported", severity]
+
+   d. Brevo email (tous types)
+      Template : accusé de réception
+      Destinataire : user_email
+      Corps : confirmation + type + mention "l'équipe a été notifiée"
+
+5. UPDATE feedback SET
+     github_issue_url, notion_page_id,
+     discord_notified=true, email_sent=true
+```
+
+### Résilience
+
+Si une destination échoue (API down, rate limit), les autres continuent. Le feedback reste intègre en Supabase dans tous les cas. Les champs `discord_notified`, `email_sent` restent `false` si la branche a échoué — permet un retry manuel.
+
+### Variables d'environnement requises
+
+```
+ANTHROPIC_API_KEY
+DISCORD_FEEDBACK_WEBHOOK_URL
+GITHUB_TOKEN
+GITHUB_REPO                    # ex. omniventus/reseau-evolve-capital
+NOTION_TOKEN
+NOTION_FEEDBACK_DB_ID
+# BREVO_API_KEY déjà présent (Edge Function send-email)
+```
+
+---
+
+## 6. Localisation (i18n)
+
+Clés à ajouter dans `messages/fr.json` et `messages/en.json` :
+
+```json
+{
+  "nav": {
+    "topbar": {
+      "feedback": "Retour"
+    }
+  },
+  "feedback": {
+    "title": "Votre retour",
+    "subtitle": "Aidez-nous à améliorer l'application",
+    "types": {
+      "bug": "Bug",
+      "feature": "Idée",
+      "question": "Question"
+    },
+    "messagePlaceholder": {
+      "bug": "Décrivez ce qui s'est passé…",
+      "feature": "Décrivez votre idée…",
+      "question": "Posez votre question…"
+    },
+    "screenshot": {
+      "attach": "Joindre une capture d'écran (optionnel)",
+      "attached": "Capture jointe",
+      "remove": "Retirer",
+      "privacyNote": "Cette capture sera partagée uniquement avec l'équipe technique."
+    },
+    "submit": "Envoyer →",
+    "sending": "Envoi…",
+    "success": {
+      "title": "Merci pour votre retour !",
+      "subtitle": "Un email de confirmation vous a été envoyé.",
+      "pill": "Vérifiez votre boîte mail",
+      "close": "Fermer"
+    },
+    "contextLabel": "Page actuelle"
+  }
+}
+```
+
+---
+
+## 7. Tests attendus
+
+| Couche                            | Ce qu'on teste                                                                                        |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Storybook play** (`@evolve/ui`) | FeedbackSheet : 4 états, sélection de type, screenshot attach/remove, submit disabled pendant loading |
+| **Vitest** (`apps/web`)           | Server Action : rejet sans auth, upload Storage, INSERT row                                           |
+| **jest-axe**                      | FeedbackSheet : focus visible, rôles ARIA, cibles tactiles ≥ 44px                                     |
+| **E2E Playwright**                | Flow complet : ouvrir widget → remplir → envoyer → voir état succès                                   |
+
+---
+
+## 8. Roadmap
+
+### V0 (ce spec — ~5–6 jours)
+
+Tout ce qui est décrit ci-dessus.
+
+### V1 (après ~50 feedbacks reçus — ~4–5 jours)
+
+- Routine IA hebdo : regroupe les features similaires, détecte patterns récurrents → résumé Discord/Notion
+- Agent IA qui draft une PR de fix sur les bugs GitHub + notif Discord
+- Déduplication : bug déjà ouvert → commentaire sur l'Issue existant
+- Emails Brevo quand bug résolu (webhook GitHub → Supabase → Brevo) ou feature planifiée
+
+### V2 (produit mature — ~7–10 jours)
+
+- Page `/feedback` : historique des soumissions + statuts in-app
+- Badge sur icône topbar si réponse disponible
+- Feature satisfaction/NPS séparée (bottom-sheet déclenchée par événements clés : J+7, J+30, post-cotisation)

--- a/docs/superpowers/specs/2026-06-13-vote-anonyme-design.md
+++ b/docs/superpowers/specs/2026-06-13-vote-anonyme-design.md
@@ -1,0 +1,331 @@
+# Vote Anonyme — Spec Design
+
+**Date** : 2026-06-13  
+**Statut** : Approuvé — prêt pour implémentation  
+**Scope** : V0 uniquement — votes scopés club (V1 réseau documenté en roadmap)
+
+---
+
+## Contexte et objectif
+
+Les membres d'un club d'investissement ne s'expriment pas librement par peur de heurter. L'objectif est de créer un canal de consultation anonyme **by design** : les membres votent sans que leur identité soit jamais associée à leur réponse, y compris pour les administrateurs.
+
+Le président ou le trésorier crée un vote depuis l'espace admin. Les membres sont notifiés via une bannière non-bloquante sur le dashboard. Ils votent depuis cette bannière ou depuis une page `/votes`. Une fois le vote clôturé, les résultats agrégés sont visibles de tous les membres du club.
+
+**Non inclus dans ce spec** : votes scopés réseau (V1), NPS/satisfaction (feature séparée), commentaires sur les votes.
+
+---
+
+## 1. Types de questions
+
+Un vote = une question, 4 formats possibles :
+
+| Type           | Clé               | Description                                                                                                        |
+| -------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Oui / Non      | `yes_no`          | 3 options fixes : Oui, Non, Abstention                                                                             |
+| Choix unique   | `single_choice`   | Options personnalisées, 1 seule réponse (radio)                                                                    |
+| Choix multiple | `multiple_choice` | Options personnalisées, N réponses possibles (checkbox)                                                            |
+| Texte libre    | `short_text`      | Champ texte court (max 280 chars). Mention explicite : "votre réponse sera visible de l'équipe sous forme anonyme" |
+
+---
+
+## 2. Visibilité des résultats
+
+Configurable par le créateur au moment de la création. Défaut : **après clôture**.
+
+| Mode          | Clé           | Comportement                                                                                                        |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Après clôture | `after_close` | Résultats accessibles uniquement quand `status = 'closed'`. Post-vote : écran "résultats disponibles à la clôture". |
+| Temps réel    | `live`        | Résultats visibles dès qu'on a voté. Post-vote : affichage immédiat des barres de progression.                      |
+
+---
+
+## 3. Portée (scope)
+
+**V0 — Club uniquement**  
+Tout vote est attaché à un `club_id`. Seuls les membres actifs du club y accèdent et y répondent.
+
+**V1 — Réseau (non implémenté, modèle prêt)**  
+Le champ `network_wide boolean` est présent dans la table dès la V0. Quand `true`, le vote est visible de tous les clubs. Créé uniquement par `network_admin`. Non activé en V0.
+
+---
+
+## 4. Cycle de vie d'un vote
+
+```
+draft → open → closed
+```
+
+- **draft** : créé mais non publié. Éditable. Invisible des membres.
+- **open** : publié. Membres notifiés. Réponses acceptées.
+- **closed** : fermé. Résultats accessibles selon le mode de visibilité.
+
+### Clôture
+
+- **Automatique** : `closes_at` (timestamptz nullable). Défaut suggéré à J+7. Un job `pg_cron` (déjà présent dans le projet) tourne toutes les heures : `UPDATE polls SET status = 'closed', closed_manually_at = now() WHERE status = 'open' AND closes_at < now()`. Le `status` en DB est toujours la source de vérité — pas de check à la lecture.
+- **Manuelle** : le président peut clôturer à tout moment depuis `/admin/votes`, même avant `closes_at`.
+
+### Vote définitif
+
+Un membre ne peut pas modifier sa réponse après soumission. La contrainte `UNIQUE (poll_id, user_id)` sur `poll_responses` l'interdit côté DB. L'UI l'annonce clairement avant confirmation : _"Votre réponse est définitive et ne pourra pas être modifiée."_
+
+---
+
+## 5. Découverte et navigation
+
+### Bannière dashboard (découverte principale)
+
+Quand un vote est `open` et que le membre n'a pas encore voté, une bannière dorée non-bloquante apparaît en haut du dashboard (au-dessus des KPI cards), sur le même pattern que `SyncBanner`.
+
+- Affiche : titre du vote, type, deadline, CTA "Voter →"
+- Disparaît automatiquement une fois que le membre a voté (`has_voted()` retourne `true`)
+- Si plusieurs votes ouverts : max **2 bannières** affichées. Au-delà, une seule bannière "X votes en attente de votre réponse → Voir tous" qui renvoie vers `/votes`
+- **GA4** : event `poll_banner_click` (+ `poll_id`, `poll_type`)
+
+### Page `/votes` (historique et accès secondaire)
+
+Accessible depuis le **menu avatar** (dropdown `AppTopbar`), pas dans la BottomNav principale — pour ne pas surcharger la nav.
+
+- Onglets : En cours / Clôturés
+- Chaque ligne : titre, type, statut, badge "✓ Voté" si déjà répondu, lien "Résultats →" pour les clôturés
+- **GA4** : event `poll_page_view` — sert à mesurer si la page est consultée et si un repositionnement nav est justifié
+
+### Entrée menu avatar
+
+Nouvelle entrée "Votes" dans le dropdown `AppTopbar`, entre "Profil" et "Déconnexion". Visible uniquement si au moins un vote `open` ou `closed` existe pour le club.
+
+---
+
+## 6. Anonymat — garantie technique
+
+L'anonymat est garanti **by design** au niveau de la base de données, pas seulement à l'UI.
+
+### Principe
+
+`user_id` est stocké dans `poll_responses` pour deux raisons légitimes :
+
+1. Garantir **1 seul vote par membre** (contrainte `UNIQUE`)
+2. Permettre au membre de savoir s'il a déjà voté (`has_voted()`)
+
+Mais `user_id` n'est **jamais exposé** via les policies RLS à un utilisateur `authenticated`.
+
+### RLS sur `poll_responses`
+
+```sql
+-- SELECT : aucune policy pour authenticated
+-- Seule la RPC SECURITY DEFINER peut lire les réponses
+
+-- INSERT : tout membre actif du club peut insérer SA réponse
+CREATE POLICY "membre peut voter" ON poll_responses
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM polls p
+      JOIN memberships m ON m.club_id = p.club_id
+      WHERE p.id = poll_id
+        AND m.user_id = auth.uid()
+        AND m.is_active = TRUE
+        AND p.status = 'open'
+    )
+  );
+```
+
+### RPC SECURITY DEFINER
+
+Trois fonctions, toutes en `SECURITY DEFINER STABLE` ou `VOLATILE` selon besoin :
+
+```sql
+-- Soumettre un vote (VOLATILE)
+submit_vote(p_poll_id uuid, p_selected_options text[], p_text_response text)
+  → vérifie : poll ouvert + membre actif du club + pas déjà voté
+  → INSERT poll_responses
+
+-- Obtenir les résultats agrégés (STABLE)
+get_poll_results(p_poll_id uuid)
+  → vérifie : membre du club + résultats visibles (after_close → status=closed, live → toujours)
+  → retourne : { option text, count int, pct numeric }[]
+  → JAMAIS user_id dans le retour
+
+-- Vérifier si le membre a voté (STABLE)
+has_voted(p_poll_id uuid)
+  → retourne boolean
+  → le membre peut savoir s'il a voté, sans voir sa propre réponse
+```
+
+---
+
+## 7. Schéma Supabase
+
+### Table `polls`
+
+```sql
+CREATE TABLE polls (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at      timestamptz DEFAULT now(),
+
+  -- Scope
+  club_id         uuid REFERENCES clubs(id) NOT NULL,
+  network_wide    boolean DEFAULT false,           -- V1, non utilisé en V0
+
+  -- Contenu
+  title           text NOT NULL,
+  description     text,
+  question_type   text NOT NULL
+                  CHECK (question_type IN ('yes_no','single_choice','multiple_choice','short_text')),
+  options         jsonb,                           -- null pour yes_no et short_text
+                                                   -- [{ id, label }] pour single/multiple
+
+  -- Paramètres
+  results_visibility text NOT NULL DEFAULT 'after_close'
+                     CHECK (results_visibility IN ('after_close','live')),
+  closes_at       timestamptz,                     -- null = pas de deadline automatique
+  notify_by_email boolean DEFAULT false,
+
+  -- Cycle de vie
+  status          text NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft','open','closed')),
+  closed_manually_at timestamptz,
+
+  -- Auteur
+  created_by      uuid REFERENCES auth.users NOT NULL
+);
+```
+
+### Table `poll_responses`
+
+```sql
+CREATE TABLE poll_responses (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at      timestamptz DEFAULT now(),
+
+  poll_id         uuid REFERENCES polls(id) ON DELETE CASCADE NOT NULL,
+  user_id         uuid REFERENCES auth.users NOT NULL,
+
+  -- Réponse (selon question_type)
+  selected_options text[],                         -- yes_no / single / multiple
+  text_response   text,                            -- short_text (max 280 chars)
+
+  UNIQUE (poll_id, user_id)                        -- 1 vote par membre
+);
+```
+
+### RLS `polls`
+
+```sql
+-- Membres : lecture des votes ouverts/clôturés de leur club
+CREATE POLICY "membre lit les votes de son club" ON polls
+  FOR SELECT TO authenticated
+  USING (
+    club_id IN (SELECT club_id FROM memberships WHERE user_id = auth.uid() AND is_active = TRUE)
+    AND status IN ('open', 'closed')
+  );
+
+-- Staff : lecture + écriture (draft inclus)
+CREATE POLICY "staff gère les votes" ON polls
+  FOR ALL TO authenticated
+  USING (get_user_role_in_club(club_id) IN ('treasurer','president','network_admin'))
+  WITH CHECK (get_user_role_in_club(club_id) IN ('treasurer','president','network_admin'));
+```
+
+---
+
+## 8. Architecture applicative
+
+### Nouvelles routes (`apps/web`)
+
+```
+/votes                          → PollsView (liste membre)
+/votes/[id]                     → PollDetailView (voter ou voir résultats)
+/admin/votes                    → AdminPollsView (liste admin)
+/admin/votes/nouveau            → AdminPollCreateView
+/admin/votes/[id]               → AdminPollDetailView (résultats + clôture)
+```
+
+### Nouveaux composants (`packages/ui`)
+
+| Composant         | Couche   | Rôle                                                  |
+| ----------------- | -------- | ----------------------------------------------------- |
+| `PollBanner`      | molecule | Bannière dashboard (dorée, CTA "Voter →")             |
+| `PollCard`        | molecule | Ligne dans la liste `/votes`                          |
+| `PollVoteSheet`   | organism | Modal/sheet de vote (4 types de réponse)              |
+| `PollResultsView` | organism | Résultats agrégés avec barres de progression          |
+| `PollCreateForm`  | organism | Formulaire admin de création (multi-steps selon type) |
+
+### Intégration dashboard
+
+`PollBanner` s'insère dans le layout `/dashboard` au-dessus des KPI cards. Il appelle `has_voted(pollId)` en RSC pour chaque vote ouvert du club. Si `has_voted = false` → bannière visible.
+
+### Intégration `AppTopbar`
+
+Nouvelle entrée dans le dropdown avatar :
+
+```tsx
+// Dans AppTopbar / AppChromeTopbar
+{ label: t('nav.topbar.votes'), href: '/votes', icon: 'Vote' }
+// Conditionnel : affiché si hasPollActivity (RSC, 1 seul check)
+```
+
+---
+
+## 9. GA4 events
+
+| Event                 | Déclencheur                           | Propriétés                              |
+| --------------------- | ------------------------------------- | --------------------------------------- |
+| `poll_banner_view`    | Bannière rendue sur le dashboard      | `poll_id`, `poll_type`                  |
+| `poll_banner_click`   | Clic sur "Voter →" depuis la bannière | `poll_id`, `poll_type`                  |
+| `poll_vote_submitted` | Submit réussi                         | `poll_id`, `poll_type`, `question_type` |
+| `poll_results_viewed` | Ouverture des résultats               | `poll_id`, `poll_type`                  |
+| `poll_page_view`      | Visite de `/votes`                    | —                                       |
+
+Le taux de `poll_page_view` vs `poll_banner_click` révèle si les membres utilisent la page en navigation directe ou seulement via la bannière — donnée décisionnelle pour un éventuel repositionnement dans la nav.
+
+---
+
+## 10. Texte libre — cas particulier
+
+Pour `question_type = 'short_text'` :
+
+- Mention obligatoire dans le modal avant le champ : _"Votre réponse sera visible de l'équipe sous forme anonyme. Votre nom n'y sera pas associé."_
+- Limite : 280 caractères (enforced UI + contrainte DB `CHECK (char_length(text_response) <= 280)`)
+- Dans les résultats : liste des réponses texte, sans attribution, avec mention "X réponses reçues"
+- Un admin voit les textes mais ne peut pas les relier à un membre (RPC `get_poll_results` ne retourne pas `user_id`)
+
+---
+
+## 11. Tests attendus
+
+| Couche                            | Ce qu'on teste                                                                                                                                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Storybook play** (`@evolve/ui`) | PollBanner : clic CTA, état "déjà voté". PollVoteSheet : 4 types, sélection, submit disabled sans sélection, état succès. PollResultsView : barres de progression, 100% total.                                       |
+| **Vitest**                        | RPC `submit_vote` : double-vote bloqué (UNIQUE), poll fermé rejeté, membre hors-club rejeté. `has_voted` : retourne false avant, true après. `get_poll_results` : agrégats corrects, jamais user_id dans la réponse. |
+| **jest-axe**                      | PollVoteSheet : focus visible, rôles ARIA (radio group, checkbox group), cibles ≥ 44px.                                                                                                                              |
+| **E2E Playwright**                | Flow complet : bannière visible → voter → bannière disparaît → résultats après clôture manuelle. Admin : créer vote → publier → vérifier bannière membre.                                                            |
+
+---
+
+## 12. Roadmap
+
+### V0 (ce spec — ~7–8 jours)
+
+- Table `polls` + `poll_responses` + RLS + 3 RPC
+- Composants `@evolve/ui` : PollBanner, PollCard, PollVoteSheet, PollResultsView, PollCreateForm
+- Routes `/votes`, `/votes/[id]`, `/admin/votes/**`
+- Bannière dashboard + entrée menu avatar
+- 4 types de question
+- Visibilité configurable (after_close / live)
+- Clôture auto (cron) + manuelle
+- GA4 events
+
+### V1 (après ~20 votes créés — ~4–5 jours)
+
+- Scope réseau (`network_wide = true`) — créé par `network_admin`, agrégats cross-club
+- Notification email Brevo à l'ouverture d'un vote (toggle déjà présent en V0)
+- Résultats par club pour les votes réseau
+- Export CSV des résultats (admin)
+
+### V2 (futur)
+
+- Votes programmés (date d'ouverture future)
+- Questionnaires multi-questions (plusieurs questions dans un même vote)
+- Rappel automatique aux membres n'ayant pas voté (J-2 avant clôture)

--- a/docs/tickets/PROMPT-DESIGN-VOTE-ANONYME.md
+++ b/docs/tickets/PROMPT-DESIGN-VOTE-ANONYME.md
@@ -1,0 +1,218 @@
+# Prompt Claude Design — Système de vote anonyme
+
+> Copier-coller ce prompt dans Claude Design. Le design system du projet est déjà connu.
+
+---
+
+Tu es Claude Design, le générateur de maquettes UI d'Anthropic. Tu connais le design system du projet Réseau Evolve Capital : tokens CSS Tailwind V4, palette brand (accent doré `#e8c96a` / `#c9a83e`), typographie MADE Tommy Soft, composants existants (`AppTopbar`, `BottomNav`, `SyncBanner`, `InfoTip`, `TrendBadge`, `ContributionsTimeline`). Génère les maquettes décrites ci-dessous en respectant scrupuleusement ce design system.
+
+---
+
+## TOKENS DE RÉFÉRENCE
+
+**Dark**
+
+- Fond app : `#0f1117`
+- Card / surface : `#1a1d2e`
+- Accent doré : `#e8c96a`
+- Accent doré pressé : `#d4b558`
+- Texte primaire : `#e8f0ff`
+- Texte secondaire : `rgba(232,240,255,0.55)`
+- Bordure : `#2a2d3a`
+- Bordure active : `#e8c96a`
+- Focus ring : outline 2px solid `#e8c96a`, offset 2px
+- CTA primaire fond : `#e8c96a`, texte : `#0f1117`
+- CTA désactivé fond : `#2a2d3a`, texte : `rgba(232,240,255,0.3)`
+- Succès/positif : `#22c55e`
+- Erreur/négatif : `#C53030` (jamais `#E93E3A` pour les états de données)
+- Badge pill fond : `rgba(232,201,106,0.15)`, texte : `#e8c96a`
+
+**Light**
+
+- Fond app : `#f4f5f7`
+- Card / surface : `#ffffff`
+- Accent doré : `#c9a83e`
+- Texte primaire : `#0f1117`
+- Texte secondaire : `rgba(15,17,23,0.55)`
+- Bordure : `#e2e4ea`
+- Bordure active : `#c9a83e`
+- Focus ring : outline 2px solid `#c9a83e`, offset 2px
+- CTA primaire fond : `#c9a83e`, texte : `#ffffff`
+- CTA désactivé fond : `#e2e4ea`, texte : `rgba(15,17,23,0.35)`
+- Badge pill fond : `rgba(201,168,62,0.12)`, texte : `#c9a83e`
+
+**Typographie**
+
+- Famille : MADE Tommy Soft (fallback : system-ui)
+- Titre card : 16px medium
+- Sous-titre / label : 13px regular, secondaire
+- CTA : 14px semibold
+- Badge pill : 11px medium, letter-spacing +0.3px
+
+**Rayons**
+
+- Card : 16px
+- Bouton CTA : 10px
+- Input / select : 8px
+- Badge pill : 999px (full)
+- Bannière : 12px
+
+**Ombres (dark)**
+
+- Card : `0 2px 16px rgba(0,0,0,0.4)`
+- Modal : `0 8px 40px rgba(0,0,0,0.6)`
+
+**Ombres (light)**
+
+- Card : `0 1px 8px rgba(15,17,23,0.08)`
+- Modal : `0 8px 40px rgba(15,17,23,0.16)`
+
+---
+
+## RÈGLES SYSTÉMIQUES (respecter dans 100 % des maquettes)
+
+1. **Focus visible** : sur au moins un élément interactif par maquette, montrer le focus ring doré (outline 2px solid accent, offset 2px). Ne jamais supprimer le focus outline.
+2. **Cibles tactiles** : tous les boutons, radios, checkboxes et CTA mesurent ≥ 44×44 px.
+3. **Badge "🔒 Vote anonyme"** : pill dorée, visible en haut du modal de vote (PollVoteSheet) avant toute interaction. Texte : « 🔒 Vote anonyme ».
+4. **Mention "Réponse définitive"** : ligne de texte secondaire juste au-dessus du CTA de confirmation, dans tous les états ready. Texte exact : « Votre réponse est définitive et ne pourra pas être modifiée. »
+5. **Taux de participation** : affiché dans tous les états résultats, format « X/Y membres ont voté (Z%) ».
+6. **Étiquette** : chaque maquette porte une étiquette visible en dehors du frame (coin supérieur gauche) au format `[Composant] — [desktop/mobile] — [état] — [dark/light]`.
+7. **Ton sobre, financier, premium** : pas de couleurs flashy. L'accent doré est la seule couleur de marque forte. Les états négatifs utilisent `#C53030`, jamais `#E93E3A`.
+8. **Icônes** : style line, 20px, stroke 1.5px. Utiliser les icônes Lucide (Vote, Check, Lock, ChevronRight, X, Calendar, Users, Plus, Trash2, Edit2, Bell).
+
+---
+
+## LIVRABLE 1 — PollBanner (bannière dashboard)
+
+Contexte : la bannière s'insère dans la page `/dashboard`, au-dessus des KPI cards, sous l'`AppTopbar`. Fond légèrement teinté accent, bordure gauche 3px accent, radius 12px, padding 14px 20px.
+
+**1a — Dashboard desktop — 1 vote ouvert — dark**
+AppTopbar + PollBanner pleine largeur + KPI cards suggérées dessous. Bannière : icône `Vote` dorée + titre vote en gras (ex : « Faut-il diversifier vers les SCPI ? ») + type badge pill « Choix unique » + deadline pill « Clôture 20 juin » + CTA « Voter → » (fond doré, 44px min, radius 10px) + fermeture × ghost à droite. Focus ring visible sur le CTA.
+
+**1b — Dashboard desktop — 2 votes ouverts — dark**
+2 PollBanners empilées (8px gap). Vote 1 : « Faut-il diversifier vers les SCPI ? » / Choix unique. Vote 2 : « Êtes-vous disponible pour l'AG de septembre ? » / Oui/Non. Chaque bannière a son propre CTA.
+
+**1c — Dashboard desktop — 3+ votes (bannière agrégée) — dark**
+Une seule PollBanner : « 4 votes en attente de votre réponse » + CTA « Voir tous → » (lien textuel doré avec chevron).
+
+**1d — Dashboard mobile (375px) — 1 vote ouvert — dark**
+BottomNav visible en bas. Bannière full width, disposition 2 lignes + CTA pleine largeur.
+
+**1e — Dashboard desktop — 1 vote ouvert — light**
+
+**1f — Dashboard mobile — 1 vote ouvert — light**
+
+---
+
+## LIVRABLE 2 — PollVoteSheet (modal de vote, 4 types)
+
+**Structure commune** : Desktop = modal centré max-width 480px, backdrop semi-opaque, header avec titre + badge pill « 🔒 Vote anonyme » + fermeture × (40×40px). Mobile = bottom sheet radius top 20px, handle bar 40×4px centré.
+
+### Type `yes_no`
+
+**2a — desktop — idle — dark**
+Titre : « Faut-il diversifier vers les SCPI ? » + description 1 ligne. 3 options radio cards (Oui / Non / Abstention), height 52px, radius 10px, fond card, bordure 1px. Radio 24px non coché. CTA désactivé.
+
+**2b — desktop — ready (« Oui » sélectionné) — dark**
+Card « Oui » : fond teinté doré + bordure 2px dorée + radio coché. Mention définitive au-dessus du CTA. CTA actif, focus ring visible.
+
+**2c — desktop — idle — light** · **2d — desktop — ready — light** · **2e — mobile — ready — dark**
+
+### Type `single_choice`
+
+**2f — desktop — idle — dark** : titre « Quel secteur prioriser pour Q3 ? », 4 options radio (Technologie, Immobilier, Énergie renouvelable, Santé). CTA désactivé.
+
+**2g — desktop — ready (« Énergie renouvelable » sélectionné) — dark** · **2h — mobile — ready — dark**
+
+### Type `multiple_choice`
+
+**2i — desktop — idle — dark** : titre « Quels thèmes souhaitez-vous aborder en AG ? », 4 checkboxes (Gouvernance, Politique d'investissement, Bilan annuel, Nouveaux membres), checkbox 24×24px radius 4px. CTA désactivé.
+
+**2j — desktop — ready (2 options cochées) — dark** : checkboxes cochées fond doré + coche blanche. Note 12px « Vous pouvez sélectionner plusieurs réponses. » Mention définitive + CTA actif.
+
+**2k — mobile — ready — light**
+
+### Type `short_text`
+
+**2l — desktop — idle — dark** : encadré avertissement (bordure gauche 2px dorée) « Votre réponse sera visible de l'équipe sous forme anonyme. Votre nom n'y sera pas associé. » Textarea 120px, placeholder, compteur « 0/280 » coin bas-droit. CTA désactivé.
+
+**2m — desktop — ready (142 chars) — dark** : textarea avec texte, compteur « 142/280 », bordure active dorée, mention définitive, CTA actif.
+
+**2n — mobile — ready — dark** · **2o — mobile — ready — light**
+
+---
+
+## LIVRABLE 3 — États post-vote
+
+**3a — desktop — after_close — dark** : icône Check cercle vert 48px + titre « Vote enregistré » + sous-titre. Pill « ⏳ Résultats disponibles à la clôture le 20 juin » (fond doré très faible, texte doré). CTA « Fermer » ghost full width.
+
+**3b — mobile — after_close — dark** · **3c — desktop — after_close — light**
+
+**3d — desktop — live — dark** : icône Check vert + titre + barre de chargement shimmer 3px + texte « Chargement des résultats... »
+
+**3e — mobile — live — dark**
+
+---
+
+## LIVRABLE 4 — PollResultsView
+
+**Structure commune** : Header = titre + badge pill « Résultats » (fond `rgba(34,197,94,0.12)`, texte `#22c55e`). Pied = pill participation « X/Y membres ont voté (Z%) ».
+
+**4a — desktop — yes_no — dark** : barres de progression full width, height 8px, radius 999px. Oui 67% = barre dorée pleine + point `●` doré + label « Option majoritaire ». Non 25% + Abstention 8% = barres secondaires (opacity réduite). Pied : « 12/12 (100%) ».
+
+**4b — desktop — yes_no — light** · **4c — mobile — yes_no — dark**
+
+**4d — desktop — single_choice — dark** : Énergie renouvelable 45% gagnant, Technologie 30%, Santé 15%, Immobilier 10%. Pied : « 10/12 (83%) ».
+
+**4e — desktop — multiple_choice — dark** : Gouvernance 91%, Bilan annuel 82%, Politique 64%, Nouveaux membres 45%. Note : « Les % dépassent 100% car choix multiples. » Pied : « 11/12 (92%) ».
+
+**4f — desktop — short_text — dark** : pas de barres, liste numérotée de 3 réponses anonymes + indicateur « ... 6 autres réponses ». Pied : « 9/12 (75%) ».
+
+**4g — desktop — short_text — light**
+
+---
+
+## LIVRABLE 5 — Page /votes (liste membre)
+
+**5a — desktop — onglet "En cours" — dark** : AppTopbar + titre « Votes » + sous-titre. Onglets « En cours (2) | Clôturés (4) » (actif = fond doré faible + texte doré + bordure bottom 2px). 2 PollCards :
+
+- Card non votée : badge « 🗳️ À voter » doré + type + deadline + CTA « Voter → » fond doré en bas à droite.
+- Card votée : badge « ✓ Voté » vert + texte secondaire « Résultats disponibles à la clôture » (icône Clock).
+
+**5b — desktop — onglet "Clôturés" — dark** : 3 cards clôturées. Badge « Clôturé » + date + pill participation dorée + CTA « Voir résultats → » ghost accent. Une card avec pill « Vous n'avez pas participé » (fond `rgba(197,48,48,0.1)`, texte `#C53030`).
+
+**5c — desktop — "En cours" — light** · **5d — mobile — "En cours" — dark** (375px, BottomNav visible) · **5e — mobile — "En cours" — light**
+
+**5f — desktop — EmptyState — dark** : icône Vote 40px secondaire + titre « Aucun vote en cours » + sous-titre centré.
+
+---
+
+## LIVRABLE 6 — Espace admin /admin/votes
+
+**6a — desktop — liste admin — dark** : sidebar admin gauche (item « Votes » actif, doré). Zone centrale : titre + CTA « + Nouveau vote » fond doré. Onglets En cours / Brouillons / Clôturés.
+
+AdminPollRow vote ouvert : titre + type + deadline + mini-barre de participation (4px, dorée, ex « 7/12 = 58% ») + actions « Voir résultats » (ghost accent) + « Clôturer » (ghost rouge) + kebab (···).
+
+Onglet Brouillons : 2 lignes — badge « Brouillon » + actions « Éditer » + « Publier → » (fond doré) + « Supprimer » (Trash2 rouge ghost).
+
+**6b — desktop — liste admin — light** · **6c — mobile — liste admin — dark** (header admin sans sidebar, hamburger)
+
+**6d — desktop — PollCreateForm step 1 — dark** : page max-width 640px centré. Breadcrumb. Titre « Nouveau vote ». Champ titre (height 48px) + textarea description. Grille 2×2 de type-cards (icône + label + description 12px), « Choix unique » sélectionné (bordure 2px dorée, fond teinté). Focus ring sur une card.
+
+**6e — desktop — PollCreateForm step 2 (single_choice) — dark** : suite du formulaire en scroll. Section « Options de réponse » : 3 inputs avec poignée drag + Trash2 rouge ghost (valeurs : Technologie, Immobilier, Énergie renouvelable) + bouton « + Ajouter une option » dashed full width. Section « Paramètres » : 2 toggles (résultats après clôture activé, email désactivé) + date input J+7. Footer sticky : « Sauver brouillon » ghost + « Publier → » doré + note 12px.
+
+**6f — desktop — PollCreateForm — light** · **6g — mobile — PollCreateForm — dark** (1 colonne pour les type-cards)
+
+---
+
+## LIVRABLE 7 — Entrée menu avatar
+
+**7a — desktop — dropdown ouvert — dark** : AppTopbar, dropdown card 220px large radius 12px. En-tête : avatar 40px + nom + email. Entrées : Profil (icône User) / **Votes (icône Vote) + badge rouge « 2 » (cercle 20×20px) + fond `rgba(232,201,106,0.06)`** / séparateur / Déconnexion (texte `#C53030`). Focus ring sur « Votes ».
+
+**7b — desktop — dropdown — dark — sans badge** (pas de vote en attente)
+
+**7c — desktop — dropdown — light**
+
+**7d — mobile — bottom sheet menu ouvert — dark** (375px) : même contenu en bottom sheet avec handle bar.
+
+**7e — mobile — bottom sheet menu — light**


### PR DESCRIPTION
## Summary

- Spec complète du **feedback widget** (`docs/superpowers/specs/2026-06-13-feedback-widget-design.md`) : FeedbackSheet (3 types bug/feature/question), capture d'écran opt-in (html2canvas), AI triage via Claude Haiku, pipeline Supabase → Discord + Notion + GitHub Issues + email Brevo
- Spec complète du **système de vote anonyme** (`docs/superpowers/specs/2026-06-13-vote-anonyme-design.md`) : 4 types de question, anonymat by design (RLS DB-level + RPC SECURITY DEFINER), cycle de vie draft→open→closed, bannière dashboard, pg_cron auto-close, GA4
- **Prompt Claude Design** pour le vote anonyme (`docs/tickets/PROMPT-DESIGN-VOTE-ANONYME.md`) : 7 livrables (PollBanner, PollVoteSheet × 4 types, états post-vote, PollResultsView, /votes, /admin/votes, menu avatar) avec tokens dark/light et règles a11y

## Statut

Specs approuvées — prêtes pour la planification d'implémentation. Les maquettes visuelles seront générées via Claude Design à partir du prompt inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)