### PR TITLE
chore(infra): déploiement Supabase prod (Makefile) + garde anti-dérive config auth + runbook

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -7,7 +7,15 @@
 # - Anti-bruit : on re-notifie à chaque run (30 min) tant que c'est cassé — assumé.
 # - Le job FINIT EN FAILURE quand la santé est KO (visible aussi côté GitHub).
 #
-# Réf : docs/monitoring/MONITORING.md
+# Job `auth-config` (parallèle) : garde anti-dérive de la config auth prod
+# (mailer_otp_length / rate_limit_email_sent) via la Management API Supabase.
+# - Secret requis : secrets.SUPABASE_ACCESS_TOKEN (PAT sbp_…). Si absent → le job
+#   se SKIP proprement (no-op) pour ne pas casser la CI des forks / secret non posé.
+# - Pas de notif Discord ici : un JOB ROUGE EST l'alerte (échec visible sur GitHub).
+#   Rappel : config.toml fixe otp_length=6 mais n'est pas poussé en CI (cf. runbook),
+#   d'où ce contrôle ; verrou côté repo = apps/web/lib/auth/otp.test.ts.
+#
+# Réf : docs/monitoring/MONITORING.md, docs/deploy/SUPABASE_PROD.md
 name: Healthcheck sync
 
 on:
@@ -103,3 +111,25 @@ jobs:
         run: |
           echo "::error::Healthcheck KO — ${{ steps.check.outputs.reason }}"
           exit 1
+
+  auth-config:
+    name: Vérifier config auth prod (anti-dérive OTP)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Le secret est mappé en env (GitHub n'évalue pas secrets.* dans un `if:` job)
+      # → bash-guard : skip propre si absent, sinon le script échoue (rouge) sur dérive.
+      - name: Vérifier mailer_otp_length=6 / rate_limit_email_sent≥5
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "skip (SUPABASE_ACCESS_TOKEN absent)"
+            exit 0
+          fi
+          node scripts/supabase-prod-auth-check.mjs

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -13,7 +13,7 @@
 #   se SKIP proprement (no-op) pour ne pas casser la CI des forks / secret non posé.
 # - Pas de notif Discord ici : un JOB ROUGE EST l'alerte (échec visible sur GitHub).
 #   Rappel : config.toml fixe otp_length=6 mais n'est pas poussé en CI (cf. runbook),
-#   d'où ce contrôle ; verrou côté repo = apps/web/lib/auth/otp.test.ts.
+#   d'où ce contrôle ; verrou côté repo = apps/web/lib/auth/otp-length-contract.test.ts.
 #
 # Réf : docs/monitoring/MONITORING.md, docs/deploy/SUPABASE_PROD.md
 name: Healthcheck sync

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: dev dev-web dev-vitrine build lint typecheck test test-e2e storybook \
         db-start db-stop db-migrate db-reset db-types db-set-sheet db-sync db-set-sheet-prod db-sync-prod \
+        supabase-deploy-prod supabase-check-prod-auth \
         docker-build docker-up docker-down \
         vitrine-export vitrine-deploy strapi-dev strapi-seed strapi-env strapi-build strapi-up strapi-down strapi-logs strapi-restart strapi-admin strapi-init strapi-clean \
         strapi-db-up strapi-db-down strapi-db-shell strapi-db-restore \
@@ -66,6 +67,39 @@ db-set-sheet-prod:
 
 db-sync-prod:
 	set -a; . ./apps/web/.env.prod; set +a; node scripts/sync-sheets.mjs $(CLUB_ID)
+
+# Déploiement PROD après un merge sur main (migrations + edge functions). Garde-fou
+# CONFIRM=yes obligatoire. NE touche PAS la config auth ni les secrets (cf. runbook).
+# Runbook complet : docs/deploy/SUPABASE_PROD.md
+supabase-deploy-prod:
+ifneq ($(CONFIRM),yes)
+	@echo "⚠️  Déploiement Supabase PROD — relance avec CONFIRM=yes pour confirmer :"
+	@echo "      make supabase-deploy-prod CONFIRM=yes"
+	@echo ""
+	@echo "   Ce que ça fait : pousse les MIGRATIONS puis déploie les EDGE FUNCTIONS"
+	@echo "   sur le projet Supabase LIÉ (verify_jwt vient de supabase/config.toml)."
+	@echo "   Prérequis : supabase link --project-ref kiwcjtilwihioswdsjjv (+ mot de passe DB)."
+	@echo "   NE touche PAS la config auth (otp_length, hook send_email) ni les secrets —"
+	@echo "   ces étapes restent manuelles (dashboard / supabase secrets set). Cf. docs/deploy/SUPABASE_PROD.md"
+	@exit 1
+else
+	@echo "▶ db push (migrations) sur le projet lié…"
+	supabase db push
+	@echo "▶ functions deploy --use-api (toutes les fonctions ; verify_jwt vient de config.toml)…"
+	supabase functions deploy --use-api
+	@echo ""
+	@echo "✅ Migrations + Edge Functions déployées."
+	@echo "⚠️  NON automatisé (à faire à la main — cf. docs/deploy/SUPABASE_PROD.md) :"
+	@echo "   • Secrets : supabase secrets set …  (SEND_EMAIL_HOOK_SECRET, BREVO_*, clés feedback IA/Discord/GitHub/Notion)"
+	@echo "   • Config auth (dashboard) : mailer_otp_length=6, rate_limit_email_sent=5"
+	@echo "   • Activation du hook send_email (dashboard — JAMAIS via config push, sinon hook désactivé)"
+	@echo "   → vérifie la config auth : make supabase-check-prod-auth"
+endif
+
+# Garde anti-dérive de la config auth prod (otp_length / rate limit) via Management API.
+supabase-check-prod-auth:
+	@echo "▶ Vérif config auth prod (exporte d'abord SUPABASE_ACCESS_TOKEN=sbp_…)"
+	node scripts/supabase-prod-auth-check.mjs
 
 ## Docker (apps/web uniquement)
 docker-build:

--- a/docs/deploy/SUPABASE_PROD.md
+++ b/docs/deploy/SUPABASE_PROD.md
@@ -1,0 +1,89 @@
+# Déploiement Supabase PROD — runbook
+
+Projet prod : **`kiwcjtilwihioswdsjjv`** (Dashboard : <https://supabase.com/dashboard/project/kiwcjtilwihioswdsjjv>).
+
+## Quand déployer
+
+Après un merge sur `main` qui touche :
+
+- `supabase/migrations/` → nouvelles migrations à pousser ;
+- `supabase/functions/` → Edge Functions à redéployer ;
+- la config auth (otp, rate limit, hook email) → étape **manuelle** (cf. plus bas).
+
+## Prérequis
+
+- **Lier le projet** : `supabase link --project-ref kiwcjtilwihioswdsjjv`
+  (demande le **mot de passe DB** pour `db push`).
+- **PAT** pour la vérif anti-dérive : `export SUPABASE_ACCESS_TOKEN="sbp_…"`
+  (Dashboard → Account → Access Tokens).
+
+## Commande de déploiement
+
+```bash
+make supabase-deploy-prod CONFIRM=yes
+```
+
+Ce qu'elle fait, sur le projet **lié** :
+
+1. `supabase db push` — applique les migrations.
+2. `supabase functions deploy --use-api` — déploie **toutes** les fonctions.
+   - `--use-api` est **obligatoire** : le bundling local échoue sur les imports
+     extensionless en Deno.
+   - `verify_jwt` par fonction vient de `supabase/config.toml`
+     (`[functions.send-email]` / `[functions.feedback-dispatch]` = `false`, épinglé) —
+     un deploy CLI le repose correctement. Un redeploy via le dashboard, lui,
+     réinitialise `verify_jwt` à `true` (incident 2026-06-14) → **toujours déployer via la CLI**.
+
+Sans `CONFIRM=yes`, la cible n'exécute rien et affiche un rappel des prérequis.
+
+## Étapes MANUELLES (non automatisées) et pourquoi
+
+### 1. Secrets Edge Functions
+
+```bash
+supabase secrets set SEND_EMAIL_HOOK_SECRET=… BREVO_API_KEY=… BREVO_SENDER_EMAIL=… \
+  FEEDBACK_AI_PROVIDER=… <clé IA> DISCORD_WEBHOOK_URL=… GITHUB_TOKEN=… NOTION_TOKEN=… …
+```
+
+(Liste indicative — voir `supabase/functions/*/` pour le détail par fonction.
+`supabase secrets set` exige un PAT `sbp_`.) Non scripté volontairement : ne jamais
+committer de valeurs ; le set se fait à la main au moment du rollout.
+
+### 2. Config auth (dashboard uniquement)
+
+À vérifier / poser dans **Auth** :
+
+- `mailer_otp_length = 6` (Auth → Email) ;
+- `rate_limit_email_sent ≥ 5` (Auth → Rate Limits) ;
+- hook **`send_email` ACTIVÉ** (Auth → Hooks) pointant sur la fonction `send-email`.
+
+**Pourquoi on ne fait JAMAIS `supabase config push` :**
+`supabase/config.toml` garde le bloc `[auth.hook.send_email]` **commenté** pour le
+dev local (la stack CLI capte tous les emails via Mailpit/Inbucket). Un `config push`
+appliquerait ce « commenté » à la prod → **désactiverait le hook send_email** et
+**casserait le magic link / l'OTP par email**. Tant que le hook local/prod n'est pas
+réconcilié (toggle par env), la config auth reste **gérée à la main dans le dashboard**.
+
+> Config-as-code complète = **tâche FUTURE** : réconcilier le hook send_email
+> (local Mailpit vs prod Brevo) via toggling env, AVANT d'activer `supabase config push`.
+
+## Garde anti-dérive (OTP / rate limit)
+
+Parce que la config auth n'est pas poussée en CI, la prod peut **dériver**.
+Incident réel : `mailer_otp_length` était passé à **8** (codes OTP à 8 chiffres),
+corrigé à 6 via la Management API.
+
+Deux garde-fous :
+
+- **Manuel** : `make supabase-check-prod-auth` (exporter `SUPABASE_ACCESS_TOKEN` d'abord)
+  — interroge la Management API et échoue si `otp_length ≠ 6` ou `rate_limit_email_sent < 5`.
+- **CI** : job `auth-config` dans `.github/workflows/healthcheck.yml` (toutes les 30 min).
+  Skip propre si le secret `SUPABASE_ACCESS_TOKEN` n'est pas posé ; **job rouge = alerte**
+  (pas de notif Discord dédiée).
+- **Verrou repo** : `apps/web/lib/auth/otp.test.ts` fige le contrat OTP 6 chiffres côté code.
+
+## Rotation des clés
+
+Tout `.env` / PAT exposé (logs, captures, partage) doit être **rotaté** :
+régénérer le PAT `sbp_` dans le dashboard, et faire tourner les clés API
+(Brevo, IA feedback, Discord/GitHub/Notion) le cas échéant.

--- a/docs/deploy/SUPABASE_PROD.md
+++ b/docs/deploy/SUPABASE_PROD.md
@@ -80,7 +80,7 @@ Deux garde-fous :
 - **CI** : job `auth-config` dans `.github/workflows/healthcheck.yml` (toutes les 30 min).
   Skip propre si le secret `SUPABASE_ACCESS_TOKEN` n'est pas posé ; **job rouge = alerte**
   (pas de notif Discord dédiée).
-- **Verrou repo** : `apps/web/lib/auth/otp.test.ts` fige le contrat OTP 6 chiffres côté code.
+- **Verrou repo** : `apps/web/lib/auth/otp-length-contract.test.ts` fige le contrat OTP 6 chiffres côté code.
 
 ## Rotation des clés
 

--- a/scripts/supabase-prod-auth-check.mjs
+++ b/scripts/supabase-prod-auth-check.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Garde anti-dérive de la config auth PROD (Management API Supabase).
+// Node pur (≥ 18, fetch global) — zéro dépendance, même esprit que set-sheet-id.mjs.
+//
+// Pourquoi ce script existe :
+//   `supabase/config.toml` fixe `[auth.email] otp_length = 6` MAIS cette config
+//   n'est PAS poussée en CI (on ne fait jamais `supabase config push` — cf.
+//   docs/deploy/SUPABASE_PROD.md, le hook send_email y est volontairement commenté).
+//   La config auth prod est donc gérée à la main dans le dashboard et peut DÉRIVER.
+//   Incident réel : `mailer_otp_length` était passé à 8 en prod (codes OTP à 8
+//   chiffres) ; corrigé à 6 via la Management API. Ce script échoue (rouge) si la
+//   dérive réapparaît — le verrou côté repo est apps/web/lib/auth/otp.test.ts.
+//
+// Variables d'env :
+//   SUPABASE_ACCESS_TOKEN   ← PAT `sbp_…` (obligatoire ; sinon exit 2, échec bruyant)
+//   SUPABASE_PROJECT_REF    ← ref projet prod (défaut kiwcjtilwihioswdsjjv)
+//
+// Usage :
+//   SUPABASE_ACCESS_TOKEN=sbp_... node scripts/supabase-prod-auth-check.mjs
+//   make supabase-check-prod-auth
+
+const token = process.env.SUPABASE_ACCESS_TOKEN
+const projectRef = process.env.SUPABASE_PROJECT_REF || 'kiwcjtilwihioswdsjjv'
+
+// Seuils attendus (source de vérité : supabase/config.toml + incident OTP 8 chiffres).
+const EXPECTED_OTP_LENGTH = 6
+const MIN_RATE_LIMIT_EMAIL = 5
+
+if (!token) {
+  console.error(
+    '\n❌ SUPABASE_ACCESS_TOKEN manquant.\n' +
+      "   Exporte un PAT Supabase (sbp_…) avant de lancer la vérif :\n" +
+      '   export SUPABASE_ACCESS_TOKEN="sbp_..."   # Dashboard → Account → Access Tokens\n' +
+      `   (projet ciblé : ${projectRef} — surchargeable via SUPABASE_PROJECT_REF)\n`
+  )
+  process.exit(2)
+}
+
+const endpoint = `https://api.supabase.com/v1/projects/${encodeURIComponent(projectRef)}/config/auth`
+console.log(`▶ Vérif config auth prod — projet ${projectRef}`)
+console.log(`  → GET ${endpoint}`)
+
+let config
+try {
+  const res = await fetch(endpoint, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  })
+
+  const text = await res.text()
+  let payload
+  try {
+    payload = JSON.parse(text)
+  } catch {
+    payload = text
+  }
+
+  if (!res.ok) {
+    console.error(`\n❌ HTTP ${res.status} en interrogeant la Management API.`)
+    console.error(typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2))
+    if (res.status === 401 || res.status === 403) {
+      console.error('\n   → PAT invalide/expiré ou sans accès à ce projet. Régénère-le dans le dashboard.')
+    }
+    process.exit(1)
+  }
+
+  config = payload
+} catch (err) {
+  console.error(`\n❌ Échec de l'appel à la Management API : ${err?.message || err}`)
+  process.exit(1)
+}
+
+const otpLength = config?.mailer_otp_length
+const rateLimitEmail = config?.rate_limit_email_sent
+
+console.log(`  mailer_otp_length      = ${otpLength}`)
+console.log(`  rate_limit_email_sent  = ${rateLimitEmail}`)
+
+const problems = []
+if (otpLength !== EXPECTED_OTP_LENGTH) {
+  problems.push(
+    `mailer_otp_length = ${otpLength} (attendu ${EXPECTED_OTP_LENGTH}). ` +
+      'Rappel : la prod a déjà dérivé à 8 chiffres (incident OTP). ' +
+      "config.toml fixe otp_length=6 mais n'est pas poussé en CI — corrige dans le dashboard (Auth → Email)."
+  )
+}
+if (typeof rateLimitEmail !== 'number' || rateLimitEmail < MIN_RATE_LIMIT_EMAIL) {
+  problems.push(
+    `rate_limit_email_sent = ${rateLimitEmail} (attendu ≥ ${MIN_RATE_LIMIT_EMAIL}). ` +
+      "Trop bas = magic link/OTP bloqués sous charge légère — relève la limite dans le dashboard (Auth → Rate Limits)."
+  )
+}
+
+if (problems.length > 0) {
+  console.error('\n❌ Config auth prod NON conforme :')
+  for (const p of problems) console.error(`   • ${p}`)
+  console.error(
+    "\n   (Cette config est dashboard-managed : on ne fait pas `supabase config push` " +
+      'pour ne pas désactiver le hook send_email prod — cf. docs/deploy/SUPABASE_PROD.md.)\n'
+  )
+  process.exit(1)
+}
+
+console.log('\n✅ config auth prod conforme (otp_length=6, rate_limit_email_sent≥5)')
+process.exit(0)

--- a/scripts/supabase-prod-auth-check.mjs
+++ b/scripts/supabase-prod-auth-check.mjs
@@ -9,7 +9,7 @@
 //   La config auth prod est donc gérée à la main dans le dashboard et peut DÉRIVER.
 //   Incident réel : `mailer_otp_length` était passé à 8 en prod (codes OTP à 8
 //   chiffres) ; corrigé à 6 via la Management API. Ce script échoue (rouge) si la
-//   dérive réapparaît — le verrou côté repo est apps/web/lib/auth/otp.test.ts.
+//   dérive réapparaît — le verrou côté repo est apps/web/lib/auth/otp-length-contract.test.ts.
 //
 // Variables d'env :
 //   SUPABASE_ACCESS_TOKEN   ← PAT `sbp_…` (obligatoire ; sinon exit 2, échec bruyant)


### PR DESCRIPTION
## Contexte

Suite à l'incident **OTP à 8 chiffres** (la config auth prod avait dérivé — `mailer_otp_length` passé à 8 — sans être détecté, car `config.toml` n'est **pas poussé en CI**), cette PR outille le **déploiement Supabase prod** et ajoute une **garde anti-dérive**. Répond aussi à : « peut-on avoir une commande Makefile pour les déploiements prod après un merge sur main ? ».

## Livrables

- **`make supabase-deploy-prod CONFIRM=yes`** — pousse les **migrations** (`supabase db push`) puis déploie **toutes les Edge Functions** (`supabase functions deploy --use-api` ; `verify_jwt` vient de `config.toml` → pas de régression du hook). Garde-fou `CONFIRM=yes` obligatoire ; sans confirmation, affiche les prérequis et ne fait rien.
- **`make supabase-check-prod-auth`** + **`scripts/supabase-prod-auth-check.mjs`** — vérifie via la Management API que la prod a bien `mailer_otp_length = 6` et `rate_limit_email_sent ≥ 5` ; échoue (rouge) sinon. Zéro dépendance (Node ≥18 `fetch`).
- **CI** — nouveau job `auth-config` dans `.github/workflows/healthcheck.yml` (toutes les 30 min) : skip proprement si le secret `SUPABASE_ACCESS_TOKEN` n'est pas posé, sinon **job rouge = alerte** en cas de dérive.
- **`docs/deploy/SUPABASE_PROD.md`** — runbook : quand déployer, prérequis (`supabase link` + PAT), commande, **étapes manuelles** (secrets, config auth dashboard) et garde anti-dérive.

## Pourquoi on ne fait PAS `supabase config push`

`config.toml` garde `[auth.hook.send_email]` **commenté** pour le dev local (la stack CLI capte les emails via Mailpit ; la prod utilise le hook Brevo activé dans le dashboard). Un `config push` appliquerait ce « commenté » à la prod → **désactiverait le hook send_email** et **recasserait le magic link** (T4). Donc la config auth reste **dashboard-managed**, et la dérive est attrapée par la garde ci-dessus. Config-as-code complète = **tâche future** (réconcilier le hook local/prod via toggling env avant d'activer `config push`).

## Action owner (pour activer la garde CI)

Poser le secret **`SUPABASE_ACCESS_TOKEN`** (`sbp_…`) dans GitHub → Settings → Secrets → Actions. Sans lui, le job `auth-config` se skip (no-op).

## Validations (aucun effet prod)

- `node --check scripts/supabase-prod-auth-check.mjs` → OK ; run sans token → message FR + `exit 2`.
- `make -n supabase-deploy-prod CONFIRM=yes` → afficherait `supabase db push` + `supabase functions deploy --use-api` (non exécuté) ; sans `CONFIRM` → notice + sortie non-zéro.
- YAML `healthcheck.yml` valide. Aucun secret committé. Aucune commande prod lancée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
