### PR TITLE
chore(infra): plugins Claude Code projet pour sessions remote

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "extraKnownMarketplaces": {
+    "omniventus-workshop": {
+      "source": {
+        "source": "github",
+        "repo": "OMNIVENTUS/ai-workshop"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "playwright@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "vercel@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "component-test-writer@omniventus-workshop": true,
+    "monorepo-navigator@omniventus-workshop": true,
+    "spec-driven-workflow@omniventus-workshop": true,
+    "git-pull-request@omniventus-workshop": true,
+    "commit-and-push@omniventus-workshop": true,
+    "pr-tech-lead-review@omniventus-workshop": true
+  }
+}


### PR DESCRIPTION
## Summary

- Ajoute `.claude/settings.json` à la racine du monorepo pour déclarer la marketplace privée `OMNIVENTUS/ai-workshop` et les plugins REC utilisés en orchestration (tests, monorepo, spec, PR).
- Active `playwright@claude-plugins-official` : le MCP Playwright (`plugin:playwright:playwright`) est embarqué par ce plugin, pas besoin de `.mcp.json` séparé.
- Les agents QA locaux (`.claude/agents/`) et `settings.local.json` restent hors scope — versionnés plus tard.

## Plugins activés

| Source | Plugins |
|--------|---------|
| `@claude-plugins-official` | playwright, superpowers, vercel, claude-md-management |
| `@omniventus-workshop` | component-test-writer, monorepo-navigator, spec-driven-workflow, git-pull-request, commit-and-push, pr-tech-lead-review |

## Prérequis remote

- Le compte GitHub connecté au cloud doit avoir accès en lecture à `OMNIVENTUS/ai-workshop` (repo privé).
- Pousser ce commit avant `claude --remote` pour que la VM clone la config.

## Test plan

- [ ] Ouvrir le repo en local : `/plugin` > Installed affiche les plugins déclarés
- [ ] `/mcp` liste le serveur Playwright (via plugin)
- [ ] `claude --remote "liste les skills disponibles"` charge les skills omniventus-workshop

Made with [Cursor](https://cursor.com)