### PR TITLE
fix: OTP connexion à 6 chiffres (verrou repo) + rate_limit_email_sent 5

### DIFF
--- a/apps/web/lib/auth/otp-length-contract.test.ts
+++ b/apps/web/lib/auth/otp-length-contract.test.ts
@@ -8,6 +8,10 @@
 // en CI) → rien ne réconcilie repo ↔ prod. Ce test verrouille au moins la cohérence
 // CÔTÉ REPO : config.toml [auth.email].otp_length == OTP_CODE_LENGTH == 6.
 // Si l'un des deux dérive, CI échoue.
+//
+// ⚠️ Portée : ce test NE voit PAS la valeur du dashboard prod (la vraie cause de l'incident).
+// La protection anti-dérive prod relève du config-as-code (`supabase config push` en CI) ou
+// d'un healthcheck prod — voir le suivi owner. Ici on verrouille uniquement le contrat repo.
 
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -37,22 +41,28 @@ function findConfigToml(startDir: string): string {
 }
 
 /**
- * Extrait otp_length de la SECTION [auth.email] uniquement.
- * Piège : config.toml contient un AUTRE `otp_length = 6` plus bas, sous [auth.mfa.phone]
- * — il ne doit PAS être confondu avec celui de l'email. On isole donc d'abord le corps
- * de la section [auth.email] (jusqu'au prochain en-tête de table `[...]`), puis on y lit
- * la première clé `otp_length` (en ignorant les lignes commentées `#`).
+ * Isole le CORPS de la section [auth.email] (de l'en-tête jusqu'au prochain en-tête de
+ * table `[...]` en début de ligne). Piège : config.toml contient un AUTRE `otp_length = 6`
+ * plus bas, sous [auth.mfa.phone] — il ne doit JAMAIS entrer dans ce corps.
+ *
+ * ⚠️ Hypothèse : `otp_length` est déclaré AVANT toute sous-table `[auth.email.*]`
+ * (ex. [auth.email.smtp], [auth.email.template.*]). C'est l'ordre actuel de config.toml.
+ * Si un jour une sous-table était insérée avant `otp_length`, le corps serait coupé trop
+ * tôt et `readEmailOtpLength` throw « introuvable » — échec BRUYANT (pas silencieux), donc
+ * détectable. Garder `otp_length` directement sous `[auth.email]`.
  */
-function readEmailOtpLength(toml: string): number {
+function readEmailSection(toml: string): string {
   const sectionStart = toml.indexOf('[auth.email]')
   expect(sectionStart, 'section [auth.email] absente de config.toml').toBeGreaterThanOrEqual(0)
 
   const afterHeader = sectionStart + '[auth.email]'.length
-  // Fin de section = prochain en-tête de table en début de ligne (ex. [auth.email.smtp]
-  // ou [auth.sms]). On garde le corps strictement entre les deux.
   const nextHeaderRel = afterHeader + indexOfNextTableHeader(toml.slice(afterHeader))
-  const body = toml.slice(afterHeader, nextHeaderRel)
+  return toml.slice(afterHeader, nextHeaderRel)
+}
 
+/** Extrait otp_length de la SECTION [auth.email] uniquement (cf. readEmailSection). */
+function readEmailOtpLength(toml: string): number {
+  const body = readEmailSection(toml)
   const match = body.match(/^\s*otp_length\s*=\s*(\d+)/m)
   expect(match, 'otp_length introuvable dans la section [auth.email]').not.toBeNull()
   return Number(match![1])
@@ -66,12 +76,22 @@ function indexOfNextTableHeader(s: string): number {
 
 describe('contrat longueur OTP email (config.toml ↔ OTP_CODE_LENGTH)', () => {
   const configPath = findConfigToml(process.cwd())
-  const otpLength = readEmailOtpLength(readFileSync(configPath, 'utf8'))
+  const toml = readFileSync(configPath, 'utf8')
+  const otpLength = readEmailOtpLength(toml)
 
-  it('config.toml [auth.email].otp_length est bien lu depuis le bon scope (≠ [auth.mfa.phone])', () => {
-    // Garde-fou : l'extraction ne doit pas attraper la clé MFA. On vérifie que la valeur
-    // lue est un entier plausible et que la section MFA n'a pas pollué la lecture.
-    expect(Number.isInteger(otpLength)).toBe(true)
+  it('otp_length est lu dans le scope [auth.email], jamais celui de [auth.mfa.phone]', () => {
+    // Preuve structurelle : le corps isolé contient bien la clé otp_length, et n'a PAS
+    // débordé sur la section MFA (qui a aussi un otp_length) ni sur une autre table.
+    const emailBody = readEmailSection(toml)
+    expect(emailBody, 'le corps [auth.email] doit contenir otp_length').toMatch(
+      /^\s*otp_length\s*=/m
+    )
+    expect(emailBody, 'le corps [auth.email] ne doit pas déborder sur [auth.mfa').not.toContain(
+      '[auth.mfa'
+    )
+    expect(emailBody, 'le corps [auth.email] ne doit pas déborder sur [auth.sms').not.toContain(
+      '[auth.sms'
+    )
   })
 
   it('otp_length email vaut 6 (verrou de régression de l’incident OTP 8 chiffres)', () => {

--- a/apps/web/lib/auth/otp-length-contract.test.ts
+++ b/apps/web/lib/auth/otp-length-contract.test.ts
@@ -1,0 +1,84 @@
+// Verrou de régression — longueur du code OTP email.
+//
+// Incident (juin 2026) : la prod GoTrue émettait un code OTP de connexion à 8 chiffres
+// alors que tout le repo attend 6 (config.toml [auth.email] otp_length = 6 ET
+// apps/web/lib/auth/otp.ts OTP_CODE_LENGTH = 6, qui sert de maxLength à l'input OTP).
+// Résultat : les utilisateurs ne pouvaient pas saisir leur code (l'input tronquait à 6).
+// La config.toml n'est PAS poussée automatiquement en prod (aucun `supabase config push`
+// en CI) → rien ne réconcilie repo ↔ prod. Ce test verrouille au moins la cohérence
+// CÔTÉ REPO : config.toml [auth.email].otp_length == OTP_CODE_LENGTH == 6.
+// Si l'un des deux dérive, CI échoue.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { OTP_CODE_LENGTH } from '@/lib/auth/otp'
+
+/**
+ * Remonte l'arborescence depuis `startDir` jusqu'à trouver `supabase/config.toml`.
+ * Robuste vis-à-vis du cwd de Vitest (racine app vs racine monorepo) : on ne code pas
+ * en dur un chemin relatif fragile.
+ */
+function findConfigToml(startDir: string): string {
+  let dir = startDir
+  // Remonte jusqu'à la racine FS (dirname d'une racine == elle-même).
+  for (;;) {
+    const candidate = join(dir, 'supabase', 'config.toml')
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(
+    `supabase/config.toml introuvable en remontant depuis ${startDir} (cwd=${process.cwd()})`
+  )
+}
+
+/**
+ * Extrait otp_length de la SECTION [auth.email] uniquement.
+ * Piège : config.toml contient un AUTRE `otp_length = 6` plus bas, sous [auth.mfa.phone]
+ * — il ne doit PAS être confondu avec celui de l'email. On isole donc d'abord le corps
+ * de la section [auth.email] (jusqu'au prochain en-tête de table `[...]`), puis on y lit
+ * la première clé `otp_length` (en ignorant les lignes commentées `#`).
+ */
+function readEmailOtpLength(toml: string): number {
+  const sectionStart = toml.indexOf('[auth.email]')
+  expect(sectionStart, 'section [auth.email] absente de config.toml').toBeGreaterThanOrEqual(0)
+
+  const afterHeader = sectionStart + '[auth.email]'.length
+  // Fin de section = prochain en-tête de table en début de ligne (ex. [auth.email.smtp]
+  // ou [auth.sms]). On garde le corps strictement entre les deux.
+  const nextHeaderRel = afterHeader + indexOfNextTableHeader(toml.slice(afterHeader))
+  const body = toml.slice(afterHeader, nextHeaderRel)
+
+  const match = body.match(/^\s*otp_length\s*=\s*(\d+)/m)
+  expect(match, 'otp_length introuvable dans la section [auth.email]').not.toBeNull()
+  return Number(match![1])
+}
+
+/** Position (dans `s`) du prochain en-tête de table TOML `[...]` en début de ligne, ou fin de `s`. */
+function indexOfNextTableHeader(s: string): number {
+  const m = s.match(/^\s*\[[^\]]+\]/m)
+  return m ? m.index! : s.length
+}
+
+describe('contrat longueur OTP email (config.toml ↔ OTP_CODE_LENGTH)', () => {
+  const configPath = findConfigToml(process.cwd())
+  const otpLength = readEmailOtpLength(readFileSync(configPath, 'utf8'))
+
+  it('config.toml [auth.email].otp_length est bien lu depuis le bon scope (≠ [auth.mfa.phone])', () => {
+    // Garde-fou : l'extraction ne doit pas attraper la clé MFA. On vérifie que la valeur
+    // lue est un entier plausible et que la section MFA n'a pas pollué la lecture.
+    expect(Number.isInteger(otpLength)).toBe(true)
+  })
+
+  it('otp_length email vaut 6 (verrou de régression de l’incident OTP 8 chiffres)', () => {
+    expect(otpLength).toBe(6)
+  })
+
+  it('otp_length email == OTP_CODE_LENGTH (config back ↔ maxLength input front, pas de dérive)', () => {
+    expect(otpLength).toBe(OTP_CODE_LENGTH)
+  })
+})

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -199,7 +199,9 @@ password_requirements = ""
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
-email_sent = 2
+# 2/h était trop bas en prod : un 429 (limite atteinte) se masquait côté utilisateur
+# en simple échec d'envoi (pas de magic link / code OTP reçu). Remonté à 5/h.
+email_sent = 5
 # Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
@@ -234,6 +236,11 @@ secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.
+# ⚠️ DOIT rester aligné sur apps/web/lib/auth/otp.ts → OTP_CODE_LENGTH (= maxLength de
+# l'input OTP). Le test apps/web/lib/auth/otp-length-contract.test.ts verrouille cette égalité.
+# ⚠️ Cette config N'EST PAS poussée automatiquement en prod (aucun `supabase config push`
+# en CI) : régler MANUELLEMENT l'OTP email à 6 dans le dashboard prod. Incident juin :
+# la prod avait dérivé à 8 chiffres → l'input (maxLength 6) ne laissait pas saisir le code.
 otp_length = 6
 # Number of seconds before the email OTP expires. 600s = 10 min (source de vérité ;
 # l'email magic link + les textes UI doivent afficher la MÊME valeur — cf. QA 2026-06-07).


### PR DESCRIPTION
## Contexte

Après le déploiement (merge de #41), la prod émettait un **code OTP de connexion à 8 chiffres** alors que toute l'app attend **6** (`Code à 6 chiffres`, input `maxLength={OTP_CODE_LENGTH}`). Les membres ne pouvaient plus saisir le code (l'input tronque à 6) ; seul le bouton « lien magique » restait fonctionnel.

## Cause racine

- Le hook `send-email` rend `email_data.token` **tel quel** ([handler.ts:177](supabase/functions/send-email/handler.ts#L177)) → les 8 chiffres viennent de **GoTrue (prod) `mailer_otp_length = 8`**, pas du code.
- Le **contrat repo est unanime à 6** : `config.toml` `[auth.email] otp_length = 6` + `apps/web/lib/auth/otp.ts` `OTP_CODE_LENGTH = 6`.
- **Aucun workflow ne pousse `config.toml` en prod** (pas de `supabase config push` en CI) → la config auth prod est gérée à la main dans le dashboard et **a dérivé à 8**.
- C'était **invisible tant que le hook `send-email` était cassé** (incident verify_jwt de #41) : aucun email de hook ne se rendait. **Réparer le hook a exposé** la dérive. Le merge n'a donc rien *introduit*, il a *révélé*.

## Cette PR (code)

- **`rate_limit_email_sent` 2 → 5** — [config.toml:202](supabase/config.toml#L202) (un 429 GoTrue se masquait en « Impossible d'envoyer le lien » ; 2/h trop bas en prod).
- **Verrou de régression** — nouveau `apps/web/lib/auth/otp-length-contract.test.ts` : lit `config.toml` `[auth.email].otp_length` (scope isolé, ne lit PAS le `otp_length` de `[auth.mfa.phone]`) et assert `=== 6 === OTP_CODE_LENGTH`. Empêche une future dérive **côté repo** (config.toml ou la constante front).
- **Commentaire de garde** dans `config.toml` : la longueur doit rester alignée sur `OTP_CODE_LENGTH`, et la config n'étant pas poussée en CI, le **dashboard prod doit valoir 6**.

## ⚠️ Portée honnête du verrou

Ce test verrouille la cohérence **côté repo** ; il **ne voit pas** la valeur du dashboard prod (la vraie cause). Il **n'aurait pas attrapé** cet incident (repo=6, prod=8). Pour empêcher la **dérive prod**, suivi owner nécessaire :
1. **Config-as-code** : ajouter `supabase config push` (ou un diff-check) au déploiement → le repo devient la source de vérité que GoTrue applique. **Fix racine.**
2. À défaut, **healthcheck prod** : un synthétique qui déclenche un OTP réel en prod et vérifie que le code reçu fait 6 chiffres (alerte sinon).

## Action prod (hors PR — en cours)

Comme la CI ne pousse pas la config, le live est corrigé séparément (Management API) : `mailer_otp_length → 6` et `rate_limit_email_sent → 5`, vérifié par une requête OTP réelle (code à 6 chiffres).

## Tests (verts)

- `pnpm --filter @evolve/web typecheck` → clean.
- `pnpm --filter @evolve/web exec vitest run lib/auth/otp` → **11/11** (8 existants + 3 du verrou).
- Preuve RED→GREEN : `otp_length=8` → le verrou échoue ; `=6` → vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
