### PR TITLE
fix(web): statut de cotisation dérivé de l'échéancier quand la feuille COTISATIONS bugge

### DIFF
--- a/apps/web/lib/data/contributionStatus.test.ts
+++ b/apps/web/lib/data/contributionStatus.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  deriveContributionStatus,
+  joinedAtToYM,
+  type MonthForStatus,
+  type ContributionStatus,
+} from './contributionStatus'
+
+// Indice ordinal absolu (year*12 + month-1), même convention que la couche data.
+const ym = (year: number, month: number) => year * 12 + (month - 1)
+const NOW = ym(2026, 6) // juin 2026
+// nowYM très bas → utilisé pour forcer des mois en « futur » dans un cas dédié.
+
+const month = (year: number, m: number, status: MonthForStatus['status']): MonthForStatus => ({
+  year,
+  month: m,
+  status,
+})
+
+describe('joinedAtToYM', () => {
+  it('convertit une date ISO en indice ordinal (mois 0-based interne)', () => {
+    expect(joinedAtToYM('2018-06-01')).toBe(ym(2018, 6))
+  })
+  it('null / chaîne vide / date invalide → null', () => {
+    expect(joinedAtToYM(null)).toBeNull()
+    expect(joinedAtToYM('')).toBeNull()
+    expect(joinedAtToYM('pas-une-date')).toBeNull()
+  })
+})
+
+describe('deriveContributionStatus — fallback (le statut feuille prime)', () => {
+  const months = [month(2026, 4, 'late'), month(2026, 5, 'late')] // 2 arriérés évidents
+
+  it.each(['ok', 'late', 'exempt'] as ContributionStatus[])(
+    'statut feuille explicite « %s » → conservé tel quel, AUCUNE dérivation',
+    (sheet) => {
+      expect(deriveContributionStatus(sheet, months, null, NOW)).toBe(sheet)
+    }
+  )
+
+  it('statut feuille `pending` → on dérive (ne reste pas bloqué sur pending)', () => {
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('late')
+  })
+})
+
+describe('deriveContributionStatus — dérivation depuis les mois (sheet = pending)', () => {
+  it('au moins un mois passé en retard → late (CAS DU BUG : 2 mois non cotisés)', () => {
+    const months = [month(2026, 1, 'paid'), month(2026, 4, 'late'), month(2026, 5, 'late')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('late')
+  })
+
+  it('que des mois payés (aucun arriéré) → ok', () => {
+    const months = [month(2026, 3, 'paid'), month(2026, 4, 'paid'), month(2026, 5, 'paid')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('ok')
+  })
+
+  it('arriéré ET paiements → late prime (un seul retard suffit)', () => {
+    const months = [month(2026, 3, 'paid'), month(2026, 4, 'late')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('late')
+  })
+
+  it('aucun mois → reste pending (on n’invente pas un « à jour »)', () => {
+    expect(deriveContributionStatus('pending', [], null, NOW)).toBe('pending')
+  })
+
+  it('que des mois `due` (mois courant non encore payé) → pending', () => {
+    const months = [month(2026, 6, 'due')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('pending')
+  })
+})
+
+describe('deriveContributionStatus — contexte adhésion + mois courant (cohérent avec la frise)', () => {
+  it('mois `late` ANTÉRIEUR à l’adhésion → ignoré (jamais d’arriéré pré-adhésion)', () => {
+    const joinedAt = ym(2026, 3) // adhésion mars 2026
+    const months = [month(2026, 1, 'late'), month(2026, 2, 'late')] // avant adhésion
+    expect(deriveContributionStatus('pending', months, joinedAt, NOW)).toBe('pending')
+  })
+
+  it('arriéré APRÈS l’adhésion → late ; ceux d’avant restent ignorés', () => {
+    const joinedAt = ym(2026, 3)
+    const months = [month(2026, 1, 'late'), month(2026, 4, 'late')]
+    expect(deriveContributionStatus('pending', months, joinedAt, NOW)).toBe('late')
+  })
+
+  it('mois `late` STRICTEMENT FUTUR (année courante) → ignoré (pas encore dû)', () => {
+    // nowYM = juin 2026 ; un mois d’août 2026 marqué late en DB ne doit pas compter.
+    const months = [month(2026, 8, 'late')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('pending')
+  })
+
+  it('mois payé futur → ignoré (n’est pas un signal « à jour » du mois courant)', () => {
+    const months = [month(2026, 9, 'paid')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('pending')
+  })
+
+  it('mois courant (== nowYM) payé → ok (limite incluse)', () => {
+    const months = [month(2026, 6, 'paid')]
+    expect(deriveContributionStatus('pending', months, null, NOW)).toBe('ok')
+  })
+})

--- a/apps/web/lib/data/contributionStatus.ts
+++ b/apps/web/lib/data/contributionStatus.ts
@@ -1,0 +1,80 @@
+// Dérivation du statut GLOBAL de cotisation, avec FALLBACK sur l'échéancier mensuel.
+//
+// Problème (bug observé en prod) : le statut global affiché sur le dashboard ET en tête de la
+// page cotisations est une RECOPIE de la colonne « statut » de la feuille COTISATIONS
+// (`contributions.status`). Cette colonne bugge régulièrement sur la matrice (cellule vide,
+// `#ERROR!`, libellé non reconnu) → le mapper `cotisations.mapper.ts` retombe sur `pending`
+// (« En attente »). Conséquence : un membre clairement EN RETARD voyait « En attente » sur son
+// dashboard, en contradiction avec sa propre frise mensuelle (qui, elle, sait déduire le retard).
+//
+// Correctif : quand le statut feuille est `pending` (= information absente/illisible), on DÉRIVE
+// le statut réel depuis l'historique mensuel (feuille « Details cotisations »), déjà fiable et
+// source de `months_count`. On applique EXACTEMENT le même contexte que la frise (`deriveVariant`
+// dans `contributions.ts`) pour garantir qu'un badge global et la frise ne se contredisent JAMAIS.
+//
+// C'est un FALLBACK, pas un override : un statut feuille EXPLICITE (`ok`/`late`/`exempt`) prime
+// toujours et n'est jamais recalculé — on ne dérive qu'en l'absence d'info fiable.
+//
+// Réf : DATA_MODEL.md §2.6/§2.7, CLAUDE.md (jamais de statut trompeur à l'écran).
+
+import type { Database } from '@evolve/data'
+
+export type ContributionStatus = Database['public']['Enums']['contribution_status']
+export type MonthStatus = Database['public']['Enums']['month_status']
+
+/** Sous-ensemble d'un `contribution_months` suffisant pour dériver le statut global. */
+export interface MonthForStatus {
+  year: number
+  month: number
+  status: MonthStatus
+}
+
+/** Indice ordinal absolu d'un mois (year*12 + month-1) — même convention que `contributions.ts`. */
+function toYM(year: number, month: number): number {
+  return year * 12 + (month - 1)
+}
+
+/** `joined_at` (ISO `string` ou `null`) → indice ordinal du mois d'adhésion, ou `null` si absent
+ *  /invalide. Partagé entre dashboard.ts et contributions.ts pour borner les mois pré-adhésion. */
+export function joinedAtToYM(joinedAt: string | null): number | null {
+  if (!joinedAt) return null
+  const d = new Date(joinedAt)
+  return Number.isNaN(d.getTime()) ? null : d.getFullYear() * 12 + d.getMonth()
+}
+
+/**
+ * Statut global de cotisation, avec fallback dérivé de l'échéancier mensuel.
+ *
+ * Règle :
+ *   - statut feuille EXPLICITE (`ok`/`late`/`exempt`) → conservé tel quel (la feuille prime) ;
+ *   - statut feuille `pending` → on dérive depuis les mois, avec le MÊME contexte que la frise :
+ *       • mois antérieur à l'adhésion (`< joinedAtYM`) → ignoré (sans objet) ;
+ *       • mois strictement futur (`> nowYM`)           → ignoré (pas encore dû) ;
+ *       • sinon : `late` ⇒ arriéré, `paid` ⇒ cotisé ;
+ *     puis : au moins un arriéré ⇒ `late` ; sinon au moins un mois payé ⇒ `ok` ;
+ *     sinon `pending` (aucun signal exploitable — on n'invente pas un « à jour » trompeur).
+ *
+ * Pure (testée sans DB). `joinedAtYM`/`nowYM` sont des indices ordinaux (cf. toYM).
+ */
+export function deriveContributionStatus(
+  sheetStatus: ContributionStatus,
+  months: MonthForStatus[],
+  joinedAtYM: number | null,
+  nowYM: number
+): ContributionStatus {
+  if (sheetStatus !== 'pending') return sheetStatus
+
+  let hasArrear = false
+  let hasPaid = false
+  for (const m of months) {
+    const ym = toYM(m.year, m.month)
+    if (joinedAtYM != null && ym < joinedAtYM) continue // pré-adhésion : sans objet
+    if (ym > nowYM) continue // futur : pas encore dû
+    if (m.status === 'late') hasArrear = true
+    else if (m.status === 'paid') hasPaid = true
+  }
+
+  if (hasArrear) return 'late'
+  if (hasPaid) return 'ok'
+  return 'pending'
+}

--- a/apps/web/lib/data/contributions.ts
+++ b/apps/web/lib/data/contributions.ts
@@ -14,6 +14,8 @@ import type { createServerClient, Database } from '@evolve/data'
 import type { TimelineYear, CotisationVariant } from '@evolve/ui'
 import { formatEUR, formatMonth, formatDate } from '@evolve/utils'
 
+import { deriveContributionStatus, joinedAtToYM } from './contributionStatus'
+
 type ServerClient = ReturnType<typeof createServerClient>
 type ContributionRow = Database['public']['Tables']['contributions']['Row']
 type ContributionMonthRow = Database['public']['Tables']['contribution_months']['Row']
@@ -242,12 +244,7 @@ export async function getContributionsData(
   const currentYear = now.getFullYear()
   // Indices ordinaux pour la dérivation contextuelle des variantes (cf. deriveVariant).
   const nowYM = currentYear * 12 + now.getMonth()
-  const joinedAtYM = membership.joined_at
-    ? (() => {
-        const d = new Date(membership.joined_at)
-        return Number.isNaN(d.getTime()) ? null : d.getFullYear() * 12 + d.getMonth()
-      })()
-    : null
+  const joinedAtYM = joinedAtToYM(membership.joined_at)
 
   // Fix 2 — paralléliser les deux requêtes data (indépendantes, cf. dashboard.ts).
   const [{ data: summary, error }, { data: monthRows, error: monthsError }] = await Promise.all([
@@ -294,7 +291,9 @@ export async function getContributionsData(
 
   return {
     clubId,
-    status: summary.status,
+    // Statut global : la colonne feuille COTISATIONS prime, mais si elle est illisible
+    // (`pending`) on dérive depuis la frise mensuelle déjà chargée (cohérence badge ↔ frise).
+    status: deriveContributionStatus(summary.status, months, joinedAtYM, nowYM),
     userRole: membership.role,
     totalContributed: Number(summary.total_contributed ?? 0),
     // D2 — la colonne `months_count` vient d'une cellule #ERROR! (→ null/0). On dérive le

--- a/apps/web/lib/data/dashboard.test.ts
+++ b/apps/web/lib/data/dashboard.test.ts
@@ -12,8 +12,9 @@ type SingleResult = { data: unknown; error: unknown }
 /**
  * Construit un faux client Supabase chaînable (zéro réseau).
  * `.from(table)` renvoie un objet dont `.select().eq()....maybeSingle()`
- * résout vers la fixture associée à la table. Les `.eq()` se chaînent à
- * l'infini ; seul `.maybeSingle()` termine la chaîne.
+ * résout vers la fixture associée à la table. Les `.eq()`/`.lte()`/`.order()`
+ * se chaînent à l'infini ; `.maybeSingle()` ET `.returns()` terminent la chaîne
+ * (le dashboard lit `contribution_months` via `.lte().returns()`, pas `.maybeSingle()`).
  */
 function makeSupabaseMock(fixtures: Record<string, SingleResult>): ServerClient {
   const from = (table: string) => {
@@ -21,7 +22,10 @@ function makeSupabaseMock(fixtures: Record<string, SingleResult>): ServerClient 
     const chain: Record<string, unknown> = {}
     chain.select = () => chain
     chain.eq = () => chain
+    chain.lte = () => chain
+    chain.order = () => chain
     chain.maybeSingle = () => Promise.resolve(result)
+    chain.returns = () => Promise.resolve(result)
     return chain
   }
   return { from } as unknown as ServerClient
@@ -120,5 +124,72 @@ describe('getDashboardData', () => {
     expect(result?.member.fullName).toBe('Membre')
     expect(result?.member.firstname).toBeNull()
     expect(result?.syncedAt).toBeNull()
+  })
+
+  // Fallback de statut (le bug d'origine) : la feuille COTISATIONS renvoie `pending` (cellule
+  // vide / #ERROR!) mais l'échéancier mensuel sait que le membre est en retard ou à jour.
+  const mqpPending = {
+    role: 'member',
+    joined_at: '2018-06-01',
+    detention_pct: '0',
+    total_contributed: '0',
+    net_market_value: '0',
+    contribution_status: 'pending',
+    amount_due: '150',
+  }
+
+  it('feuille `pending` + arriérés dans l’échéancier → dérive `late` (CAS DU BUG)', async () => {
+    const supabase = makeSupabaseMock({
+      member_quote_part: { data: mqpPending, error: null },
+      users: { data: { firstname: 'Test', full_name: 'Membre Test' }, error: null },
+      clubs: { data: { name: 'Club Test', synced_at: '2026-06-05T10:00:00Z' }, error: null },
+      memberships: { data: { id: 'm-1' }, error: null },
+      contribution_months: {
+        data: [
+          { year: 2020, month: 1, amount: '100', status: 'paid' },
+          { year: 2020, month: 2, amount: '0', status: 'late' },
+          { year: 2020, month: 3, amount: '0', status: 'late' },
+        ],
+        error: null,
+      },
+    })
+
+    const result = await getDashboardData(supabase, 'user-1', 'club-1')
+    expect(result?.contribution.status).toBe('late')
+  })
+
+  it('feuille `pending` + tous les mois payés → dérive `ok`', async () => {
+    const supabase = makeSupabaseMock({
+      member_quote_part: { data: mqpPending, error: null },
+      users: { data: { firstname: 'Test', full_name: 'Membre Test' }, error: null },
+      clubs: { data: { name: 'Club Test' }, error: null },
+      memberships: { data: { id: 'm-1' }, error: null },
+      contribution_months: {
+        data: [
+          { year: 2020, month: 1, amount: '100', status: 'paid' },
+          { year: 2020, month: 2, amount: '100', status: 'paid' },
+        ],
+        error: null,
+      },
+    })
+
+    const result = await getDashboardData(supabase, 'user-1', 'club-1')
+    expect(result?.contribution.status).toBe('ok')
+  })
+
+  it('feuille explicite `ok` → conservée, AUCUNE dérivation même avec des arriérés', async () => {
+    const supabase = makeSupabaseMock({
+      member_quote_part: { data: { ...mqpPending, contribution_status: 'ok' }, error: null },
+      users: { data: { firstname: 'Test', full_name: 'Membre Test' }, error: null },
+      clubs: { data: { name: 'Club Test' }, error: null },
+      memberships: { data: { id: 'm-1' }, error: null },
+      contribution_months: {
+        data: [{ year: 2020, month: 2, amount: '0', status: 'late' }],
+        error: null,
+      },
+    })
+
+    const result = await getDashboardData(supabase, 'user-1', 'club-1')
+    expect(result?.contribution.status).toBe('ok')
   })
 })

--- a/apps/web/lib/data/dashboard.ts
+++ b/apps/web/lib/data/dashboard.ts
@@ -15,12 +15,15 @@
 import type { createServerClient } from '@evolve/data'
 import type { Database } from '@evolve/data'
 
+import { deriveContributionStatus, joinedAtToYM } from './contributionStatus'
+
 /** Client Supabase serveur tel que retourné par `createServerClient` (session + RLS). */
 type ServerClient = ReturnType<typeof createServerClient>
 
 type MemberQuotePartRow = Database['public']['Views']['member_quote_part']['Row']
 type UserRow = Database['public']['Tables']['users']['Row']
 type ClubRow = Database['public']['Tables']['clubs']['Row']
+type ContributionMonthRow = Database['public']['Tables']['contribution_months']['Row']
 
 export type ContributionStatus = Database['public']['Enums']['contribution_status']
 export type MemberRole = Database['public']['Enums']['member_role']
@@ -105,17 +108,34 @@ export async function getDashboardData(
 
   // E3 — capacité d'investissement restante de l'année (même calcul que l'attestation :
   // plafond annuel du club − somme des mois cotisés `paid` de l'année en cours).
+  //
+  // Même requête mensuelle réutilisée pour DÉRIVER le statut de cotisation : la colonne « statut »
+  // de la feuille COTISATIONS bugge parfois (→ `pending`), on retombe alors sur l'échéancier réel
+  // (cf. deriveContributionStatus). On élargit donc le filtre à tous les mois ≤ année courante
+  // (et non plus le seul mois `paid` de l'année), puis on filtre côté JS pour `yearInvested`.
   const cap = club?.annual_investment_cap != null ? Number(club.annual_investment_cap) : null
   let yearInvested = 0
+  let contributionStatus = mqp.contribution_status ?? 'pending'
   if (membership?.id) {
-    const currentYear = new Date().getFullYear()
+    const now = new Date()
+    const currentYear = now.getFullYear()
+    const nowYM = currentYear * 12 + now.getMonth()
     const { data: months } = await supabase
       .from('contribution_months')
-      .select('amount')
+      .select('year, month, amount, status')
       .eq('membership_id', membership.id)
-      .eq('year', currentYear)
-      .eq('status', 'paid')
-    yearInvested = (months ?? []).reduce((sum, m) => sum + Number(m.amount ?? 0), 0)
+      .lte('year', currentYear)
+      .returns<Pick<ContributionMonthRow, 'year' | 'month' | 'amount' | 'status'>[]>()
+    const rows = months ?? []
+    yearInvested = rows
+      .filter((m) => m.year === currentYear && m.status === 'paid')
+      .reduce((sum, m) => sum + Number(m.amount ?? 0), 0)
+    contributionStatus = deriveContributionStatus(
+      contributionStatus,
+      rows.map((m) => ({ year: m.year, month: m.month, status: m.status })),
+      joinedAtToYM(mqp.joined_at),
+      nowYM
+    )
   }
   const remaining = cap === null ? null : Math.max(0, cap - yearInvested)
 
@@ -131,7 +151,7 @@ export async function getDashboardData(
     detentionPct: Number(mqp.detention_pct ?? 0),
     totalContributed: Number(mqp.total_contributed ?? 0),
     contribution: {
-      status: mqp.contribution_status ?? 'pending',
+      status: contributionStatus,
       amountDue: Number(mqp.amount_due ?? 0),
     },
     investment: { cap, yearInvested, remaining },


### PR DESCRIPTION
## Problème

Sur le **dashboard** (et en tête de la **page cotisations**), le statut global de cotisation est une **recopie de la colonne « statut » de la feuille `COTISATIONS`** (`contributions.status`). Cette colonne **bugge régulièrement sur la matrice** : cellule vide, `#ERROR!`, libellé non reconnu → le mapper `cotisations.mapper.ts` retombe sur `pending` (« En attente »).

**Symptôme constaté en prod** : un membre dont la dernière cotisation remonte à ~2 mois voit **« En attente »** sur son dashboard, alors que sa **frise mensuelle** (calculée par dates) affiche bien les mois en **retard**. Le badge global et la frise se contredisaient.

## Cause racine

Le statut global n'était **jamais** calculé à partir des dates/paiements — uniquement recopié de la feuille. Détail dans la table de vérité (voir commit). La frise mensuelle (`contribution_months`), elle, déduit déjà correctement `paid` / `late` / `due`.

## Correctif — fallback, pas override

Nouveau helper pur **`deriveContributionStatus`** :

- statut feuille **explicite** (`ok` / `late` / `exempt`) → **conservé tel quel** (la feuille prime) ;
- statut feuille **`pending`** (info absente/illisible) → on **dérive** depuis l'échéancier mensuel, avec **exactement le même contexte que la frise** (`deriveVariant` : adhésion + mois courant) pour ne **jamais** se contredire :
  - au moins un **arriéré** (mois passé non payé, après l'adhésion) → **`late`**
  - sinon au moins un mois **payé** → **`ok`**
  - sinon → **`pending`** (aucun signal — on n'invente pas un « à jour » trompeur).

Les mois **antérieurs à l'adhésion** et **strictement futurs** sont ignorés, exactement comme dans la frise.

## Périmètre

- `apps/web/lib/data/contributionStatus.ts` — helper pur `deriveContributionStatus` + `joinedAtToYM` (zéro dépendance UI).
- `apps/web/lib/data/contributions.ts` — câblage (la frise est déjà chargée → coût nul).
- `apps/web/lib/data/dashboard.ts` — requête mensuelle élargie à `≤ année courante` (au lieu du seul mois `paid` de l'année), `yearInvested` re-filtré côté JS.
- **Aucun changement de vue / SQL / migration** : les vues dérivent déjà label, message, couleur et montant dû du statut → le fallback se propage automatiquement (dashboard V1 + V2 + page cotisations).

## Tests (aucune régression)

- **16** tests unitaires du helper (fallback, dérivation, contexte adhésion/futur, limites).
- **3** tests d'intégration `dashboard.test.ts` dont le **cas du bug** (`pending` + arriérés → `late`).
- Gate vert : **356** tests `apps/web`, `typecheck` + `lint` + `prettier`, clés i18n `fr`/`en` présentes pour tous les statuts.

> E2E Playwright non exécuté ici (nécessite la stack Supabase locale + seed dédié). La logique est gatée derrière `status === 'pending'` et entièrement couverte à la couche data — couche la plus basse pertinente selon la stratégie de tests du repo. Les vues étant inchangées, le risque de régression e2e est négligeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)