### PR TITLE
fix(vitrine): ajoute og:url, og:locale et og:siteName manquants (OG score 76→100)

### DIFF
--- a/apps/vitrine/src/app/[locale]/layout.tsx
+++ b/apps/vitrine/src/app/[locale]/layout.tsx
@@ -68,6 +68,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     // Enhanced SEO settings
 
     openGraph: {
+      url: `/${locale}/`,
+      siteName: siteConfig.name[locale],
+      locale: locale === 'fr' ? 'fr_FR' : 'en_US',
       title: siteConfig.name[locale],
       description: siteConfig.description[locale],
       type: 'website',
@@ -78,12 +81,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           width: 1200,
           height: 630,
         },
-        // {
-        //   url: siteConfig.author.avatar,
-        //   type: "image/png",
-        //   width: 1200,
-        //   height: 630,
-        // },
       ],
     },
   }


### PR DESCRIPTION
## Performance Guardian — Fix Open Graph

**Routine** : Performance Guardian hebdo — 2026-06-14
**Déclencheur** : Score OG 76/100 < seuil 80 sur 3 URLs auditées

### Diagnostic

| URL | og:url | og:locale | og:site_name | Score OG |
|-----|--------|-----------|--------------|----------|
| `/fr/` | ❌ manquant | ❌ manquant | ❌ manquant | 76/100 |
| `/en/` | ❌ manquant | ❌ manquant | ❌ manquant | 76/100 |
| `/fr/blog/` | ❌ manquant | ❌ manquant | ❌ manquant | 76/100 |

Les 3 balises manquantes sont des champs `required` et `recommended` selon la config guardian.

### Fix

Ajout de `url`, `siteName` et `locale` dans le `openGraph` de `generateMetadata` dans `apps/vitrine/src/app/[locale]/layout.tsx` :

```tsx
openGraph: {
  url: `/${locale}/`,
  siteName: siteConfig.name[locale],
  locale: locale === 'fr' ? 'fr_FR' : 'en_US',
  // ... champs existants inchangés
}
```

Le layout couvre les 3 URLs auditées (la home page et le listing blog n'ont pas de `generateMetadata` propre).

### Scores attendus après deploy

| Métrique | Avant | Après | Seuil |
|---------|-------|-------|-------|
| Open Graph | 76/100 | ~100/100 | ≥ 80 |

### Scores hors périmètre (information)

| Métrique | Mobile | Desktop | Seuil | État |
|---------|--------|---------|-------|------|
| Performance | 74 | 95 | 90/95 | ❌ Mobile |
| LCP | 5,8 s | 1,2 s | 2,5 s | ❌ Mobile |
| Unused JS | 134 KB | 134 KB | 30 KB | ❌ (85 KB = GTM externe) |
| Accessibility | 86 | 86 | 90 | ❌ |
| CLS | 0,01 | 0 | 0,1 | ✅ |

> Les problèmes de perf mobile (LCP) et accessibilité nécessitent des fixes multi-composants — réservés à des tickets dédiés hors périmètre guardian.

### Validation

- ✅ `pnpm tsc --noEmit` — 0 erreur
- ✅ ESLint — 0 warning
- ⚠️ `next build` — échec pré-existant (Strapi hors ligne en CI, documenté CLAUDE.md vitrine)
- ✅ Périmètre fix : `apps/vitrine/src/` uniquement

https://claude.ai/code/session_01GCpGTD5muZ5inEg9fvrUhd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCpGTD5muZ5inEg9fvrUhd)_