### PR TITLE
fix(supabase): garde-fou anti-effondrement de valorisation dans la sync (incident GOOGLEFINANCE)

### DIFF
--- a/supabase/functions/sync/__tests__/sync.test.ts
+++ b/supabase/functions/sync/__tests__/sync.test.ts
@@ -1480,3 +1480,128 @@ Deno.test('handler : sync réussie → aucune alerte email', async () => {
   assertEquals(body.success, true)
   assertEquals(emailSends.calls.length, 0)
 })
+
+// ===========================================================================
+// GARDE-FOU VALORISATION — incident GOOGLEFINANCE 2026-06-14
+// ===========================================================================
+// Quand les cours live (GOOGLEFINANCE) sont transitoirement vides dans la feuille,
+// la valo des positions tombe à 0, le total « Portefeuille » s'effondre et les
+// « Valeur Boursière nette » des membres (formule Sheet = détention × total)
+// s'effondrent dans la même proportion. Le garde-fou : si le total chute > 50 % vs la
+// dernière valeur saine persistée → on REFUSE d'écrire (positions/agrégats/net_market_value),
+// on conserve la dernière valeur saine, et on escalade en erreur DURE (alerte trésorier).
+Deno.test(
+  'handler : collapse valorisation (cours GOOGLEFINANCE vides) → valo rejetée, valeurs préservées, success=false',
+  async () => {
+    // POSITIONS SAINES (col 6 = Valeur boursière) : 1 position cotée + agrégat « Portefeuille ».
+    const GOOD_POSITIONS = [
+      ['Nom', 'Symbole', 'Catégorie', 'Parts', 'Devise', 'Cours', 'Valeur'],
+      ['Apple', 'AAPL', 'Action', '10', 'EUR', '120,00', '1 200,00'],
+      ['Portefeuille', '', 'Agrégat', '', '', '', '700 000,00'],
+    ]
+    // POSITIONS EFFONDRÉES : cours vide (GOOGLEFINANCE KO) → valeur vide ; total = résidu cash.
+    const COLLAPSED_POSITIONS = [
+      ['Nom', 'Symbole', 'Catégorie', 'Parts', 'Devise', 'Cours', 'Valeur'],
+      ['Apple', 'AAPL', 'Action', '10', 'EUR', '', ''],
+      ['Portefeuille', '', 'Agrégat', '', '', '', '159,08'],
+    ]
+    // COTISATIONS effondrées (net_market_value = 2,00€ au lieu de 9 500,00€) — doit être PRÉSERVÉ.
+    const COLLAPSED_COTISATIONS = [
+      [
+        'nom',
+        'Nb de mois cotisés',
+        'Pourcentage de détention',
+        'pénalités dues',
+        'Total Cotisé',
+        'Valeur Boursière nette',
+        'Nb normal de cotisations',
+        'Statut',
+        'Montant dû',
+        'Echéancier',
+        'Gain/Perte',
+        'Suffixe',
+      ],
+      [
+        'AFOUDAH Ruben',
+        '90',
+        '33,30%',
+        '0',
+        '9 000,00€',
+        '2,00€',
+        '95',
+        'Situation régulière',
+        '0',
+        '',
+        '',
+        '0,95',
+      ],
+    ]
+
+    const store = emptyStore(true)
+    seedTreasurer(store)
+
+    // 1) Sync SAINE → établit la baseline : agrégat « Portefeuille » = 700 000, net membre = 9 500.
+    await buildHandler(store, { overrides: { POSITIONS: GOOD_POSITIONS } })(syncRequest(CLUB_ID))
+    const aggBefore = store.portfolio_aggregates.find((a) => a.label === 'Portefeuille')
+    assert(aggBefore !== undefined)
+    assertEquals(Number(aggBefore.market_value), 700000)
+    assert(store.contributions.some((c) => Number(c.net_market_value) === 9500))
+
+    // 2) Sync EFFONDRÉE → le garde-fou doit refuser l'écriture.
+    const emailSends: EmailSends = { calls: [] }
+    const res = await buildHandler(store, {
+      overrides: { POSITIONS: COLLAPSED_POSITIONS, COTISATIONS: COLLAPSED_COTISATIONS },
+      emailSends,
+    })(syncRequest(CLUB_ID))
+    assertEquals(res.status, 200)
+    const body = (await res.json()) as SyncResponseBody
+
+    // Erreur DURE escaladée → success=false + message explicite.
+    assertEquals(body.success, false)
+    assert(body.errors.some((e) => e.includes('Valorisation REJETÉE')))
+    // Snapshot Portefeuille marqué partial (et NON success).
+    assertEquals(body.snapshots['Portefeuille'].status, 'partial')
+
+    // Agrégat « Portefeuille » NON écrasé : la dernière valeur saine (700 000) est conservée.
+    const aggAfter = store.portfolio_aggregates.find((a) => a.label === 'Portefeuille')
+    assert(aggAfter !== undefined)
+    assertEquals(Number(aggAfter.market_value), 700000)
+
+    // net_market_value PRÉSERVÉ : 9 500 conservé, la valeur effondrée (2) JAMAIS écrite.
+    assert(store.contributions.some((c) => Number(c.net_market_value) === 9500))
+    assert(store.contributions.every((c) => Number(c.net_market_value) !== 2))
+
+    // Alerte trésorier partie (le mail couvre trésorier + président + network_admin).
+    assertEquals(emailSends.calls.length, 1)
+    assertEquals(emailSends.calls[0].recipients, ['treso@club.fr'])
+  }
+)
+
+// Garde-fou — un VRAI mouvement (baisse < 50 %) ne déclenche PAS le garde-fou : la valo s'écrit.
+Deno.test(
+  'handler : baisse de marché modérée (< 50 %) → PAS de rejet, valo mise à jour',
+  async () => {
+    const POS_700K = [
+      ['Nom', 'Symbole', 'Catégorie', 'Parts', 'Devise', 'Cours', 'Valeur'],
+      ['Apple', 'AAPL', 'Action', '10', 'EUR', '120,00', '1 200,00'],
+      ['Portefeuille', '', 'Agrégat', '', '', '', '700 000,00'],
+    ]
+    // -20 % : cours présents (pas de trou GOOGLEFINANCE), total 560 000 > 50 % de 700 000.
+    const POS_560K = [
+      ['Nom', 'Symbole', 'Catégorie', 'Parts', 'Devise', 'Cours', 'Valeur'],
+      ['Apple', 'AAPL', 'Action', '10', 'EUR', '96,00', '960,00'],
+      ['Portefeuille', '', 'Agrégat', '', '', '', '560 000,00'],
+    ]
+    const store = emptyStore(true)
+    await buildHandler(store, { overrides: { POSITIONS: POS_700K } })(syncRequest(CLUB_ID))
+    const res = await buildHandler(store, { overrides: { POSITIONS: POS_560K } })(
+      syncRequest(CLUB_ID)
+    )
+    const body = (await res.json()) as SyncResponseBody
+    assertEquals(body.success, true)
+    assert(!body.errors.some((e) => e.includes('Valorisation REJETÉE')))
+    const agg = store.portfolio_aggregates.find((a) => a.label === 'Portefeuille')
+    assert(agg !== undefined)
+    assertEquals(Number(agg.market_value), 560000) // la baisse légitime EST écrite
+  }
+)

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -87,6 +87,35 @@ function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
+/**
+ * Alerte Discord best-effort sur erreur DURE de sync (incident GOOGLEFINANCE 2026-06-14).
+ * POST le contenu sur le webhook `SYNC_ALERT_DISCORD_WEBHOOK_URL`. Comme tout l'alerting
+ * de cette fonction : ne throw JAMAIS et n'interrompt jamais la sync (webhook absent =
+ * no-op silencieux). Le mail trésorier/président reste géré par maybeSendSyncErrorAlert.
+ */
+export async function notifyDiscordSyncError(
+  webhookUrl: string | undefined,
+  clubId: string,
+  errors: string[]
+): Promise<void> {
+  if (!webhookUrl) return
+  try {
+    const content =
+      `🔴 **Sync Evolve Capital — erreur**\nClub \`${clubId}\`\n` +
+      errors
+        .map((e) => `• ${e}`)
+        .join('\n')
+        .slice(0, 1800)
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content }),
+    })
+  } catch {
+    // Alerting best-effort : un webhook KO n'interrompt jamais la sync.
+  }
+}
+
 /** Recharge les memberships du club avec le full_name (jointure users) pour les lookups par nom. */
 async function loadMembershipLookups(
   supabase: SupabaseClient,
@@ -179,6 +208,14 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
     const syncedSheets: string[] = []
     const errors: string[] = []
     const warnings: string[] = []
+    // GARDE-FOU VALORISATION (incident GOOGLEFINANCE 2026-06-14) — drapeau partagé entre
+    // l'étape Portefeuille (DÉTECTION du collapse) et l'étape COTISATIONS (PRÉSERVATION de
+    // net_market_value). Quand les cours live (GOOGLEFINANCE) sont transitoirement vides
+    // dans la feuille, la valo des positions tombe à 0, le total portefeuille s'effondre et
+    // les formules « Valeur Boursière nette » des membres (= détention × total) s'effondrent
+    // dans la même proportion. On REFUSE alors d'écrire ces valeurs (on conserve la dernière
+    // valeur saine en base) et on escalade en erreur DURE pour alerter trésorier + président.
+    let valuationUntrusted = false
     // Dirigeants extraits de PARAMETRAGES (capturés à l'étape 1) — consommés APRÈS l'import
     // Base par la réconciliation des rôles. Vide par défaut : si PARAMETRAGES échoue, la
     // réconciliation ne touche aucun rôle (les memberships restent tous 'member').
@@ -474,62 +511,117 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
       const validPositions = positions.filter((p) => p.quantity != null)
       const droppedPositions = positions.filter((p) => p.quantity == null)
       const synced_at = new Date().toISOString()
-      const positionsWithMeta = validPositions.map((p) => ({ ...p, is_active: true, synced_at }))
-      if (positionsWithMeta.length > 0) {
-        const { error } = await supabase
-          .from('positions')
-          .upsert(positionsWithMeta, { onConflict: 'club_id,symbol' })
-        if (error) throw new Error(`upsert positions: ${error.message}`)
-      }
-      // RÉCONCILIATION — désactive les positions FANTÔMES : celles présentes en base mais
-      // ABSENTES de la matrice courante. Les lignes vivantes viennent d'être (ré)upsertées
-      // avec ce `synced_at` (constant du run) ; toute position du club encore active avec un
-      // synced_at ANTÉRIEUR n'a pas été revue → on la désactive (is_active=false) plutôt que
-      // de la supprimer (on conserve l'historique). Idempotent : un re-sync ne réactive rien.
-      // La lecture portfolio filtre déjà .eq('is_active', true) → les fantômes disparaissent.
+
+      // ---- GARDE-FOU VALORISATION (incident GOOGLEFINANCE 2026-06-14) ----
+      // Signature du collapse : une position a une quantité MAIS aucune valeur boursière
+      // (cours « Cours en € » vide/#N/A → market_value null/0). En régime normal, toutes
+      // les positions détenues ont une valo > 0. On corrobore par la MAGNITUDE : le nouveau
+      // total « Portefeuille » chute > 50 % vs la dernière valeur SAINE persistée (un vrai
+      // krach en 2h garde des cours, donc ne déclenche PAS unpriced ; seul un cours manquant
+      // le fait). Si suspect → on n'écrase NI positions, NI agrégats, NI net_market_value :
+      // on garde la dernière valeur saine en base, et on escalade en erreur DURE (alerte).
+      const aggregatesMapped = mapAggregateRows(aggregateRows, clubId)
+      const newTotal =
+        aggregatesMapped.find((a) => a.label.trim().toLowerCase() === 'portefeuille')
+          ?.market_value ?? null
+      const unpriced = validPositions.filter(
+        (p) => (p.quantity ?? 0) > 0 && (p.market_value == null || p.market_value === 0)
+      )
+      let lastGoodTotal: number | null = null
       {
-        const { error: deactErr } = await supabase
-          .from('positions')
-          .update({ is_active: false })
-          .eq('club_id', clubId)
-          .eq('is_active', true)
-          .lt('synced_at', synced_at)
-        if (deactErr) throw new Error(`deactivate positions: ${deactErr.message}`)
-      }
-      // AGRÉGATS (C2) — persiste les lignes à symbole vide (« Portefeuille », « Provision »,
-      // « Solde : … ») dans portfolio_aggregates pour que l'app lise le TOTAL et les soldes par
-      // label. Même logique de réconciliation que les positions : upsert par (club_id, label) avec
-      // ce synced_at, puis désactivation des labels au synced_at antérieur (absents de la matrice).
-      // Matching TOUJOURS par label (jamais par index).
-      {
-        const aggregates = mapAggregateRows(aggregateRows, clubId).map((a) => ({
-          ...a,
-          is_active: true,
-          synced_at,
-        }))
-        if (aggregates.length > 0) {
-          const { error: aggErr } = await supabase
-            .from('portfolio_aggregates')
-            .upsert(aggregates, { onConflict: 'club_id,label' })
-          if (aggErr) throw new Error(`upsert portfolio_aggregates: ${aggErr.message}`)
-        }
-        const { error: aggDeactErr } = await supabase
+        const { data: prevAgg } = await supabase
           .from('portfolio_aggregates')
-          .update({ is_active: false })
+          .select('market_value')
           .eq('club_id', clubId)
-          .eq('is_active', true)
-          .lt('synced_at', synced_at)
-        if (aggDeactErr) throw new Error(`deactivate portfolio_aggregates: ${aggDeactErr.message}`)
+          .eq('label', 'Portefeuille')
+          .maybeSingle()
+        const mv = (prevAgg as { market_value?: number | null } | null)?.market_value
+        lastGoodTotal = mv == null ? null : Number(mv)
       }
-      const status: SnapshotStatus = droppedPositions.length > 0 ? 'partial' : 'success'
-      const note =
-        droppedPositions.length > 0
-          ? `${droppedPositions.length} position(s) ignorée(s) : quantité illisible (${droppedPositions
-              .map((p) => p.symbol)
-              .join(', ')})`
-          : null
-      // MOLLE : positions à quantité illisible écartées → warnings[] (la feuille a importé).
-      if (note) warnings.push(`Portefeuille (lignes ignorées): ${note}`)
+      // On exige une BASELINE saine (dernière valeur « Portefeuille » persistée > 0) pour juger :
+      // sans historique (1er sync, club neuf) on ne peut pas détecter un collapse → on laisse
+      // passer. Trip si le total chute > 50 % vs baseline, OU si le total a disparu alors que des
+      // positions n'ont plus de cours (signature GOOGLEFINANCE). `unpriced` enrichit l'alerte.
+      // Le seuil 50 % est volontairement large : un vrai krach garde des cours (donc baisse
+      // < 50 % entre 2 syncs de 2h), tandis qu'un trou de cours fait chuter le total bien plus.
+      const haveBaseline = lastGoodTotal != null && lastGoodTotal > 0
+      const collapseByMagnitude = haveBaseline && newTotal != null && newTotal < 0.5 * lastGoodTotal
+      const totalVanished = haveBaseline && newTotal == null && unpriced.length > 0
+      valuationUntrusted = collapseByMagnitude || totalVanished
+
+      let status: SnapshotStatus
+      let note: string | null
+      if (valuationUntrusted) {
+        // ON N'ÉCRIT RIEN (positions/agrégats) : la dernière valeur saine en base est conservée.
+        const reason =
+          `Valorisation REJETÉE (effondrement détecté, données conservées) : total ` +
+          `${newTotal ?? '—'} € vs ${lastGoodTotal ?? '—'} € au dernier sync sain ; ` +
+          `${unpriced.length} position(s) sans cours [${unpriced.map((p) => p.symbol).join(', ')}]. ` +
+          `Cause probable : GOOGLEFINANCE transitoire. Vérifier les cellules « Cours en € » ` +
+          `de la feuille POSITIONS, puis relancer la sync.`
+        // DURE : escalade dans errors[] → success=false + alerte trésorier/président + Discord.
+        errors.push(`Portefeuille: ${reason}`)
+        status = 'partial'
+        note = reason
+      } else {
+        const positionsWithMeta = validPositions.map((p) => ({ ...p, is_active: true, synced_at }))
+        if (positionsWithMeta.length > 0) {
+          const { error } = await supabase
+            .from('positions')
+            .upsert(positionsWithMeta, { onConflict: 'club_id,symbol' })
+          if (error) throw new Error(`upsert positions: ${error.message}`)
+        }
+        // RÉCONCILIATION — désactive les positions FANTÔMES : celles présentes en base mais
+        // ABSENTES de la matrice courante. Les lignes vivantes viennent d'être (ré)upsertées
+        // avec ce `synced_at` (constant du run) ; toute position du club encore active avec un
+        // synced_at ANTÉRIEUR n'a pas été revue → on la désactive (is_active=false) plutôt que
+        // de la supprimer (on conserve l'historique). Idempotent : un re-sync ne réactive rien.
+        // La lecture portfolio filtre déjà .eq('is_active', true) → les fantômes disparaissent.
+        {
+          const { error: deactErr } = await supabase
+            .from('positions')
+            .update({ is_active: false })
+            .eq('club_id', clubId)
+            .eq('is_active', true)
+            .lt('synced_at', synced_at)
+          if (deactErr) throw new Error(`deactivate positions: ${deactErr.message}`)
+        }
+        // AGRÉGATS (C2) — persiste les lignes à symbole vide (« Portefeuille », « Provision »,
+        // « Solde : … ») dans portfolio_aggregates pour que l'app lise le TOTAL et les soldes par
+        // label. Même logique de réconciliation que les positions : upsert par (club_id, label) avec
+        // ce synced_at, puis désactivation des labels au synced_at antérieur (absents de la matrice).
+        // Matching TOUJOURS par label (jamais par index).
+        {
+          const aggregates = aggregatesMapped.map((a) => ({
+            ...a,
+            is_active: true,
+            synced_at,
+          }))
+          if (aggregates.length > 0) {
+            const { error: aggErr } = await supabase
+              .from('portfolio_aggregates')
+              .upsert(aggregates, { onConflict: 'club_id,label' })
+            if (aggErr) throw new Error(`upsert portfolio_aggregates: ${aggErr.message}`)
+          }
+          const { error: aggDeactErr } = await supabase
+            .from('portfolio_aggregates')
+            .update({ is_active: false })
+            .eq('club_id', clubId)
+            .eq('is_active', true)
+            .lt('synced_at', synced_at)
+          if (aggDeactErr)
+            throw new Error(`deactivate portfolio_aggregates: ${aggDeactErr.message}`)
+        }
+        status = droppedPositions.length > 0 ? 'partial' : 'success'
+        note =
+          droppedPositions.length > 0
+            ? `${droppedPositions.length} position(s) ignorée(s) : quantité illisible (${droppedPositions
+                .map((p) => p.symbol)
+                .join(', ')})`
+            : null
+        // MOLLE : positions à quantité illisible écartées → warnings[] (la feuille a importé).
+        if (note) warnings.push(`Portefeuille (lignes ignorées): ${note}`)
+      }
       // raw_data enrichi : matrice brute + lignes d'agrégat isolées (Provision, Espèces, total…).
       snapshots['Portefeuille'] = await createSnapshot(
         supabase,
@@ -735,10 +827,35 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
       )
       const synced_at = new Date().toISOString()
       if (contributions.length > 0) {
-        const { error } = await supabase.from('contributions').upsert(
-          contributions.map((c) => ({ ...c, synced_at })),
-          { onConflict: 'membership_id' }
-        )
+        let rows_ = contributions.map((c) => ({ ...c, synced_at }))
+        // GARDE-FOU VALORISATION — si l'étape Portefeuille a rejeté la valo (cours
+        // GOOGLEFINANCE vides), net_market_value des membres est lui aussi effondré (formule
+        // Sheet = détention × total). On PRÉSERVE alors la valeur en base (dernière saine) et
+        // on laisse passer les autres colonnes (détention, total cotisé, statut, dû) qui ne
+        // dépendent pas des cours. L'erreur DURE a déjà été poussée par l'étape Portefeuille.
+        if (valuationUntrusted) {
+          const ids = contributions.map((c) => c.membership_id)
+          const { data: prev } = await supabase
+            .from('contributions')
+            .select('membership_id, net_market_value')
+            .in('membership_id', ids)
+          const prevMap = new Map(
+            ((prev ?? []) as Array<{ membership_id: string; net_market_value: number | null }>).map(
+              (p) => [p.membership_id, p.net_market_value]
+            )
+          )
+          rows_ = rows_.map((r) =>
+            prevMap.has(r.membership_id)
+              ? { ...r, net_market_value: prevMap.get(r.membership_id) ?? r.net_market_value }
+              : r
+          )
+          warnings.push(
+            'COTISATIONS: net_market_value préservé (valorisation rejetée ce run, voir Portefeuille).'
+          )
+        }
+        const { error } = await supabase
+          .from('contributions')
+          .upsert(rows_, { onConflict: 'membership_id' })
         if (error) throw new Error(`upsert contributions: ${error.message}`)
       }
       const notes: string[] = []
@@ -824,6 +941,8 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
       await maybeSendSyncErrorAlert(supabase, clubId, errors.join(' | '), {
         sendEmail: deps.sendSyncErrorEmail,
       })
+      // Alerte Discord en parallèle du mail (best-effort, webhook optionnel).
+      await notifyDiscordSyncError(Deno.env.get('SYNC_ALERT_DISCORD_WEBHOOK_URL'), clubId, errors)
     }
 
     // success n'encode QUE les erreurs dures ; warnings est un ajout non-breaking.


### PR DESCRIPTION
## Contexte — incident prod 2026-06-14

La quote-part de tous les membres s'est effondrée (ex. `64 188 € → 14,35 €`) puis est revenue seule au sync suivant, **sans aucun déploiement**. Investigation : la table `sheet_snapshots` (95 runs) montre **~5 reads pourris**.

**Coupable : `GOOGLEFINANCE()` dans la feuille source.** Les cours des positions sont calculés en direct ; GOOGLEFINANCE renvoie par intermittence des cellules vides/#N/A. Quand le `sync` lit la feuille (toutes les 2 h, au `:00`) pile à ce moment → valo positions = 0 → total club `711 810 € → 159,08 €` (résidu trésorerie) → la colonne « Valeur Boursière nette » de COTISATIONS, qui est une **formule Sheet** `= détention × total`, s'effondre dans la même proportion (×4474). Le sync recopiait **verbatim** et `status='partial'` **ne bloquait pas** l'écriture.

## Changements

- **Garde-fou (bloque + conserve la dernière valeur saine)** — étape Portefeuille : si le total « Portefeuille » chute **> 50 %** vs la dernière valeur saine persistée (ou disparaît avec des positions sans cours), on n'écrit **ni positions ni agrégats** (dernière valeur saine conservée) et on **escalade en erreur DURE**.
- **Préservation `net_market_value`** — étape COTISATIONS : si la valo est rejetée, `net_market_value` de chaque membre est préservé (valeur en base réutilisée) ; les autres colonnes (détention, total cotisé, statut, dû) s'écrivent normalement.
- **Alerte** : erreur DURE → e-mail trésorier/président/network_admin (`maybeSendSyncErrorAlert` existant, anti-spam 4 h) + Discord best-effort (`notifyDiscordSyncError`, secret `SYNC_ALERT_DISCORD_WEBHOOK_URL`).
- **Tests** : collapse rejeté + valeurs préservées + alerte ; baisse de marché < 50 % **non** bloquée. `deno test` → **36/36**.

> Seuil 50 % volontairement large : un vrai krach garde ses cours (baisse < 50 % entre 2 syncs de 2 h), seul un trou GOOGLEFINANCE fait chuter le total au-delà.

## Déploiement (owner)
1. `supabase functions deploy sync --use-api`
2. (option) secret `SYNC_ALERT_DISCORD_WEBHOOK_URL` + vérifier `BREVO_API_KEY` + qu'un membre `treasurer`/`president` a un email réel.

## Suivi (hors PR, non bloquant)
- Amont : encadrer GOOGLEFINANCE avec `IFERROR(GOOGLEFINANCE(...); dernier_cours)` pour ne jamais retomber à vide.
- Nettoyer le bruit chronique (ligne ESPECES avec le montant en col B « Symboles » → la mettre en col G ; en-tête « Cotisation attendue ») pour que `partial` redevienne un signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)