### PR TITLE
fix: zoom iOS feedback, nom profil, magic link + feedback-dispatch (verify_jwt) [post-deploy]

### DIFF
--- a/.claude/agents/qa-a11y.md
+++ b/.claude/agents/qa-a11y.md
@@ -23,6 +23,10 @@ Cible : **AA minimum, AAA sur les chiffres-clés** (quote-part, variation, valor
   ```bash
   pnpm --filter @evolve/web exec playwright test cursor-pointer.spec.ts --workers=1
   ```
+- **Font-size ≥16px sur tout `input`/`textarea`/`select`** (anti-zoom iOS) : `apps/web/playwright/input-min-fontsize.spec.ts` — scanne les routes au viewport mobile, ouvre le widget Feedback, échoue (message verbeux) si un champ de saisie visible a un `font-size` < 16px. À relancer à chaque NOUVEAU champ introduit. Lancer :
+  ```bash
+  pnpm --filter @evolve/web exec playwright test input-min-fontsize.spec.ts --workers=1
+  ```
 
 ## Méthode
 
@@ -30,6 +34,7 @@ Cible : **AA minimum, AAA sur les chiffres-clés** (quote-part, variation, valor
 2. Lance axe sur les écrans du périmètre (nouveaux composants / markup modifié en priorité).
 3. Vérifie manuellement les points non couverts par axe : focus visible au clavier, ordre de tabulation, cibles ≥44px mobile, `prefers-reduced-motion` (animations figées), états non-couleur-seule, `lang` correct.
    - Lance `cursor-pointer.spec.ts` — **0 cliquable sans `cursor: pointer`** (et `disabled` → `not-allowed`, cf. #R-035). Signale tout cliquable custom (`div`/`span` `onClick`) sans `role="button"` + `tabIndex={0}` + `onKeyDown`.
+   - Lance `input-min-fontsize.spec.ts` — **0 `input`/`textarea`/`select` visible avec `font-size` < 16px** (anti-zoom iOS). À vérifier surtout sur tout NOUVEAU champ de saisie.
 4. ⚠ Piège contraste : ne pas signaler les dettes connues comme nouvelles régressions, MAIS signaler toute NOUVELLE chute (ex. opacité sur texte coloré → #R-026). Le contraste rouge texte fin doit utiliser `--data-negative-strong`.
 
 ## Sortie

--- a/apps/web/app/(app)/admin/invitations/InvitationsView.tsx
+++ b/apps/web/app/(app)/admin/invitations/InvitationsView.tsx
@@ -137,7 +137,8 @@ export function InvitationsView({ initialData }: { initialData: ClubInvitationsP
               value={link}
               aria-label={t('linkLabel')}
               onFocus={(e) => e.currentTarget.select()}
-              className="min-w-0 flex-1 rounded-md border border-border bg-bg px-3 py-2 text-[13px] text-text"
+              // 16px sur mobile pour empêcher le zoom auto d'iOS au focus (input < 16px), 13px dès `md`.
+              className="min-w-0 flex-1 rounded-md border border-border bg-bg px-3 py-2 text-[16px] text-text md:text-[13px]"
             />
             <Button variant="secondary" onClick={() => void copyLink()}>
               <Icon name={copied ? 'Check' : 'Copy'} size={16} aria-hidden="true" />

--- a/apps/web/app/(app)/profil/ProfileView.tsx
+++ b/apps/web/app/(app)/profil/ProfileView.tsx
@@ -42,11 +42,16 @@ export async function ProfileView({ data }: { data: ProfileData }) {
       </header>
 
       <section className="rounded-lg border border-border bg-card p-6 shadow-card">
-        <div className="flex items-center gap-4">
+        <div className="flex items-start gap-4">
           {/* Avatar cliquable — ouvre le sélecteur de fichier (ProfileAvatarUpload est client). */}
           <ProfileAvatarUpload initialUrl={data.avatarUrl} name={displayName} />
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <p className="truncate font-display text-[18px] font-bold text-text">{displayName}</p>
+          {/* `min-w-0` autorise le retour à la ligne du nom dans l'espace restant ;
+              le nom n'est JAMAIS tronqué (pas de `truncate`) — l'avatar ne doit pas masquer le
+              nom de famille (souvent long et en majuscules). `break-words` casse un mot trop long. */}
+          <div className="flex min-w-0 flex-col gap-1.5 pt-1">
+            <p className="font-display text-[18px] leading-snug font-bold break-words text-text">
+              {displayName}
+            </p>
             {roleLabel && data.role ? (
               <span>
                 <Badge variant={roleVariant(data.role)}>{roleLabel}</Badge>

--- a/apps/web/app/api/auth/magic-link/route.test.ts
+++ b/apps/web/app/api/auth/magic-link/route.test.ts
@@ -67,10 +67,39 @@ describe('POST /api/auth/magic-link', () => {
     expect(mocks.signInWithOtp).not.toHaveBeenCalled()
   })
 
-  it('502 si signInWithOtp échoue', async () => {
+  it("502 si signInWithOtp échoue (vraie panne d'envoi)", async () => {
     mocks.rpc.mockResolvedValue({ data: true, error: null })
     mocks.signInWithOtp.mockResolvedValue({ error: { message: 'smtp down' } })
     const res = await POST(req({ email: 'test@example.com' }))
     expect(res.status).toBe(502)
+    expect(await res.json()).toEqual({ error: "Impossible d'envoyer le lien." })
+  })
+
+  it('429 si signInWithOtp est rate-limité par Supabase (status 429)', async () => {
+    mocks.rpc.mockResolvedValue({ data: true, error: null })
+    // AuthApiError de GoTrue : status HTTP 429 → on doit renvoyer notre 429, pas le 502 générique.
+    mocks.signInWithOtp.mockResolvedValue({
+      error: {
+        status: 429,
+        code: 'over_email_send_rate_limit',
+        message: 'email rate limit exceeded',
+      },
+    })
+    const res = await POST(req({ email: 'test@example.com' }))
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBeTruthy()
+    expect(await res.json()).toEqual({
+      error: 'Trop de tentatives. Réessaie dans quelques minutes.',
+    })
+  })
+
+  it('429 si signInWithOtp expose le code over_email_send_rate_limit sans status', async () => {
+    mocks.rpc.mockResolvedValue({ data: true, error: null })
+    // Filet : certaines versions n'exposent que le code GoTrue (pas de status HTTP exploitable).
+    mocks.signInWithOtp.mockResolvedValue({
+      error: { code: 'over_email_send_rate_limit', message: 'over_email_send_rate_limit' },
+    })
+    const res = await POST(req({ email: 'test@example.com' }))
+    expect(res.status).toBe(429)
   })
 })

--- a/apps/web/app/api/auth/magic-link/route.ts
+++ b/apps/web/app/api/auth/magic-link/route.ts
@@ -4,7 +4,8 @@
 //   - validation du corps { email } (zod, format email) → 400
 //   - vérification invitation via RPC email_is_invited (anon, SECURITY DEFINER) → 403
 //   - rate limit Upstash : 5 requêtes / 10 min par IP — fail-open si Upstash absent
-//   - envoi du lien via supabase.auth.signInWithOtp → 502 en cas d'échec
+//   - envoi du lien via supabase.auth.signInWithOtp → 429 si Supabase rate-limite,
+//     502 pour une vraie panne d'envoi
 //   - succès : { sent: true }
 //
 // Réf : ARCHITECTURE.md §1, DATA_MODEL.md, CLAUDE.md (conventions auth).
@@ -40,6 +41,25 @@ function emailDomain(email: string): string {
 // (risque d'open-redirect). On utilise la variable d'env publique, sinon le défaut dev.
 function origin(): string {
   return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3001'
+}
+
+// Retry-After (secondes) renvoyé quand c'est Supabase (et non notre limiteur Upstash) qui
+// rate-limite : l'AuthApiError n'expose pas de délai fiable, on retombe sur une minute.
+const SUPABASE_RATE_LIMIT_RETRY_SECONDS = 60
+
+// L'erreur de signInWithOtp est-elle un rate-limit côté Supabase (GoTrue) ? On reconnaît :
+//   - le code HTTP 429 (AuthApiError.status) ;
+//   - le code GoTrue `over_email_send_rate_limit` (AuthApiError.code) ;
+//   - à défaut, un message contenant « rate limit » (filet de sécurité, versions plus anciennes).
+// Objectif : ne plus masquer un 429 derrière le 502 générique « échec d'envoi » (incident prod).
+function isSupabaseRateLimit(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const e = error as { status?: unknown; code?: unknown; message?: unknown }
+  if (e.status === 429) return true
+  if (typeof e.code === 'string' && /rate.?limit|over_email_send_rate_limit/i.test(e.code)) {
+    return true
+  }
+  return typeof e.message === 'string' && /rate.?limit|over_email_send_rate_limit/i.test(e.message)
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
@@ -105,6 +125,12 @@ export async function POST(request: Request): Promise<NextResponse> {
       tags: { endpoint: '/api/auth/magic-link', step: 'signInWithOtp' },
       extra: { email_domain: emailDomain(email) },
     })
+    // Rate-limit Supabase (429 / over_email_send_rate_limit) : on renvoie le MÊME 429 que notre
+    // limiteur Upstash plutôt qu'un 502 trompeur — sinon un dépassement de quota d'envoi (Supabase
+    // ou Brevo) est indistinguable d'une vraie panne SMTP (cf. incident prod).
+    if (isSupabaseRateLimit(otpError)) {
+      return rateLimitedResponse(SUPABASE_RATE_LIMIT_RETRY_SECONDS)
+    }
     return NextResponse.json({ error: "Impossible d'envoyer le lien." }, { status: 502 })
   }
 

--- a/apps/web/playwright/input-min-fontsize.spec.ts
+++ b/apps/web/playwright/input-min-fontsize.spec.ts
@@ -7,26 +7,31 @@
  * (`text-[16px] md:text-[14px]` — 16px sous md, 14px à partir de md où le zoom ne s'applique
  * pas). L'atome Input applique déjà ce pattern (packages/ui/src/atoms/Input/Input.tsx:11-12).
  *
- * Cette spec scanne les routes au VIEWPORT MOBILE (390×844, iPhone-ish), sélectionne tous les
- * champs de saisie VISIBLES et activables (input texte, textarea, select), calcule leur
+ * Cette spec scanne au VIEWPORT MOBILE (390×844, iPhone-ish) une LISTE de routes (publiques +
+ * authentifiées membre + une route admin) ET le textarea du widget Feedback : elle sélectionne
+ * tous les champs de saisie VISIBLES et activables (input texte, textarea, select), calcule leur
  * `font-size` effectif et REMONTE tout champ < 16px, avec un message verbeux (tag/id/name/
- * classes/px calculés) pour guider la correction. Chaque NOUVEL input introduit est ainsi
- * vérifié automatiquement.
+ * classes/px calculés) pour guider la correction. La garantie n'est donc PAS « tout input
+ * partout », mais « tout champ visible sur les routes listées + le FeedbackSheet ». Un nouvel
+ * input sur une route non listée n'est couvert que si on ajoute la route ici.
  *
  * Le widget Feedback (textarea derrière l'icône « Retour » de l'AppTopbar) n'est PAS dans le
- * DOM au chargement : on l'OUVRE explicitement sur les routes authentifiées avant de scanner,
- * pour couvrir le textarea du FeedbackSheet.
+ * DOM au chargement : on l'OUVRE explicitement sur une route authentifiée avant de scanner,
+ * pour couvrir le textarea du FeedbackSheet (c'était le cas du bug d'origine, `text-[14px]`).
  *
  * Stratégie d'auth : identique à cursor-pointer.spec.ts — `loginAsSeedMember` connecte le
- * membre seed et marque l'onboarding terminé. Exécution sérielle (workers:1).
+ * membre seed et marque l'onboarding terminé. Pour /admin/*, on élève le seed en 'treasurer'
+ * le temps de la suite (helper postgres `setSeedRole`, repris de cursor-pointer.spec.ts).
+ * Exécution sérielle (workers:1).
  *
  * Réf : CLAUDE.md (a11y AA, cibles tactiles, PWA), Input.tsx (pattern anti-zoom), helpers.ts,
- * cursor-pointer.spec.ts (structure de scan).
+ * cursor-pointer.spec.ts (structure de scan + élévation trésorier).
  */
 
 import { test, expect, type Page } from '@playwright/test'
+import postgres from 'postgres'
 
-import { loginAsSeedMember } from './helpers'
+import { loginAsSeedMember, SEED_EMAIL } from './helpers'
 
 // Viewport mobile « iPhone-ish » : c'est SOUS md (Tailwind md = 768px) que le zoom iOS
 // s'applique, donc c'est là qu'on vérifie le font-size effectif.
@@ -34,6 +39,10 @@ const MOBILE_VIEWPORT = { width: 390, height: 844 }
 
 // Seuil iOS : tout champ focusable < 16px déclenche le zoom auto.
 const MIN_FONT_SIZE_PX = 16
+
+// Élévation trésorier pour scanner /admin/* (pattern repris de cursor-pointer.spec.ts).
+const DB_URL = process.env.E2E_DB_URL ?? 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+const SEED_CLUB_ID = 'aaaaaaaa-0000-0000-0000-000000000001'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Sélecteur des champs de saisie concernés par le zoom iOS
@@ -133,6 +142,28 @@ async function assertNoFontSizeOffenders(page: Page, route: string): Promise<voi
   expect(offenders, offenders.length ? formatOffenders(offenders) : '').toEqual([])
 }
 
+/** Client postgres mono-connexion, fermé en fin d'appel. */
+async function withDb<T>(fn: (sql: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
+  const sql = postgres(DB_URL, { max: 1 })
+  try {
+    return await fn(sql)
+  } finally {
+    await sql.end()
+  }
+}
+
+/** Bascule le rôle du seed dans le club (par EMAIL → robuste au re-key user au login). */
+async function setSeedRole(role: 'member' | 'treasurer'): Promise<void> {
+  await withDb(async (sql) => {
+    await sql`
+      UPDATE memberships
+         SET role = ${role}::member_role
+       WHERE club_id = ${SEED_CLUB_ID}::uuid
+         AND user_id IN (SELECT id FROM users WHERE email = ${SEED_EMAIL})
+    `
+  })
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Bloc 1 — Routes PUBLIQUES (sans auth) — champs de saisie au repos
 // ─────────────────────────────────────────────────────────────────────────────
@@ -142,7 +173,9 @@ test.describe('font-size ≥16px (anti-zoom iOS) — routes publiques', () => {
 
   // /login : champ e-mail (atome Input). Les autres routes publiques peuvent ne porter aucun
   // champ ; le scan asserte alors trivialement 0 offender (non bruyant).
-  const PUBLIC_ROUTES = ['/', '/login', '/login/check-email', '/verifier']
+  // NB : /verifier est une route DYNAMIQUE (/verifier/[ref]) — le chemin nu rend un not-found et
+  // ne porte de toute façon aucun champ de saisie ; on ne la liste donc pas (scan inutile).
+  const PUBLIC_ROUTES = ['/', '/login', '/login/check-email']
 
   for (const route of PUBLIC_ROUTES) {
     test(`${route} → tous les champs visibles en font-size ≥16px`, async ({ page }) => {
@@ -185,8 +218,31 @@ test.describe('font-size ≥16px (anti-zoom iOS) — widget Feedback', () => {
 test.describe('font-size ≥16px (anti-zoom iOS) — routes authentifiées', () => {
   test.use({ viewport: MOBILE_VIEWPORT })
 
-  // Routes de l'espace membre susceptibles de porter des champs de saisie (profil = nom, etc.).
-  const AUTH_ROUTES = ['/dashboard', '/portfolio', '/contributions', '/profil']
+  // Le membre seed est élevé en 'treasurer' pour autoriser /admin/* ; remis à 'member' après.
+  test.beforeAll(async () => {
+    await setSeedRole('treasurer')
+  })
+
+  test.afterAll(async () => {
+    await setSeedRole('member')
+  })
+
+  // Routes de l'espace membre + une route admin portant un champ de saisie.
+  // NB : /profil est en LECTURE SEULE (un <dl> + l'avatar) — il ne porte aucun champ texte
+  //      (l'<input type=file> caché de l'avatar est exclu du sélecteur) → scan no-op, gardé en
+  //      filet pour capter une future régression.
+  //      /admin/invitations : au repos, on scanne l'input e-mail de l'InviteForm (atome Input,
+  //      déjà ≥16px). L'input « lien à copier » (readOnly mais focusable → zoom iOS si < 16px,
+  //      corrigé à 16px md:13px dans cette passe) n'apparaît qu'APRÈS création d'une invitation ;
+  //      il n'est donc scanné par cette route que si un lien est présent dans le DOM. La garantie
+  //      durable sur cet input vit dans le code (la classe corrigée), pas seulement dans ce scan.
+  const AUTH_ROUTES = [
+    '/dashboard',
+    '/portfolio',
+    '/contributions',
+    '/profil',
+    '/admin/invitations',
+  ]
 
   for (const route of AUTH_ROUTES) {
     test(`${route} → tous les champs visibles en font-size ≥16px`, async ({ page }) => {

--- a/apps/web/playwright/input-min-fontsize.spec.ts
+++ b/apps/web/playwright/input-min-fontsize.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests E2E — garde anti-zoom iOS sur les champs de formulaire.
+ *
+ * iOS Safari (et Chrome iOS) zoome AUTOMATIQUEMENT sur un champ de saisie focusé dont le
+ * `font-size` calculé est < 16px. Ce zoom intempestif casse la mise en page (notamment en
+ * PWA plein écran) et nuit à l'accessibilité. La parade standard : viser ≥ 16px sur mobile
+ * (`text-[16px] md:text-[14px]` — 16px sous md, 14px à partir de md où le zoom ne s'applique
+ * pas). L'atome Input applique déjà ce pattern (packages/ui/src/atoms/Input/Input.tsx:11-12).
+ *
+ * Cette spec scanne les routes au VIEWPORT MOBILE (390×844, iPhone-ish), sélectionne tous les
+ * champs de saisie VISIBLES et activables (input texte, textarea, select), calcule leur
+ * `font-size` effectif et REMONTE tout champ < 16px, avec un message verbeux (tag/id/name/
+ * classes/px calculés) pour guider la correction. Chaque NOUVEL input introduit est ainsi
+ * vérifié automatiquement.
+ *
+ * Le widget Feedback (textarea derrière l'icône « Retour » de l'AppTopbar) n'est PAS dans le
+ * DOM au chargement : on l'OUVRE explicitement sur les routes authentifiées avant de scanner,
+ * pour couvrir le textarea du FeedbackSheet.
+ *
+ * Stratégie d'auth : identique à cursor-pointer.spec.ts — `loginAsSeedMember` connecte le
+ * membre seed et marque l'onboarding terminé. Exécution sérielle (workers:1).
+ *
+ * Réf : CLAUDE.md (a11y AA, cibles tactiles, PWA), Input.tsx (pattern anti-zoom), helpers.ts,
+ * cursor-pointer.spec.ts (structure de scan).
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+import { loginAsSeedMember } from './helpers'
+
+// Viewport mobile « iPhone-ish » : c'est SOUS md (Tailwind md = 768px) que le zoom iOS
+// s'applique, donc c'est là qu'on vérifie le font-size effectif.
+const MOBILE_VIEWPORT = { width: 390, height: 844 }
+
+// Seuil iOS : tout champ focusable < 16px déclenche le zoom auto.
+const MIN_FONT_SIZE_PX = 16
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sélecteur des champs de saisie concernés par le zoom iOS
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// On cible les champs où l'utilisateur SAISIT du texte (donc focus → zoom potentiel) :
+//   - <input> de saisie (on exclut hidden/checkbox/radio/file/submit/button/reset : pas de
+//     zoom de saisie possible, ou non visibles) ;
+//   - <textarea> ;
+//   - <select> (iOS zoome aussi sur un select < 16px à l'ouverture du picker).
+// On exclut les désactivés et, au scan, les éléments masqués (offsetParent null / hidden).
+const FIELD_SELECTOR = [
+  'input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="submit"]):not([type="button"]):not([type="reset"]):not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+].join(', ')
+
+type Offender = {
+  route: string
+  tag: string
+  type: string | null
+  id: string | null
+  name: string | null
+  classes: string
+  fontSize: string
+  fontSizePx: number
+}
+
+/**
+ * Scanne la page courante et renvoie les champs visibles dont le `font-size` calculé est
+ * < 16px (zoom iOS au focus). Le détail (tag/type/id/name/classes/px) sert au diagnostic.
+ */
+async function findFontSizeOffenders(page: Page, route: string): Promise<Offender[]> {
+  const raw = await page.evaluate(
+    ({ selector, min }) => {
+      const out: Array<{
+        tag: string
+        type: string | null
+        id: string | null
+        name: string | null
+        classes: string
+        fontSize: string
+        fontSizePx: number
+      }> = []
+      const els = Array.from(document.querySelectorAll<HTMLElement>(selector))
+      for (const el of els) {
+        const style = getComputedStyle(el)
+        // Exclure les champs masqués (repliés / hors flux) → évite le bruit.
+        const hidden =
+          el.offsetParent === null || style.display === 'none' || style.visibility === 'hidden'
+        if (hidden) continue
+        const px = parseFloat(style.fontSize)
+        if (!Number.isFinite(px) || px >= min) continue
+        out.push({
+          tag: el.tagName.toLowerCase(),
+          type: el.getAttribute('type'),
+          id: el.getAttribute('id'),
+          name: el.getAttribute('name'),
+          classes: el.getAttribute('class') ?? '',
+          fontSize: style.fontSize,
+          fontSizePx: px,
+        })
+      }
+      return out
+    },
+    { selector: FIELD_SELECTOR, min: MIN_FONT_SIZE_PX }
+  )
+
+  return raw.map((r) => ({ route, ...r }))
+}
+
+/** Formate les offenders en message d'erreur verbeux, prêt à guider une correction. */
+function formatOffenders(offenders: Offender[]): string {
+  const lines = offenders.map((o, i) => {
+    const type = o.type ? ` type="${o.type}"` : ''
+    const id = o.id ? ` id="${o.id}"` : ''
+    const name = o.name ? ` name="${o.name}"` : ''
+    return [
+      `  [${i + 1}] <${o.tag}${type}${id}${name}>  font-size=${o.fontSize} (${o.fontSizePx}px)`,
+      `      route : ${o.route}`,
+      `      class : ${o.classes || '(aucune)'}`,
+    ].join('\n')
+  })
+  return (
+    `${offenders.length} champ(s) de saisie avec font-size < ${MIN_FONT_SIZE_PX}px ` +
+    `(zoom auto iOS au focus) :\n${lines.join('\n')}\n\n` +
+    `→ Corriger : viser ≥16px sur mobile, ex. \`text-[16px] md:text-[14px]\` ` +
+    `(cf. atome Input packages/ui/src/atoms/Input/Input.tsx:11-12).`
+  )
+}
+
+/** Charge la route, attend le réseau au repos, scanne, et asserte 0 offender. */
+async function assertNoFontSizeOffenders(page: Page, route: string): Promise<void> {
+  await page.goto(route)
+  await page.waitForLoadState('networkidle')
+  const offenders = await findFontSizeOffenders(page, route)
+  expect(offenders, offenders.length ? formatOffenders(offenders) : '').toEqual([])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bloc 1 — Routes PUBLIQUES (sans auth) — champs de saisie au repos
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('font-size ≥16px (anti-zoom iOS) — routes publiques', () => {
+  test.use({ viewport: MOBILE_VIEWPORT })
+
+  // /login : champ e-mail (atome Input). Les autres routes publiques peuvent ne porter aucun
+  // champ ; le scan asserte alors trivialement 0 offender (non bruyant).
+  const PUBLIC_ROUTES = ['/', '/login', '/login/check-email', '/verifier']
+
+  for (const route of PUBLIC_ROUTES) {
+    test(`${route} → tous les champs visibles en font-size ≥16px`, async ({ page }) => {
+      await assertNoFontSizeOffenders(page, route)
+    })
+  }
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bloc 2 — Widget Feedback (textarea derrière l'AppTopbar) — le cas du bug
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('font-size ≥16px (anti-zoom iOS) — widget Feedback', () => {
+  test.use({ viewport: MOBILE_VIEWPORT })
+
+  // Le textarea du FeedbackSheet n'est rendu QU'APRÈS ouverture du sheet (déclenché par
+  // l'icône « Retour »/« Feedback » de l'AppTopbar). On se connecte, on ouvre le sheet,
+  // puis on scanne le dialog : c'est ce textarea qui portait `text-[14px]` (bug iOS).
+  test('le textarea du widget Feedback est en font-size ≥16px sur mobile', async ({ page }) => {
+    await loginAsSeedMember(page) // connecte + onboarding=true + charge /dashboard
+
+    // Ouvre le widget via l'icône AppTopbar (aria-label « Retour » FR / « Feedback » EN).
+    const trigger = page.getByRole('button', { name: /Retour|Feedback/ })
+    await trigger.first().click()
+
+    // Le textarea du sheet (label « Ton message » FR / « Your message » EN) doit être visible.
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('textbox').first().waitFor({ state: 'visible' })
+
+    const offenders = await findFontSizeOffenders(page, '/dashboard (FeedbackSheet ouvert)')
+    expect(offenders, offenders.length ? formatOffenders(offenders) : '').toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bloc 3 — Routes AUTHENTIFIÉES — champs au repos (profil, etc.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('font-size ≥16px (anti-zoom iOS) — routes authentifiées', () => {
+  test.use({ viewport: MOBILE_VIEWPORT })
+
+  // Routes de l'espace membre susceptibles de porter des champs de saisie (profil = nom, etc.).
+  const AUTH_ROUTES = ['/dashboard', '/portfolio', '/contributions', '/profil']
+
+  for (const route of AUTH_ROUTES) {
+    test(`${route} → tous les champs visibles en font-size ≥16px`, async ({ page }) => {
+      await loginAsSeedMember(page)
+      await assertNoFontSizeOffenders(page, route)
+    })
+  }
+})

--- a/docs/qa/RGAA.md
+++ b/docs/qa/RGAA.md
@@ -19,6 +19,7 @@
 10. **Curseur (RGAA 3.3 / UX)** : tout élément interactif affiche `cursor: pointer` (et `disabled` → `not-allowed`).
     - Couvert globalement par la règle `@layer base` du design-system (`packages/design-system/styles/index.css`) ; ne jamais surcharger avec un `cursor` en dur (cf. #R-035, régression preflight Tailwind v4).
     - Tout cliquable custom (`div`/`span` avec `onClick`) doit aussi porter `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Espace).
+11. **Font-size ≥16px sur tout `input`/`textarea`/`select`** (anti-zoom iOS) : iOS Safari/Chrome zoome automatiquement sur un champ focusé dont le `font-size` calculé est < 16px. Viser ≥16px sur mobile, ex. `text-[16px] md:text-[14px]` (cf. atome `Input` / `TextArea`). À vérifier sur chaque NOUVEAU champ de saisie introduit.
 
 ## Outils
 
@@ -26,6 +27,7 @@
   (`new AxeBuilder({ page }).withTags(['wcag2a','wcag2aa','wcag21a','wcag21aa'])`). **Violations bloquantes = `critical`/`serious`**.
 - **Lighthouse CI** : config existante (pages publiques) — viser score a11y ≥ 90.
 - **Curseur** : `apps/web/playwright/cursor-pointer.spec.ts` scanne les routes et échoue (message verbeux) si un cliquable n'a pas `cursor: pointer` (cf. #R-035). Lancer : `pnpm --filter @evolve/web exec playwright test cursor-pointer.spec.ts --workers=1`.
+- **Font-size ≥16px** (anti-zoom iOS) : `apps/web/playwright/input-min-fontsize.spec.ts` scanne les routes au viewport mobile (390×844), ouvre le widget Feedback, et échoue (message verbeux : tag/id/name/classes/px) si un `input`/`textarea`/`select` visible a un `font-size` calculé < 16px. Lancer : `pnpm --filter @evolve/web exec playwright test input-min-fontsize.spec.ts --workers=1`.
 
 ## Critères par écran (référence FLOWS.md)
 

--- a/packages/ui/src/atoms/AvatarUpload/AvatarUpload.tsx
+++ b/packages/ui/src/atoms/AvatarUpload/AvatarUpload.tsx
@@ -62,7 +62,9 @@ export function AvatarUpload({
         onDrop={onDrop}
         aria-label={uploadAriaLabel}
         className={cn(
-          'relative grid h-[120px] w-[120px] place-items-center overflow-hidden rounded-full',
+          // Responsive : 88px sur mobile (laisse respirer le nom à côté sur les fiches denses),
+          // 120px dès `sm`. `shrink-0` garantit que l'avatar ne se déforme jamais en flex-row.
+          'relative grid h-[88px] w-[88px] shrink-0 place-items-center overflow-hidden rounded-full sm:h-[120px] sm:w-[120px]',
           'border-2 border-dashed border-border text-text-ter',
           'transition-colors duration-[150ms]',
           'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]',

--- a/packages/ui/src/atoms/AvatarUpload/AvatarUpload.tsx
+++ b/packages/ui/src/atoms/AvatarUpload/AvatarUpload.tsx
@@ -50,7 +50,9 @@ export function AvatarUpload({
   }
 
   return (
-    <div className={cn('flex flex-col items-center gap-2', className)}>
+    // `shrink-0` sur le wrapper racine (le vrai enfant flex d'une fiche en flex-row) :
+    // c'est lui qui garantit que la colonne avatar ne se comprime jamais à côté du nom.
+    <div className={cn('flex shrink-0 flex-col items-center gap-2', className)}>
       <button
         type="button"
         onClick={() => inputRef.current?.click()}
@@ -63,7 +65,8 @@ export function AvatarUpload({
         aria-label={uploadAriaLabel}
         className={cn(
           // Responsive : 88px sur mobile (laisse respirer le nom à côté sur les fiches denses),
-          // 120px dès `sm`. `shrink-0` garantit que l'avatar ne se déforme jamais en flex-row.
+          // 120px dès `sm`. `shrink-0` ici est une ceinture de sécurité ; la garantie flex-row
+          // vit sur le wrapper racine (vrai enfant flex de la fiche).
           'relative grid h-[88px] w-[88px] shrink-0 place-items-center overflow-hidden rounded-full sm:h-[120px] sm:w-[120px]',
           'border-2 border-dashed border-border text-text-ter',
           'transition-colors duration-[150ms]',

--- a/packages/ui/src/atoms/TextArea/TextArea.tsx
+++ b/packages/ui/src/atoms/TextArea/TextArea.tsx
@@ -8,7 +8,8 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     <textarea
       ref={ref}
       className={cn(
-        'w-full min-h-[80px] rounded-[10px] border border-border bg-card px-3 py-2 text-[14px] text-text placeholder:text-text-ter',
+        // text-[16px] sur mobile : empêche le zoom auto iOS Safari/Chrome au focus (< 16px) ; 14px ≥ md.
+        'w-full min-h-[80px] rounded-[10px] border border-border bg-card px-3 py-2 text-[16px] text-text placeholder:text-text-ter md:text-[14px]',
         'transition-shadow duration-[150ms] focus:outline-none focus-visible:shadow-[var(--sh-glow)] resize-y',
         'aria-[invalid=true]:border-data-negative',
         'disabled:opacity-40 disabled:cursor-not-allowed',

--- a/packages/ui/src/organisms/FeedbackSheet/FeedbackSheet.tsx
+++ b/packages/ui/src/organisms/FeedbackSheet/FeedbackSheet.tsx
@@ -483,7 +483,8 @@ function FormView({
           className={cn(
             'mt-2 block w-full resize-y rounded-[var(--r-md)] p-3',
             hasImages ? 'min-h-[72px]' : 'min-h-[120px]',
-            'border border-border-strong bg-card-sub text-[14px] text-text placeholder:text-text-ter',
+            // text-[16px] sur mobile : empêche le zoom auto iOS Safari/Chrome au focus (< 16px) ; 14px ≥ md.
+            'border border-border-strong bg-card-sub text-[16px] text-text placeholder:text-text-ter md:text-[14px]',
             'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]'
           )}
         />

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -441,6 +441,30 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Edge Functions — verify_jwt ÉPINGLÉ (durabilité post-incident prod 2026-06)
+# ─────────────────────────────────────────────────────────────────────────────
+# Le défaut de `supabase functions deploy` est verify_jwt = true. Un redeploy CLI
+# qui ne précise pas ces blocs RÉINITIALISE verify_jwt à true et casse les deux
+# fonctions ci-dessous, qui ne sont PAS appelées avec un JWT Supabase. Ces blocs
+# rendent le réglage explicite et reproductible (plus de --no-verify-jwt à ne pas
+# oublier à la main).
+
+[functions.send-email]
+# Auth Hook « Send Email » : appelé par GoTrue, authentifié par SIGNATURE HMAC
+# (standardwebhooks / SEND_EMAIL_HOOK_SECRET), PAS par un JWT Supabase.
+# verify_jwt DOIT rester false, sinon le gateway rejette l'appel de GoTrue
+# (« Hook requires authorization token » → 500, magic link KO). Un redeploy CLI
+# sans cette ligne réinitialise verify_jwt=true et casse l'envoi du lien.
+verify_jwt = false
+
+[functions.feedback-dispatch]
+# Appelée par le trigger Postgres feedback_after_insert (pg_net), authentifiée par
+# le Bearer service-role (== SUPABASE_SERVICE_ROLE_KEY, vérifié dans la fonction).
+# verify_jwt DOIT rester false (le gateway ne peut pas valider une clé sb_secret
+# non-JWT) sinon le trigger reçoit 401 et aucun retour n'est distribué.
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
## Contexte

Correctifs **post-déploiement** suite à des retours de test réel (mobile/PWA). 4 problèmes traités en mode orchestrateur (implémenteurs + reviewers croisés, boucle dev→test→QA→fix).

## Corrigé dans cette PR (code)

- **T1 — zoom iOS sur le feedback** : la textarea du `FeedbackSheet` et l'atome `TextArea` passent à `text-[16px] md:text-[14px]` (anti-zoom iOS Safari/PWA, < 16px déclenche le zoom au focus). Nouveau garde E2E **`input-min-fontsize.spec.ts`** (scanne les routes à viewport mobile, échoue si un `input`/`textarea`/`select` visible est < 16px) + doc `qa-a11y` / `RGAA.md`. _Bonus_ : l'input « lien d'invitation » de `/admin/invitations` (repéré en review) repassé à 16px et couvert par le garde.
- **T3 — nom de profil tronqué derrière l'avatar** : suppression de `truncate` (le nom complet s'enroule), avatar responsive 88→120px, `shrink-0` sur le wrapper racine. Lisible en light/dark, mobile.
- **T4 — durcissement de la route magic link** : `/api/auth/magic-link` distingue désormais un **rate-limit (429 « réessaie dans quelques minutes »)** d'un échec d'envoi générique (avant : tout collapsait en « Impossible d'envoyer le lien »).
- **Durabilité (T2 + T4)** : **`verify_jwt = false` épinglé dans `supabase/config.toml`** pour `send-email` et `feedback-dispatch` — empêche la régression au prochain `supabase functions deploy` (c'est précisément ce qui avait cassé la prod).

## Déjà appliqué en PROD (config — hors diff)

> Ces deux bugs étaient de la **config prod**, pas du code. Corrigés en live (autorisé par l'owner) et vérifiés :

- `send-email` `verify_jwt=false` → **magic link réparé** (`signInWithOtp` renvoie 200, était 500 « Hook requires authorization token »).
- `feedback-dispatch` `verify_jwt=false` + Vault `service_role_key` réaligné sur la clé **`sb_secret`** → **dispatch réparé**, vérifié end-to-end (Discord + GitHub #40 + Notion + Brevo). Le retour bug perdu a été redistribué.

## Cause racine

Les deux fonctions sont appelées par de l'**infra** (hook GoTrue signé HMAC ; trigger `pg_net` avec Bearer service-role), **pas par un navigateur**. `verify_jwt=true` (réinitialisé à sa valeur par défaut lors d'un redeploy CLI) faisait rejeter ces appels par le gateway. En plus, après la migration des clés API Supabase, l'env injecte `SUPABASE_SERVICE_ROLE_KEY = sb_secret…` alors que le Vault contenait l'ancien JWT legacy → 401.

## Tests (gate vert)

- `typecheck` + `lint` verts (`@evolve/ui`, `@evolve/web`).
- `@evolve/ui` : **469** tests verts. Route magic-link : **7/7** (dont 2 nouveaux cas 429).
- Playwright : `input-min-fontsize.spec.ts` **9/9** (dont `/admin/invitations`), `cursor-pointer.spec.ts` **13/13** (pas de régression).

## Suivis owner (non bloquants)

1. **Rotater** les clés exposées en clair dans `supabase/functions/.env` (PAT, `ghp_`, OpenAI, Notion, Anthropic).
2. `rate_limit_email_sent = 2`/h trop bas pour la prod → ~10–30.
3. `GITHUB_REPO` pointe sur le repo `…github.io` (les issues feedback y atterrissent).
4. Fonction `sync` : ses appels `net` **time-out (>5s)** tous les 2h — séparé de ces bugs, à investiguer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
