### PR TITLE
fix(vitrine): canonical des articles avec préfixe de langue (preview sociale)

### DIFF
--- a/apps/vitrine/src/app/[locale]/blog/[slug]/page.tsx
+++ b/apps/vitrine/src/app/[locale]/blog/[slug]/page.tsx
@@ -64,7 +64,11 @@ export async function generateMetadata({ params }: ArticlePageProps): Promise<Me
     : null
 
   const alternates = {
-    canonical: `/blog/${slug}`,
+    // Le canonical DOIT inclure le préfixe de langue : la page est rendue à
+    // `/${locale}/blog/${slug}` (200). Sans le préfixe, `/blog/${slug}` renvoie 404
+    // → les crawlers sociaux (WhatsApp/Facebook) suivent le canonical, tombent sur
+    // le 404 et retombent sur l'og générique du site (RT-07).
+    canonical: `/${locale}/blog/${slug}`,
     languages: {
       fr: `/fr/blog/${locale === 'fr' ? slug : alternateArticle?.slug || ''}`,
       en: `/en/blog/${locale === 'en' ? slug : alternateArticle?.slug || ''}`,


### PR DESCRIPTION
**Le vrai débloqueur des previews sociales d'articles** (WhatsApp/Facebook). Indépendant de #56/#57.

## Symptôme (Facebook Sharing Debugger)
Partager `https://reseauevolvecapital.com/fr/blog/<slug>/` → preview générique (`og:title` = « reseauevolvecapital.com », description vide), alerte « code de réponse HTTP erroné / 404 ».

## Cause (vérifiée en live)
La page article répond **200** avec tous les bons tags (titre, description, `og:image` = dérivé `large_` Strapi ✓ — le fix RT-07 marche). **MAIS** son `rel="canonical"` pointait sur `/blog/<slug>` **sans le préfixe de langue** → cette URL est un **404** (la page vit à `/<locale>/blog/<slug>`). Les crawlers sociaux **suivent le canonical** → tombent sur le 404 → retombent sur l'og **générique** du site.

`page.tsx` : `canonical: \`/blog/${slug}\`` → `canonical: \`/${locale}/blog/${slug}\``. Les `languages` alternates étaient déjà corrects (`/fr/…`, `/en/…`).

## Effet
Le canonical résout désormais en `/<locale>/blog/<slug>` (200, og de l'article corrects) → preview sociale correcte. Diff chirurgical (1 ligne + commentaire), typecheck + lint vitrine verts.

## Note (hors PR, optionnel)
`metadataBase` = `https://www.reseauevolvecapital.com` (www) alors que le site est servi en non-www (CNAME) → le canonical fait un 301 www→non-www avant d'atteindre le 200. Inoffensif (les crawlers suivent les 301), mais on pourrait passer `metadataBase` en non-www pour éviter le saut. À décider (touche `site-config.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)