### PR TITLE
chore(infra): plugins Omniventus et config performance-guardian

### DIFF
--- a/.claude/perf-guardian.config.json
+++ b/.claude/perf-guardian.config.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "./skills/performance-guardian/config.schema.json",
+  "project_name": "Réseau Evolve Capital — Vitrine",
+  "url": "https://reseauevolvecapital.com",
+  "strategies": ["mobile", "desktop"],
+  "categories": ["performance", "accessibility", "best-practices", "seo"],
+  "locale": "fr",
+  "thresholds": {
+    "performance_mobile": 90,
+    "performance_desktop": 95,
+    "lcp_mobile_seconds": 2.5,
+    "cls_mobile": 0.1,
+    "accessibility": 90,
+    "best_practices": 90,
+    "seo": 95,
+    "unused_js_kb": 30,
+    "largest_image_kb": 200
+  },
+  "repo": {
+    "base_branch": "main",
+    "branch_prefix": "fix/perf",
+    "worktree_dir": ".claude/worktrees",
+    "commit_scope": "vitrine",
+    "pr_labels": ["perf", "automated"],
+    "stale_pr_days": 2
+  },
+  "allowed_paths": [
+    "apps/vitrine/public/",
+    "apps/vitrine/src/",
+    "apps/vitrine/next.config.ts",
+    "apps/vitrine/package.json"
+  ],
+  "forbidden_paths": [
+    "apps/web/",
+    "apps/cms/",
+    "supabase/",
+    "packages/",
+    ".github/workflows/deploy-vitrine.yml"
+  ],
+  "build_command": "pnpm --filter @evolve/vitrine build",
+  "fix_priority": [
+    {
+      "id": "hero-image-lcp",
+      "match": ["largest-contentful-paint", "image", "webp", "hero"],
+      "branch_suffix": "images-lcp"
+    },
+    {
+      "id": "unused-javascript",
+      "match": ["unused-javascript", "javascript"],
+      "branch_suffix": "unused-js"
+    },
+    {
+      "id": "redirects",
+      "match": ["redirect", "redirects"],
+      "branch_suffix": "redirects"
+    },
+    {
+      "id": "unused-css",
+      "match": ["unused-css", "css"],
+      "branch_suffix": "unused-css"
+    },
+    {
+      "id": "accessibility",
+      "match": ["accessibility", "aria", "contrast"],
+      "branch_suffix": "a11y"
+    }
+  ],
+  "notifications": {
+    "enabled": true,
+    "channel": "discord",
+    "discord": {
+      "webhook_url_env": "PERF_GUARDIAN_DISCORD_WEBHOOK",
+      "username": "Performance Guardian",
+      "mention_on_action_required": false,
+      "mention_user_id": null
+    },
+    "notion": {
+      "token_env": "NOTION_TOKEN",
+      "parent_type": "page",
+      "parent_id_env": "PERF_GUARDIAN_NOTION_PAGE_ID",
+      "database_id_env": null
+    }
+  }
+}

--- a/.claude/perf-guardian.config.json
+++ b/.claude/perf-guardian.config.json
@@ -16,6 +16,16 @@
     "unused_js_kb": 30,
     "largest_image_kb": 200
   },
+  "open_graph": {
+    "enabled": true,
+    "audit_urls": ["/fr/", "/en/", "/fr/blog/"],
+    "min_score": 80,
+    "required_tags": ["og:title", "og:description", "og:image", "og:url", "og:type"],
+    "recommended_tags": ["og:locale", "og:site_name", "og:image:width", "og:image:height"],
+    "image_min_width": 1200,
+    "image_min_height": 630,
+    "include_twitter_card": true
+  },
   "repo": {
     "base_branch": "main",
     "branch_prefix": "fix/perf",
@@ -43,6 +53,11 @@
       "id": "hero-image-lcp",
       "match": ["largest-contentful-paint", "image", "webp", "hero"],
       "branch_suffix": "images-lcp"
+    },
+    {
+      "id": "open-graph",
+      "match": ["open-graph", "og:", "twitter:card", "og:image", "og:url"],
+      "branch_suffix": "open-graph"
     },
     {
       "id": "unused-javascript",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,7 @@
     "database-designer@omniventus-workshop": true,
     "dependency-auditor@omniventus-workshop": true,
     "orchestrate-goal@omniventus-workshop": true,
-    "tech-debt-tracker@omniventus-workshop": true
+    "tech-debt-tracker@omniventus-workshop": true,
+    "performance-guardian@omniventus-workshop": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,12 @@
     "spec-driven-workflow@omniventus-workshop": true,
     "git-pull-request@omniventus-workshop": true,
     "commit-and-push@omniventus-workshop": true,
-    "pr-tech-lead-review@omniventus-workshop": true
+    "pr-tech-lead-review@omniventus-workshop": true,
+    "agent-designer@omniventus-workshop": true,
+    "codebase-onboarding@omniventus-workshop": true,
+    "database-designer@omniventus-workshop": true,
+    "dependency-auditor@omniventus-workshop": true,
+    "orchestrate-goal@omniventus-workshop": true,
+    "tech-debt-tracker@omniventus-workshop": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ db_cluster-*.gz
 # Captures d'écran d'audit/QA ad-hoc (volumineuses). Les références versionnées
 # déjà commitées restent suivies ; ceci évite que les nouvelles polluent le repo.
 docs/audits/shots/
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ db_cluster-*.gz
 # déjà commitées restent suivies ; ceci évite que les nouvelles polluent le repo.
 docs/audits/shots/
 .superpowers/
+
+# Worktrees git créés par performance-guardian (fixes perf isolés)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Ajoute 6 plugins `omniventus-workshop` au `.claude/settings.json` projet pour standardiser l'outillage IA de l'équipe.
- Introduit `.claude/perf-guardian.config.json` pour le skill performance-guardian (cible vitrine `reseauevolvecapital.com`).
- Ignore `.superpowers/` dans `.gitignore` (artefacts locaux de brainstorming).

## Test plan

- [ ] Ouvrir le repo avec Claude Code : les plugins projet se proposent à l'installation
- [ ] Vérifier que `.claude/perf-guardian.config.json` valide contre `config.schema.json`
- [ ] Confirmer que `.superpowers/` reste untracked localement


Made with [Cursor](https://cursor.com)