### PR TITLE
feat(web): couverture Sentry ~20% → ≥75% — routes, boundaries, React Query, edge

### DIFF
--- a/apps/web/app/(app)/admin/actions.ts
+++ b/apps/web/app/(app)/admin/actions.ts
@@ -14,6 +14,7 @@ import { resolveAdminContext } from '@/lib/data/admin'
 import { buildUpdateArgs, validateInput, type ClubSettingsInput } from '@/lib/data/clubSettings'
 import { getInvitationMailer } from '@/lib/invitations/mailer'
 import { newInviteToken, hashInviteToken, inviteUrl } from '@/lib/invitations/token'
+import { captureActionError } from '@/lib/monitoring/sentry'
 
 /** Résultat sans payload (lock/unlock/revoke). */
 export type ActionResult = { ok: true } | { ok: false; error: string }
@@ -39,6 +40,20 @@ function mapPgError(code: string | undefined): string {
   if (code === '22023') return 'invalid' // invalid_parameter_value : email/pays/plafond invalide
   if (code === 'P0002') return 'not_member' // B5 : RAISE « email hors club » (migration 031)
   return 'unknown'
+}
+
+/**
+ * Capture une erreur Supabase inattendue (code PG non mappé → 'unknown').
+ * Les erreurs métier connues (duplicate/forbidden/invalid/not_member) ne sont pas des bugs.
+ */
+function captureIfUnknown(
+  error: { code?: string; message?: string } | null | undefined,
+  action: string,
+  userId?: string
+): void {
+  if (!error) return
+  if (mapPgError(error.code) !== 'unknown') return
+  captureActionError(error, { action, userId, extra: { code: error.code, message: error.message } })
 }
 
 /**
@@ -80,7 +95,10 @@ export async function createInvitationAction(rawEmail: string): Promise<Invitati
     p_email: email,
     p_token_hash: hashInviteToken(token),
   })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'createInvitation', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
 
   const link = inviteUrl(token)
   const delivered = await tryDeliverInvitation(email, link)
@@ -102,7 +120,10 @@ export async function resendInvitationAction(
     p_invitation_id: invitationId,
     p_token_hash: hashInviteToken(token),
   })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'resendInvitation', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
 
   const link = inviteUrl(token)
   // L'email du destinataire n'est pas renvoyé par la RPC resend ; en V0 le mailer est no-op de
@@ -120,7 +141,10 @@ export async function revokeInvitationAction(invitationId: string): Promise<Acti
   if (!user) return { ok: false, error: 'unauthorized' }
 
   const { error } = await supabase.rpc('admin_revoke_invitation', { p_invitation_id: invitationId })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'revokeInvitation', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
   return { ok: true }
 }
 
@@ -140,7 +164,10 @@ export async function lockMemberAction(
     p_locked: true,
     p_reason: reason && reason.trim().length > 0 ? reason.trim() : undefined,
   })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'lockMember', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
   return { ok: true }
 }
 
@@ -157,7 +184,10 @@ export async function unlockMemberAction(membershipId: string): Promise<ActionRe
     p_locked: false,
     p_reason: undefined,
   })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'unlockMember', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
   return { ok: true }
 }
 
@@ -182,7 +212,10 @@ export async function updateClubSettingsAction(input: ClubSettingsInput): Promis
   }
 
   const { error } = await supabase.rpc('update_club_settings', buildUpdateArgs(ctx.clubId, input))
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'updateClubSettings', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
   return { ok: true }
 }
 
@@ -210,6 +243,9 @@ export async function updateMemberEmailAction(
     p_membership_id: membershipId,
     p_email: email,
   })
-  if (error) return { ok: false, error: mapPgError(error.code) }
+  if (error) {
+    captureIfUnknown(error, 'updateMemberEmail', user.id)
+    return { ok: false, error: mapPgError(error.code) }
+  }
   return { ok: true }
 }

--- a/apps/web/app/(app)/admin/cotisations/error.tsx
+++ b/apps/web/app/(app)/admin/cotisations/error.tsx
@@ -1,11 +1,21 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
-export default function AdminCotisationsError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function AdminCotisationsError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="admin/cotisations" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.admin.cotisations.title')}
       </h2>

--- a/apps/web/app/(app)/admin/error.tsx
+++ b/apps/web/app/(app)/admin/error.tsx
@@ -1,11 +1,15 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
-export default function AdminError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function AdminError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="admin" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.admin.dashboard.title')}
       </h2>

--- a/apps/web/app/(app)/admin/invitations/error.tsx
+++ b/apps/web/app/(app)/admin/invitations/error.tsx
@@ -1,11 +1,21 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
-export default function AdminInvitationsError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function AdminInvitationsError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="admin/invitations" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.admin.invitations.title')}
       </h2>

--- a/apps/web/app/(app)/admin/members/error.tsx
+++ b/apps/web/app/(app)/admin/members/error.tsx
@@ -1,11 +1,15 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
-export default function AdminMembersError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function AdminMembersError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="admin/members" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.admin.members.title')}
       </h2>

--- a/apps/web/app/(app)/admin/newsletter/page.tsx
+++ b/apps/web/app/(app)/admin/newsletter/page.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs'
 import type { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import { listNewsletters, type NewsletterSummary } from '@/lib/strapi-editorial'
@@ -26,6 +27,9 @@ export default async function AdminNewsletterPage() {
     editions = await listNewsletters()
   } catch (err) {
     // Log serveur pour diagnostic (env STRAPI manquante, CMS down, 4xx…) ; l'UI reste tolérante.
+    Sentry.captureException(err, {
+      tags: { endpoint: 'admin/newsletter' },
+    })
     console.error('[newsletter] échec du chargement des éditions depuis le CMS :', err)
     loadError = true
   }

--- a/apps/web/app/(app)/admin/settings/error.tsx
+++ b/apps/web/app/(app)/admin/settings/error.tsx
@@ -1,11 +1,15 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
-export default function AdminSettingsError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function AdminSettingsError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="admin/settings" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.admin.settings.title')}
       </h2>

--- a/apps/web/app/(app)/contributions/error.tsx
+++ b/apps/web/app/(app)/contributions/error.tsx
@@ -3,11 +3,14 @@ import { useTranslations } from 'next-intl'
 
 import { Button } from '@evolve/ui'
 
-export default function ContributionsError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function ContributionsError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations('errors.contributions')
   const tc = useTranslations('common')
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="contributions" />
       <h2 className="font-display font-bold text-[18px] text-text">{t('title')}</h2>
       <p className="text-[14px] text-text-sec">{tc('dataSafe')}</p>
       <Button onClick={() => reset()}>{tc('retry')}</Button>

--- a/apps/web/app/(app)/dashboard/error.tsx
+++ b/apps/web/app/(app)/dashboard/error.tsx
@@ -3,10 +3,13 @@ import { useTranslations } from 'next-intl'
 
 import { Button } from '@evolve/ui'
 
-export default function DashboardError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function DashboardError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="dashboard" />
       <h2 className="font-display font-bold text-[18px] text-text">
         {t('errors.dashboard.title')}
       </h2>

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs'
 import { cookies } from 'next/headers'
 import { createServerClient } from '@evolve/data'
 import { getDashboardData } from '@/lib/data/dashboard'
@@ -44,6 +45,10 @@ export default async function DashboardPage() {
       })
     } catch (error) {
       // Log serveur uniquement (jamais à l'écran) — fallback demo assuré par chartData=null.
+      Sentry.captureException(error, {
+        level: 'warning',
+        tags: { endpoint: 'dashboard/chart' },
+      })
       console.error('[dashboard] getDashboardChartData a échoué — fallback demo :', error)
     }
   }

--- a/apps/web/app/(app)/portfolio/error.tsx
+++ b/apps/web/app/(app)/portfolio/error.tsx
@@ -3,11 +3,14 @@ import { useTranslations } from 'next-intl'
 
 import { Button } from '@evolve/ui'
 
-export default function PortfolioError({ reset }: { error: Error; reset: () => void }) {
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
+export default function PortfolioError({ error, reset }: { error: Error; reset: () => void }) {
   const t = useTranslations('errors.portfolio')
   const tCommon = useTranslations('common')
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="portfolio" />
       <h2 className="font-display font-bold text-[18px] text-text">{t('title')}</h2>
       <p className="text-[14px] text-text-sec">{tCommon('dataSafe')}</p>
       <Button onClick={() => reset()}>{tCommon('retry')}</Button>

--- a/apps/web/app/(auth)/error.tsx
+++ b/apps/web/app/(auth)/error.tsx
@@ -1,8 +1,12 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
 export default function AuthError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string }
@@ -11,6 +15,7 @@ export default function AuthError({
   const t = useTranslations()
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="auth" />
       <h2 className="font-display font-bold text-[18px] text-text">{t('errors.auth.title')}</h2>
       <p className="text-[14px] text-text-sec">{t('errors.auth.body')}</p>
       <Button onClick={() => reset()}>{t('common.retry')}</Button>

--- a/apps/web/app/(auth)/onboarding/error.tsx
+++ b/apps/web/app/(auth)/onboarding/error.tsx
@@ -1,8 +1,12 @@
 'use client'
 import { useTranslations } from 'next-intl'
+
 import { Button } from '@evolve/ui'
 
+import { RouteErrorReporter } from '@/components/RouteErrorReporter'
+
 export default function OnboardingError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string }
@@ -13,6 +17,7 @@ export default function OnboardingError({
 
   return (
     <div className="mx-auto w-full max-w-md px-4 py-16 text-center flex flex-col items-center gap-4">
+      <RouteErrorReporter error={error} routeSegment="onboarding" />
       <h2 className="font-display font-bold text-[18px] text-text">{t('title')}</h2>
       <p className="text-[14px] text-text-sec">{t('body')}</p>
       <Button onClick={() => reset()}>{tCommon('retry')}</Button>

--- a/apps/web/app/acces-suspendu/actions.ts
+++ b/apps/web/app/acces-suspendu/actions.ts
@@ -7,9 +7,18 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { createServerClient } from '@evolve/data'
+import { captureActionError } from '@/lib/monitoring/sentry'
 
 export async function signOutAction(): Promise<void> {
   const supabase = createServerClient(await cookies())
-  await supabase.auth.signOut()
+  try {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      captureActionError(error, { action: 'signOut', extra: { code: error.code } })
+    }
+  } catch (err) {
+    captureActionError(err, { action: 'signOut' })
+  }
+  // Redirection inconditionnelle : même en cas d'erreur signOut, on renvoie vers /login.
   redirect('/login')
 }

--- a/apps/web/app/api/admin/club-summary/route.ts
+++ b/apps/web/app/api/admin/club-summary/route.ts
@@ -6,6 +6,7 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 import { getClubSummary, isStaffRole, type ClubSummary } from '@/lib/data/admin'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -29,7 +30,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let data: ClubSummary
   try {
     data = await getClubSummary(supabase, clubId, role)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/admin/club-summary',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
   return NextResponse.json(data, { headers: { 'Cache-Control': 'private, no-store' } })

--- a/apps/web/app/api/admin/contributions/route.ts
+++ b/apps/web/app/api/admin/contributions/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 import { getClubContributionsTimeline, isStaffRole } from '@/lib/data/admin'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -33,7 +34,12 @@ export async function GET(request: Request): Promise<NextResponse> {
       { clubId, years: timeline.years, stats: timeline.stats },
       { headers: { 'Cache-Control': 'private, no-store' } }
     )
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/admin/contributions',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
 }

--- a/apps/web/app/api/admin/invitations/route.ts
+++ b/apps/web/app/api/admin/invitations/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 import { isStaffRole } from '@/lib/data/admin'
 import { listClubInvitations, type Invitation } from '@/lib/data/invitations'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -30,7 +31,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let invitations: Invitation[]
   try {
     invitations = await listClubInvitations(supabase, clubId)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/admin/invitations',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
   return NextResponse.json(

--- a/apps/web/app/api/admin/members/route.ts
+++ b/apps/web/app/api/admin/members/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 import { getClubMembers, isStaffRole, type ClubMember } from '@/lib/data/admin'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -28,7 +29,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let members: ClubMember[]
   try {
     members = await getClubMembers(supabase, clubId)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/admin/members',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
   return NextResponse.json(

--- a/apps/web/app/api/auth/handoff-link/route.ts
+++ b/apps/web/app/api/auth/handoff-link/route.ts
@@ -26,6 +26,7 @@ import { createServerClient, createServiceRoleClient } from '@evolve/data'
 
 import { siteOrigin } from '@/lib/invitations/token'
 import { checkRateLimit, rateLimitedResponse } from '@/lib/rate-limit'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -58,6 +59,11 @@ export async function POST(): Promise<NextResponse> {
   if (error || !hashed) {
     // Log server-only — on ne fuite jamais le détail au client (credential / surface d'attaque).
     console.error('handoff-link: échec generateLink', error?.message ?? 'hashed_token absent')
+    captureRouteError(error ?? new Error('mint_failed'), {
+      endpoint: '/api/auth/handoff-link',
+      userId: user.id,
+      extra: { reason: error?.message ?? 'hashed_token absent' },
+    })
     return NextResponse.json({ error: 'mint_failed' }, { status: 500 })
   }
 

--- a/apps/web/app/api/contributions/route.ts
+++ b/apps/web/app/api/contributions/route.ts
@@ -15,6 +15,7 @@ import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 
 import { getContributionsData, type ContributionsData } from '@/lib/data/contributions'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -50,7 +51,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let data: ContributionsData | null
   try {
     data = await getContributionsData(supabase, auth.user.id, clubId)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/contributions',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
   if (!data) {

--- a/apps/web/app/api/dashboard/route.ts
+++ b/apps/web/app/api/dashboard/route.ts
@@ -15,6 +15,7 @@ import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 
 import { getDashboardData } from '@/lib/data/dashboard'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -50,7 +51,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let data
   try {
     data = await getDashboardData(supabase, auth.user.id, clubId)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/dashboard',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
   if (!data) {

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -19,6 +19,7 @@
 import { NextResponse } from 'next/server'
 
 import { createServerClient } from '@evolve/data'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -64,6 +65,7 @@ export async function GET(): Promise<NextResponse> {
     )
   } catch (e) {
     // Jamais de stack ni de secret dans la réponse — message court uniquement.
+    captureRouteError(e, { endpoint: '/api/health' })
     const message = e instanceof Error ? e.message : 'Erreur inconnue.'
     return NextResponse.json(
       { status: 'down', error: message },

--- a/apps/web/app/api/market-prices/route.ts
+++ b/apps/web/app/api/market-prices/route.ts
@@ -8,6 +8,7 @@ import { createServerClient } from '@evolve/data'
 import { getPricesWithFallback } from '@evolve/data/prices'
 
 import { checkRateLimit, rateLimitedResponse } from '@/lib/rate-limit'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -53,6 +54,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   } catch (err) {
     // Défensif : on ne casse jamais le portefeuille pour un échec de cours.
     console.error('[market-prices] erreur provider:', err)
+    captureRouteError(err, { endpoint: '/api/market-prices', extra: { symbols } })
     return NextResponse.json(
       { prices: Object.fromEntries(symbols.map((s) => [s, null])) },
       { status: 200 }

--- a/apps/web/app/api/newsletter/preview/route.ts
+++ b/apps/web/app/api/newsletter/preview/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server'
 import { getNewsletterBySlug } from '@/lib/strapi-editorial'
 import { guardStaff } from '../_guard'
 import { renderNewsletterHtml } from '../_render'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -21,7 +22,8 @@ export async function GET(request: Request): Promise<Response> {
     const article = await getNewsletterBySlug(slug)
     if (!article) return NextResponse.json({ error: 'Édition introuvable.' }, { status: 404 })
     html = await renderNewsletterHtml(article)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, { endpoint: '/api/newsletter/preview', extra: { slug } })
     return NextResponse.json({ error: "Erreur de rendu de l'aperçu." }, { status: 500 })
   }
 

--- a/apps/web/app/api/newsletter/send-test/route.ts
+++ b/apps/web/app/api/newsletter/send-test/route.ts
@@ -8,6 +8,7 @@ import { getNewsletterBySlug } from '@/lib/strapi-editorial'
 import { guardStaff } from '../_guard'
 import { renderNewsletterHtml, subjectFor } from '../_render'
 import { newsletterSender, testRecipients } from '../config'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -44,7 +45,8 @@ export async function POST(request: Request): Promise<NextResponse> {
       sender: newsletterSender(),
       to: recipients,
     })
-  } catch {
+  } catch (error) {
+    captureRouteError(error, { endpoint: '/api/newsletter/send-test' })
     return NextResponse.json({ error: "Échec de l'envoi du test." }, { status: 502 })
   }
 

--- a/apps/web/app/api/newsletter/send/route.ts
+++ b/apps/web/app/api/newsletter/send/route.ts
@@ -22,6 +22,7 @@ import { getNewsletterBySlug } from '@/lib/strapi-editorial'
 import { guardStaff } from '../_guard'
 import { renderNewsletterHtml, subjectFor } from '../_render'
 import { membersListId, newsletterSender } from '../config'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -83,7 +84,8 @@ export async function POST(request: Request): Promise<NextResponse> {
         { status: 409 }
       )
     }
-  } catch {
+  } catch (error) {
+    captureRouteError(error, { endpoint: '/api/newsletter/send', extra: { step: 'verify-brevo' } })
     return NextResponse.json({ error: 'Erreur de vérification Brevo.' }, { status: 502 })
   }
 
@@ -98,7 +100,8 @@ export async function POST(request: Request): Promise<NextResponse> {
     })
     await sendCampaignNow(campaign.id)
     return NextResponse.json({ ok: true, campaignId: campaign.id, name })
-  } catch {
+  } catch (error) {
+    captureRouteError(error, { endpoint: '/api/newsletter/send', extra: { step: 'send-campaign' } })
     return NextResponse.json({ error: "Échec de l'envoi de la campagne." }, { status: 502 })
   }
 }

--- a/apps/web/app/api/onboarding/profile/route.ts
+++ b/apps/web/app/api/onboarding/profile/route.ts
@@ -13,6 +13,7 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import * as Sentry from '@sentry/nextjs'
 import { createServerClient } from '@evolve/data'
 
 export const runtime = 'nodejs'
@@ -83,7 +84,13 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (avatarUrl) update.avatar_url = avatarUrl
 
   const { error: updErr } = await supabase.from('users').update(update).eq('id', user.id)
-  if (updErr) return NextResponse.json({ error: "Échec de l'enregistrement." }, { status: 500 })
+  if (updErr) {
+    Sentry.captureException(updErr, {
+      tags: { endpoint: '/api/onboarding/profile' },
+      user: { id: user.id },
+    })
+    return NextResponse.json({ error: "Échec de l'enregistrement." }, { status: 500 })
+  }
 
   return NextResponse.json({ user_id: user.id, onboarding_completed: true })
 }

--- a/apps/web/app/api/portfolio/route.ts
+++ b/apps/web/app/api/portfolio/route.ts
@@ -21,6 +21,7 @@ import { NextResponse } from 'next/server'
 import { createServerClient } from '@evolve/data'
 
 import { getMemberRole, getPortfolioData, type PortfolioData } from '@/lib/data/portfolio'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 
 export const runtime = 'nodejs'
 
@@ -56,7 +57,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   let data: PortfolioData | null
   try {
     data = await getPortfolioData(supabase, auth.user.id, clubId)
-  } catch {
+  } catch (error) {
+    captureRouteError(error, {
+      endpoint: '/api/portfolio',
+      userId: auth.user.id,
+      extra: { club_id: clubId },
+    })
     return NextResponse.json({ error: 'Erreur de chargement.' }, { status: 500 })
   }
 

--- a/apps/web/app/api/sync/route.ts
+++ b/apps/web/app/api/sync/route.ts
@@ -15,6 +15,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { cookies } from 'next/headers'
+import { captureRouteError } from '@/lib/monitoring/sentry'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -116,6 +117,14 @@ export async function POST(request: Request): Promise<NextResponse> {
   const errors = toStringArray(invokeData?.errors)
   const warnings = toStringArray(invokeData?.warnings)
   const success = invokeData?.success === true && errors.length === 0
+
+  if (errors.length > 0) {
+    captureRouteError(new Error('Sync partial failure'), {
+      endpoint: '/api/sync',
+      userId: user.id,
+      extra: { club_id, errors, success: invokeData?.success ?? false },
+    })
+  }
 
   // 8. Relecture de la date de dernière sync (best-effort, ne bloque pas la réponse).
   const { data: club } = await supabase.from('clubs').select('synced_at').eq('id', club_id).single()

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,14 +1,21 @@
 'use client'
+import { useEffect } from 'react'
+
+import * as Sentry from '@sentry/nextjs'
 
 // Boundary racine : Next exige que global-error rende son propre <html>/<body>
 // car il remplace le root layout quand celui-ci a planté. On reste sobre et FR.
 // Aucune stack n'est affichée à l'utilisateur ; `error` est typé mais non rendu.
 export default function GlobalError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    Sentry.captureException(error)
+  }, [error])
   return (
     <html lang="fr">
       <body

--- a/apps/web/components/RouteErrorReporter.tsx
+++ b/apps/web/components/RouteErrorReporter.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { useEffect } from 'react'
+
+import * as Sentry from '@sentry/nextjs'
+
+interface Props {
+  error: Error & { digest?: string }
+  routeSegment?: string
+}
+
+export function RouteErrorReporter({ error, routeSegment }: Props) {
+  useEffect(() => {
+    Sentry.captureException(error, {
+      tags: { route_segment: routeSegment },
+    })
+  }, [error, routeSegment])
+
+  return null
+}

--- a/apps/web/components/providers/QueryProvider.tsx
+++ b/apps/web/components/providers/QueryProvider.tsx
@@ -1,13 +1,29 @@
 'use client'
 import { useState, type ReactNode } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
+import { captureClientError } from '@/lib/monitoring/sentry'
 
 export function QueryProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        queryCache: new QueryCache({
+          onError: (error, query) => {
+            // Ne pas capturer les 401 — gérés par le middleware auth (redirect vers /login)
+            if (error instanceof Error && error.message.includes('401')) return
+            captureClientError(error, {
+              source: 'react-query',
+              queryKey: query.queryKey,
+            })
+          },
+        }),
+        mutationCache: new MutationCache({
+          onError: (error) => {
+            captureClientError(error, { source: 'react-query-mutation' })
+          },
+        }),
         defaultOptions: { queries: { staleTime: 5 * 60 * 1000, refetchOnWindowFocus: true } },
       })
   )

--- a/apps/web/lib/feedback/actions.ts
+++ b/apps/web/lib/feedback/actions.ts
@@ -28,6 +28,7 @@ import { cookies } from 'next/headers'
 import { createServerClient } from '@evolve/data'
 import type { FeedbackSubmission } from '@evolve/ui'
 import { MAX_FEEDBACK_IMAGES } from '@evolve/ui'
+import { captureActionError } from '@/lib/monitoring/sentry'
 
 /** Résultat discriminé (jamais de throw) — l'UI mappe l'erreur sur un message i18n. */
 export type FeedbackActionResult = { ok: true } | { ok: false; error: string }
@@ -123,7 +124,14 @@ export async function submitFeedbackAction(
     // ai_* / github_issue_url / notion_page_id / discord_notified / email_sent / status :
     // laissés aux défauts DB — remplis par l'Edge Function feedback-dispatch (service_role).
   })
-  if (insertError) return { ok: false, error: 'insert_failed' }
+  if (insertError) {
+    captureActionError(insertError, {
+      action: 'submitFeedback',
+      userId: user.id,
+      extra: { step: 'insert', code: insertError.code },
+    })
+    return { ok: false, error: 'insert_failed' }
+  }
 
   return { ok: true }
 }

--- a/apps/web/lib/monitoring/sentry.test.ts
+++ b/apps/web/lib/monitoring/sentry.test.ts
@@ -26,7 +26,7 @@ describe('sentry monitoring helpers', () => {
       captureRouteError(err, { endpoint: '/api/sync' })
 
       expect(mocks.captureException).toHaveBeenCalledOnce()
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.tags).toEqual({ endpoint: '/api/sync' })
     })
 
@@ -34,14 +34,14 @@ describe('sentry monitoring helpers', () => {
       const err = new Error('unauthorized')
       captureRouteError(err, { endpoint: '/api/dashboard', userId: 'uuid-123' })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.user).toEqual({ id: 'uuid-123' })
     })
 
     it("n'inclut pas user si userId absent", () => {
       captureRouteError(new Error('nope'), { endpoint: '/api/health' })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.user).toBeUndefined()
     })
 
@@ -51,7 +51,7 @@ describe('sentry monitoring helpers', () => {
         extra: { club_id: 'club-42' },
       })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.extra).toEqual({ club_id: 'club-42' })
     })
 
@@ -64,7 +64,7 @@ describe('sentry monitoring helpers', () => {
       const err = new TypeError('type err')
       captureRouteError(err, { endpoint: '/api/portfolio' })
 
-      const [capturedErr] = mocks.captureException.mock.calls[0]
+      const [capturedErr] = mocks.captureException.mock.calls[0]!
       expect(capturedErr).toBe(err)
     })
   })
@@ -79,7 +79,7 @@ describe('sentry monitoring helpers', () => {
       captureActionError(err, { action: 'updateProfile' })
 
       expect(mocks.captureException).toHaveBeenCalledOnce()
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.tags).toEqual({ action: 'updateProfile' })
     })
 
@@ -89,14 +89,14 @@ describe('sentry monitoring helpers', () => {
         userId: 'uuid-456',
       })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.user).toEqual({ id: 'uuid-456' })
     })
 
     it("n'inclut pas user si userId absent", () => {
       captureActionError(new Error('nope'), { action: 'exportCSV' })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.user).toBeUndefined()
     })
 
@@ -106,7 +106,7 @@ describe('sentry monitoring helpers', () => {
         extra: { club_id: 'club-1' },
       })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.extra).toEqual({ club_id: 'club-1' })
     })
   })
@@ -121,7 +121,7 @@ describe('sentry monitoring helpers', () => {
       captureClientError(err, { source: 'usePortfolio' })
 
       expect(mocks.captureException).toHaveBeenCalledOnce()
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.tags).toEqual({ source: 'usePortfolio' })
     })
 
@@ -131,14 +131,14 @@ describe('sentry monitoring helpers', () => {
         queryKey: ['dashboard', 'club-1'],
       })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.extra).toMatchObject({ queryKey: ['dashboard', 'club-1'] })
     })
 
     it("n'inclut pas queryKey dans extra si undefined", () => {
       captureClientError(new Error('no key'), { source: 'useContributions' })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.extra).not.toHaveProperty('queryKey')
     })
 
@@ -154,7 +154,7 @@ describe('sentry monitoring helpers', () => {
         extra: { club_id: 'club-7' },
       })
 
-      const [, opts] = mocks.captureException.mock.calls[0]
+      const [, opts] = mocks.captureException.mock.calls[0]!
       expect(opts.extra).toEqual({ queryKey: ['portfolio'], club_id: 'club-7' })
     })
   })

--- a/apps/web/lib/monitoring/sentry.test.ts
+++ b/apps/web/lib/monitoring/sentry.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted garantit que le mock est en place avant l'import du module testé
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: mocks.captureException,
+}))
+
+import { captureRouteError, captureActionError, captureClientError } from './sentry'
+
+describe('sentry monitoring helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ---------------------------------------------------------------------------
+  // captureRouteError
+  // ---------------------------------------------------------------------------
+
+  describe('captureRouteError', () => {
+    it('appelle captureException avec le tag endpoint', () => {
+      const err = new Error('boom')
+      captureRouteError(err, { endpoint: '/api/sync' })
+
+      expect(mocks.captureException).toHaveBeenCalledOnce()
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.tags).toEqual({ endpoint: '/api/sync' })
+    })
+
+    it('inclut user.id si userId fourni', () => {
+      const err = new Error('unauthorized')
+      captureRouteError(err, { endpoint: '/api/dashboard', userId: 'uuid-123' })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.user).toEqual({ id: 'uuid-123' })
+    })
+
+    it("n'inclut pas user si userId absent", () => {
+      captureRouteError(new Error('nope'), { endpoint: '/api/health' })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.user).toBeUndefined()
+    })
+
+    it('transmet le champ extra si fourni', () => {
+      captureRouteError(new Error('extra'), {
+        endpoint: '/api/sync',
+        extra: { club_id: 'club-42' },
+      })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.extra).toEqual({ club_id: 'club-42' })
+    })
+
+    it('ne casse pas si error est une string', () => {
+      expect(() => captureRouteError('string error', { endpoint: '/api/foo' })).not.toThrow()
+      expect(mocks.captureException).toHaveBeenCalledOnce()
+    })
+
+    it("passe l'erreur comme premier argument a captureException", () => {
+      const err = new TypeError('type err')
+      captureRouteError(err, { endpoint: '/api/portfolio' })
+
+      const [capturedErr] = mocks.captureException.mock.calls[0]
+      expect(capturedErr).toBe(err)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // captureActionError
+  // ---------------------------------------------------------------------------
+
+  describe('captureActionError', () => {
+    it('appelle captureException avec le tag action', () => {
+      const err = new Error('db fail')
+      captureActionError(err, { action: 'updateProfile' })
+
+      expect(mocks.captureException).toHaveBeenCalledOnce()
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.tags).toEqual({ action: 'updateProfile' })
+    })
+
+    it('inclut user.id si userId fourni', () => {
+      captureActionError(new Error('action error'), {
+        action: 'suspendMember',
+        userId: 'uuid-456',
+      })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.user).toEqual({ id: 'uuid-456' })
+    })
+
+    it("n'inclut pas user si userId absent", () => {
+      captureActionError(new Error('nope'), { action: 'exportCSV' })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.user).toBeUndefined()
+    })
+
+    it('transmet le champ extra si fourni', () => {
+      captureActionError(new Error('extra'), {
+        action: 'inviteMember',
+        extra: { club_id: 'club-1' },
+      })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.extra).toEqual({ club_id: 'club-1' })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // captureClientError
+  // ---------------------------------------------------------------------------
+
+  describe('captureClientError', () => {
+    it('appelle captureException avec le tag source', () => {
+      const err = new Error('query fail')
+      captureClientError(err, { source: 'usePortfolio' })
+
+      expect(mocks.captureException).toHaveBeenCalledOnce()
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.tags).toEqual({ source: 'usePortfolio' })
+    })
+
+    it('inclut queryKey dans extra si fourni', () => {
+      captureClientError(new Error('rq err'), {
+        source: 'useDashboard',
+        queryKey: ['dashboard', 'club-1'],
+      })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.extra).toMatchObject({ queryKey: ['dashboard', 'club-1'] })
+    })
+
+    it("n'inclut pas queryKey dans extra si undefined", () => {
+      captureClientError(new Error('no key'), { source: 'useContributions' })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.extra).not.toHaveProperty('queryKey')
+    })
+
+    it('ne casse pas si error est null', () => {
+      expect(() => captureClientError(null, { source: 'useAdmin' })).not.toThrow()
+      expect(mocks.captureException).toHaveBeenCalledOnce()
+    })
+
+    it('fusionne queryKey et extra supplémentaire', () => {
+      captureClientError(new Error('merge'), {
+        source: 'usePortfolio',
+        queryKey: ['portfolio'],
+        extra: { club_id: 'club-7' },
+      })
+
+      const [, opts] = mocks.captureException.mock.calls[0]
+      expect(opts.extra).toEqual({ queryKey: ['portfolio'], club_id: 'club-7' })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Comportement SDK — pas de no-op conditionnel dans le helper
+  // ---------------------------------------------------------------------------
+
+  describe('comportement délégation SDK', () => {
+    it('chaque helper délègue systématiquement à captureException (pas de guard interne)', () => {
+      captureRouteError(new Error('r'), { endpoint: '/api/a' })
+      captureActionError(new Error('a'), { action: 'doSomething' })
+      captureClientError(new Error('c'), { source: 'useX' })
+
+      expect(mocks.captureException).toHaveBeenCalledTimes(3)
+    })
+
+    it("si captureException leve, le helper laisse l'erreur propager", () => {
+      mocks.captureException.mockImplementationOnce(() => {
+        throw new Error('SDK crash')
+      })
+
+      expect(() => captureRouteError(new Error('r'), { endpoint: '/api/b' })).toThrow('SDK crash')
+    })
+  })
+})

--- a/apps/web/lib/monitoring/sentry.ts
+++ b/apps/web/lib/monitoring/sentry.ts
@@ -1,0 +1,79 @@
+/**
+ * Helper centralisé Sentry pour apps/web.
+ *
+ * Règles RGPD :
+ *  - Seul user.id (UUID) est transmis — jamais d'email ni de PII.
+ *  - Pas de guard `if (dsn)` : le SDK est déjà no-op sans DSN via `enabled: Boolean(dsn)`.
+ */
+
+import * as Sentry from '@sentry/nextjs'
+
+// ---------------------------------------------------------------------------
+// Types de contexte
+// ---------------------------------------------------------------------------
+
+export interface RouteErrorContext {
+  endpoint: string
+  userId?: string
+  extra?: Record<string, unknown>
+}
+
+export interface ActionErrorContext {
+  action: string
+  userId?: string
+  extra?: Record<string, unknown>
+}
+
+export interface ClientErrorContext {
+  source: string
+  queryKey?: readonly unknown[]
+  extra?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture une erreur depuis un route handler Next.js (server-side).
+ *
+ * @example
+ * captureRouteError(error, { endpoint: '/api/sync', userId: user.id, extra: { club_id } })
+ */
+export function captureRouteError(error: unknown, ctx: RouteErrorContext): void {
+  Sentry.captureException(error, {
+    tags: { endpoint: ctx.endpoint },
+    ...(ctx.userId ? { user: { id: ctx.userId } } : {}),
+    extra: ctx.extra,
+  })
+}
+
+/**
+ * Capture une erreur depuis une Server Action Next.js (server-side).
+ *
+ * @example
+ * captureActionError(error, { action: 'updateProfile', userId: user.id })
+ */
+export function captureActionError(error: unknown, ctx: ActionErrorContext): void {
+  Sentry.captureException(error, {
+    tags: { action: ctx.action },
+    ...(ctx.userId ? { user: { id: ctx.userId } } : {}),
+    extra: ctx.extra,
+  })
+}
+
+/**
+ * Capture une erreur côté client (React Query `onError`, error boundaries…).
+ *
+ * @example
+ * captureClientError(error, { source: 'usePortfolio', queryKey: ['portfolio', clubId] })
+ */
+export function captureClientError(error: unknown, ctx: ClientErrorContext): void {
+  Sentry.captureException(error, {
+    tags: { source: ctx.source },
+    extra: {
+      ...(ctx.queryKey !== undefined ? { queryKey: ctx.queryKey } : {}),
+      ...ctx.extra,
+    },
+  })
+}

--- a/docs/monitoring/sentry.md
+++ b/docs/monitoring/sentry.md
@@ -48,15 +48,61 @@ Le DSN est **public par nature** (préfixe `NEXT_PUBLIC_`) : c'est une clé d'in
 un secret. `SENTRY_AUTH_TOKEN` en revanche est un **secret** (server-only, jamais shippé au
 client) — défini uniquement comme secret GitHub Actions.
 
+## Helper centralisé (apps/web)
+
+`apps/web/lib/monitoring/sentry.ts` expose 3 fonctions typées :
+
+| Fonction                         | Contexte d'appel       | Champs obligatoires |
+| -------------------------------- | ---------------------- | ------------------- |
+| `captureRouteError(error, ctx)`  | Route handlers (catch) | `endpoint: string`  |
+| `captureActionError(error, ctx)` | Server Actions         | `action: string`    |
+| `captureClientError(error, ctx)` | React Query onError    | `source: string`    |
+
+Toutes délèguent à `Sentry.captureException` — no-op sans DSN garanti par le SDK.
+Pas de guard `if (dsn)` dans le helper : c'est le SDK qui court-circuite via `enabled: false`.
+
+Tests unitaires : `apps/web/lib/monitoring/sentry.test.ts` (17 tests, Vitest).
+
 ## Captures & tags
 
-Captures ancrées dans les `catch` / branches d'erreur existantes des routes :
+### Routes API
 
-| Route                        | Tags                                                    | Contexte (non nominatif)                   |
-| ---------------------------- | ------------------------------------------------------- | ------------------------------------------ |
-| `/api/sync`                  | `sync_error: true`, `endpoint`, `role`                  | `user.id`, `extra.club_id`                 |
-| `/api/auth/magic-link`       | `endpoint`, `step` (`email_is_invited`/`signInWithOtp`) | `extra.email_domain` (domaine seul)        |
-| `/api/attestation/detention` | `endpoint`                                              | `user.id`, `extra.club_id`, `extra.period` |
+| Route                        | Tags                                 | Contexte (non nominatif)        | Helper                    |
+| ---------------------------- | ------------------------------------ | ------------------------------- | ------------------------- |
+| `/api/admin/club-summary`    | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/admin/contributions`   | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/admin/invitations`     | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/admin/members`         | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/attestation/detention` | `endpoint`                           | `user.id`, `club_id`, `period`  | `Sentry.captureException` |
+| `/api/auth/handoff-link`     | `endpoint`                           | `userId`                        | `captureRouteError`       |
+| `/api/auth/magic-link`       | `endpoint`, `step`                   | `email_domain` (domaine seul)   | `Sentry.captureException` |
+| `/api/contributions`         | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/dashboard`             | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/health`                | `endpoint`                           | —                               | `captureRouteError`       |
+| `/api/market-prices`         | `endpoint`                           | `symbols[]`                     | `captureRouteError`       |
+| `/api/newsletter/preview`    | `endpoint`                           | `slug`                          | `captureRouteError`       |
+| `/api/newsletter/send-test`  | `endpoint`                           | —                               | `captureRouteError`       |
+| `/api/newsletter/send`       | `endpoint`, `step`                   | —                               | `captureRouteError`       |
+| `/api/onboarding/profile`    | `endpoint`                           | `userId`                        | `Sentry.captureException` |
+| `/api/portfolio`             | `endpoint`                           | `userId`, `club_id`             | `captureRouteError`       |
+| `/api/sync`                  | `endpoint`, `role` + partial failure | `userId`, `club_id`, `errors[]` | mixte                     |
+
+### Error boundaries
+
+| Composant          | Type                  | Mécanisme                                                 |
+| ------------------ | --------------------- | --------------------------------------------------------- |
+| `global-error.tsx` | Root boundary         | `Sentry.captureException(error)` dans `useEffect`         |
+| 10 × `error.tsx`   | Boundaries segmentées | `<RouteErrorReporter error={error} routeSegment="..." />` |
+
+### React Query & Server Actions
+
+| Couche                              | Couverture                                                       |
+| ----------------------------------- | ---------------------------------------------------------------- |
+| React Query `QueryCache.onError`    | Toutes les queries (sauf 401) → `captureClientError`             |
+| React Query `MutationCache.onError` | Toutes les mutations → `captureClientError`                      |
+| `admin/actions.ts` (7 actions)      | Erreurs PG inconnues (`captureIfUnknown`) → `captureActionError` |
+| `feedback/actions.ts`               | Erreur INSERT Supabase inattendue → `captureActionError`         |
+| `acces-suspendu/actions.ts`         | Erreur `signOut()` → `captureActionError`                        |
 
 ### Données personnelles — pas d'email en clair
 
@@ -64,8 +110,30 @@ La route magic-link manipule l'email du membre. **On n'envoie jamais l'adresse c
 Sentry** : seul le **domaine** (`emailDomain()`, partie après `@`) est remonté en `extra`,
 suffisant pour diagnostiquer un souci SMTP/DNS sans exposer la partie locale (RGPD).
 
-Les routes `sync` et `attestation` remontent `user.id` (UUID Supabase, non nominatif) +
-`club_id`, pas de nom/email.
+Les routes `sync`, `attestation` et les Server Actions remontent `user.id` (UUID Supabase,
+non nominatif) + `club_id`, pas de nom/email.
+
+## Couverture effective (post-Phase-8)
+
+| Couche                         | Avant       | Après                                      |
+| ------------------------------ | ----------- | ------------------------------------------ |
+| Routes API                     | 3/17 (18 %) | 17/17 (100 %)                              |
+| Error boundaries               | 0/11 (0 %)  | 11/11 (100 %)                              |
+| React Query                    | 0 %         | global onError actif                       |
+| Server Actions                 | 0 %         | 3 fichiers, erreurs inconnues capturees    |
+| RSC pages                      | 0 %         | 2 pages (dashboard chart + newsletter CMS) |
+| Edge Functions                 | 1/5 (20 %)  | 5/5 (100 %)                                |
+| **Couverture globale estimee** | **~20 %**   | **>= 75 %**                                |
+
+## Edge Functions
+
+| Fonction                    | Couverture                                                               |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `sync`                      | `alertSentry` si `errors.length >= 1` (seuil abaisse de 2 vers 1)        |
+| `send-email`                | `alertSentry` avant throw sur BREVO_API_KEY manquante + echec HTTP Brevo |
+| `feedback-dispatch`         | `alertSentry` dans le catch final                                        |
+| `send-monthly-attestations` | `alertSentry` dans le catch final                                        |
+| `on-user-first-login`       | `alertSentry` avant throw sur BREVO_API_KEY manquante + echec HTTP Brevo |
 
 ## Coexistence avec le helper Edge Function
 

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -1,0 +1,50 @@
+// Alerte Sentry best-effort. Déclenchée quand une sync accumule >= 2 erreurs.
+// Implémentation minimale via l'API Store de Sentry (pas de SDK Node).
+// Toute défaillance est avalée : l'alerting ne doit jamais faire échouer la sync.
+
+/** Parse un DSN Sentry en { storeUrl, authHeader }. null si DSN absent/malformé. */
+function parseDsn(dsn: string): { storeUrl: string; publicKey: string } | null {
+  try {
+    const url = new URL(dsn)
+    const publicKey = url.username
+    const projectId = url.pathname.replace(/^\//, '')
+    if (!publicKey || !projectId) return null
+    const storeUrl = `${url.protocol}//${url.host}/api/${projectId}/store/`
+    return { storeUrl, publicKey }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Envoie un événement Sentry décrivant les erreurs de sync. Best-effort : swallow.
+ * Ne fait rien si SENTRY_DSN n'est pas configuré.
+ */
+export async function alertSentry(
+  dsn: string | undefined,
+  context: { club_id: string; errors: string[]; sheets: string[] }
+): Promise<void> {
+  if (!dsn) return
+  const parsed = parseDsn(dsn)
+  if (!parsed) return
+  try {
+    const event = {
+      message: `Sync Sheets en échec partiel pour le club ${context.club_id} (${context.errors.length} erreurs)`,
+      level: 'error',
+      platform: 'other',
+      timestamp: Date.now() / 1000,
+      extra: context,
+      tags: { club_id: context.club_id, source: 'edge-function:sync' },
+    }
+    await fetch(parsed.storeUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-sentry-auth': `Sentry sentry_version=7, sentry_key=${parsed.publicKey}, sentry_client=evolve-sync/1.0`,
+      },
+      body: JSON.stringify(event),
+    })
+  } catch {
+    // Alerting best-effort : on n'interrompt jamais la sync à cause de Sentry.
+  }
+}

--- a/supabase/functions/feedback-dispatch/index.ts
+++ b/supabase/functions/feedback-dispatch/index.ts
@@ -43,6 +43,7 @@ import type { SupabaseClient } from 'npm:@supabase/supabase-js@^2'
 
 import { dispatchFeedback } from './handler.ts'
 import type { AiTriage, FeedbackRecord, FeedbackUpdater } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -116,6 +117,12 @@ if (import.meta.main) {
       return json({ ok: true, result })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: record?.club_id ?? 'unknown',
+        errors: [message],
+        sheets: ['feedback-dispatch'],
+      }).catch(() => {})
       return json({ ok: false, error: message }, 500)
     }
   })

--- a/supabase/functions/on-user-first-login/index.ts
+++ b/supabase/functions/on-user-first-login/index.ts
@@ -29,6 +29,7 @@ import { createElement } from 'npm:react@^19'
 
 import { createWelcomeHandler } from './handler.ts'
 import type { BrevoEmailPayload } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
 
 import { WelcomeEmail } from '../../../packages/data/src/emails/WelcomeEmail.tsx'
 import { renderEmailHtml } from '../../../packages/data/src/emails/index.ts'
@@ -36,7 +37,15 @@ import { renderEmailHtml } from '../../../packages/data/src/emails/index.ts'
 /** POST l'email transactionnel sur l'API Brevo (`api-key` header). */
 async function sendBrevoEmail(payload: BrevoEmailPayload): Promise<void> {
   const apiKey = Deno.env.get('BREVO_API_KEY') ?? ''
-  if (apiKey === '') throw new Error('BREVO_API_KEY manquante.')
+  if (apiKey === '') {
+    const dsn = Deno.env.get('SENTRY_DSN')
+    await alertSentry(dsn, {
+      club_id: 'on-user-first-login',
+      errors: ['BREVO_API_KEY manquante'],
+      sheets: ['on-user-first-login'],
+    }).catch(() => {})
+    throw new Error('BREVO_API_KEY manquante.')
+  }
   const res = await fetch('https://api.brevo.com/v3/smtp/email', {
     method: 'POST',
     headers: {
@@ -48,6 +57,12 @@ async function sendBrevoEmail(payload: BrevoEmailPayload): Promise<void> {
   })
   if (!res.ok) {
     const detail = await res.text().catch(() => '')
+    const dsn = Deno.env.get('SENTRY_DSN')
+    await alertSentry(dsn, {
+      club_id: 'on-user-first-login',
+      errors: [`Brevo ${res.status}: ${detail}`],
+      sheets: ['on-user-first-login'],
+    }).catch(() => {})
     throw new Error(`Brevo ${res.status}: ${detail}`)
   }
 }

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -28,6 +28,7 @@ import { Webhook } from 'npm:standardwebhooks@^1'
 
 import { createSendEmailHandler } from './handler.ts'
 import type { BrevoEmailPayload, EmailLocale } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
 
 import { MagicLinkEmail } from '../../../packages/data/src/emails/MagicLinkEmail.tsx'
 import { renderEmailHtml } from '../../../packages/data/src/emails/index.ts'
@@ -52,7 +53,15 @@ function verifyPayload(rawBody: string, headers: Headers): string {
 /** POST l'email transactionnel sur l'API Brevo (`api-key` header). */
 async function sendBrevoEmail(payload: BrevoEmailPayload): Promise<void> {
   const apiKey = Deno.env.get('BREVO_API_KEY') ?? ''
-  if (apiKey === '') throw new Error('BREVO_API_KEY manquante.')
+  if (apiKey === '') {
+    const dsn = Deno.env.get('SENTRY_DSN')
+    await alertSentry(dsn, {
+      club_id: 'send-email',
+      errors: ['BREVO_API_KEY manquante'],
+      sheets: ['send-email'],
+    }).catch(() => {})
+    throw new Error('BREVO_API_KEY manquante.')
+  }
   const res = await fetch('https://api.brevo.com/v3/smtp/email', {
     method: 'POST',
     headers: {
@@ -64,6 +73,12 @@ async function sendBrevoEmail(payload: BrevoEmailPayload): Promise<void> {
   })
   if (!res.ok) {
     const detail = await res.text().catch(() => '')
+    const dsn = Deno.env.get('SENTRY_DSN')
+    await alertSentry(dsn, {
+      club_id: 'send-email',
+      errors: [`Brevo ${res.status}: ${detail}`],
+      sheets: ['send-email'],
+    }).catch(() => {})
     throw new Error(`Brevo ${res.status}: ${detail}`)
   }
 }

--- a/supabase/functions/send-monthly-attestations/index.ts
+++ b/supabase/functions/send-monthly-attestations/index.ts
@@ -31,6 +31,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { formatEUR, formatPct } from '@evolve/utils'
 
 import { BrevoRateLimitError, firstNameOf, runAttestationBatch } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
 import type {
   AttestationAssembly,
   AttestationBatchDeps,
@@ -329,6 +330,12 @@ if (import.meta.main) {
       return json({ ok: true, ...summary })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: 'send-monthly-attestations',
+        errors: [message],
+        sheets: ['send-monthly-attestations'],
+      }).catch(() => {})
       return json({ ok: false, error: message }, 500)
     }
   })

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -807,8 +807,8 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
       if (error) errors.push(`update clubs.synced_at: ${error.message}`)
     }
 
-    // Alerte Sentry si >= 2 erreurs DURES accumulées (jamais sur de simples warnings).
-    if (errors.length >= 2) {
+    // Alerte Sentry dès la 1re erreur DURE accumulée (jamais sur de simples warnings).
+    if (errors.length >= 1) {
       await alertSentry(Deno.env.get('SENTRY_DSN'), {
         club_id: clubId,
         errors,


### PR DESCRIPTION
## Summary

Passe la couverture effective Sentry de ~20% à ≥75% sur \`apps/web\` et les Edge Functions Supabase, sans régression fonctionnelle ni RGPD.

## Changes

- **Helper centralisé** \`apps/web/lib/monitoring/sentry.ts\` — 3 fonctions (\`captureRouteError\`, \`captureActionError\`, \`captureClientError\`)
- **Routes API** — 14 routes sans Sentry instrumentées + \`/api/sync\` partial failures → 17/17 couvertes
- **Error boundaries** — \`global-error.tsx\` + composant \`RouteErrorReporter\` → 11/11 boundaries
- **React Query** — \`QueryCache.onError\` + \`MutationCache.onError\` globaux dans \`QueryProvider\`
- **Server Actions** — \`admin/actions.ts\`, \`feedback/actions.ts\`, \`acces-suspendu/actions.ts\`
- **RSC pages** — \`dashboard/page.tsx\` (level: warning, fallback demo intact) + \`admin/newsletter/page.tsx\`
- **Edge Functions** — \`_shared/sentry.ts\` + seuil sync ≥2→≥1 + 4 fonctions instrumentées
- **Tests + doc** — 17 tests unitaires helper, \`docs/monitoring/sentry.md\` table complète avant/après

## Couverture avant/après

| Couche | Avant | Après |
|--------|-------|-------|
| Routes API | 3/17 (18%) | 17/17 (100%) |
| Error boundaries | 0/11 (0%) | 11/11 (100%) |
| React Query onError | ❌ | ✅ global |
| Server Actions | 0% | 3 fichiers |
| Edge Functions | 1/5 (20%) | 5/5 (100%) |
| **Global estimé** | **~20%** | **≥ 75%** |

## RGPD

Aucun email en clair — \`user.id\` (UUID) + \`club_id\` uniquement. Pattern \`emailDomain()\` sur magic-link préservé.

## ⚠️ Risk

| Level | File |
|-------|------|
| Low | \`apps/web/app/api/auth/handoff-link/route.ts\` — ajout \`captureRouteError\` dans catch existant, aucune logique auth modifiée |

🤖 Generated with [Claude Code](https://claude.com/claude-code)