### PR TITLE
feat: Web Push + email de vote (PUSH-001, club-scopé)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -36,6 +36,12 @@ NEXT_PUBLIC_GA_ID_APP=G-GEV5MZ4QPV
 NEXT_PUBLIC_CONSENT_BANNER_VARIANT=compact
 NEXT_PUBLIC_CONSENT_BANNER_SIDE=gauche
 
+# Web Push (PUSH-001) — clé publique VAPID pour pushManager.subscribe(). PUBLIQUE (pas un secret).
+# VIDE = abonnement push désactivé (subscribePush() retourne 'no-vapid-key', aucun crash).
+# La clé PRIVÉE (VAPID_PRIVATE_KEY) vit côté Edge Functions UNIQUEMENT, jamais ici.
+# Générer la paire : npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+
 # Expérience A/B « Dashboard V2 » — SERVER-ONLY (résolue côté RSC, jamais shippée au client).
 # Force une variante pour tout le monde (kill-switch / dev). v1 | v2 — vide = pas de forçage.
 DASHBOARD_V2_FORCE=

--- a/apps/web/app/(app)/admin/votes/actions.test.ts
+++ b/apps/web/app/(app)/admin/votes/actions.test.ts
@@ -1,0 +1,259 @@
+// Tests des Server Actions du module Vote — volet INTÉGRATION notifications (spec §8).
+//
+// Couvre le câblage push + email à la publication / clôture d'un vote :
+//   (1) publish + notifyByEmail=true → dispatchNotification('poll.opened', clubId du vote) UNE
+//       fois + invoke('send-poll-email', { poll_id, variant:'opened' }) ;
+//   (2) publish + notifyByEmail=false → AUCUN dispatch, AUCUN email ;
+//   (3) draft (même notifyByEmail=true) → AUCUN dispatch (status ≠ 'open') ;
+//   (4) close → dispatchNotification('poll.closed', clubId du vote) ;
+//   (5) FIRE-AND-FORGET : dispatch qui throw / client service-role qui throw → l'action retourne
+//       quand même { ok:true } (la notif n'échoue jamais la publication) ;
+//   (6) ANTI-CROSS-CLUB : l'event.clubId vaut TOUJOURS le club résolu du vote, jamais un autre
+//       (pas de broadcast plus large).
+//
+// On mocke @evolve/data (createServerClient, createServiceRoleClient, dispatchNotification),
+// next/headers (cookies) et @/lib/data/admin (resolveAdminContext). Le client session expose
+// auth.getUser + from('polls').insert/update/select ; le client service-role n'expose que
+// functions.invoke (push résolu côté Edge, jamais en service-role browser).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const CLUB = 'club-evolve-001'
+const OTHER_CLUB = 'club-autre-999'
+const USER = { id: 'user-staff-1' }
+const POLL_ID = 'poll-abc-123'
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  // polls table
+  insertSingle: vi.fn(),
+  updateResult: vi.fn(),
+  selectSingle: vi.fn(),
+  // notifications
+  dispatchNotification: vi.fn(),
+  createServiceRoleClient: vi.fn(),
+  invoke: vi.fn(),
+  resolveAdminContext: vi.fn(),
+}))
+
+// Builder de requête `polls` minimal et chaînable. insert().select().single() pour la création ;
+// update().eq().eq().eq() (thenable) pour la clôture ; select().eq().eq().single() pour relire le
+// titre. Chaque terminal lit le mock dédié.
+function makePollsQuery() {
+  const updateChain = {
+    eq: vi.fn(),
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(mocks.updateResult()).then(resolve),
+  }
+  updateChain.eq.mockReturnValue(updateChain)
+
+  const selectChain = {
+    eq: vi.fn(),
+    single: () => mocks.selectSingle(),
+  }
+  selectChain.eq.mockReturnValue(selectChain)
+
+  return {
+    insert: () => ({
+      select: () => ({ single: () => mocks.insertSingle() }),
+    }),
+    update: () => updateChain,
+    select: () => selectChain,
+  }
+}
+
+vi.mock('@evolve/data', () => ({
+  createServerClient: () => ({
+    auth: { getUser: mocks.getUser },
+    from: () => makePollsQuery(),
+  }),
+  createServiceRoleClient: () => mocks.createServiceRoleClient(),
+  dispatchNotification: (...args: unknown[]) => mocks.dispatchNotification(...args),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, getAll: () => [], set: () => {} }),
+}))
+
+vi.mock('@/lib/data/admin', () => ({
+  resolveAdminContext: (...args: unknown[]) => mocks.resolveAdminContext(...args),
+}))
+
+import { createPollAction, closePollAction } from './actions'
+
+type CreatePayload = {
+  title: string
+  description: string
+  questionType: 'yes_no' | 'single_choice' | 'multiple_choice' | 'short_text'
+  options: string[]
+  resultsVisibility: 'after_close' | 'live'
+  notifyByEmail: boolean
+  closesAt: string | null
+}
+
+function makePayload(over: Partial<CreatePayload> = {}): CreatePayload {
+  return {
+    title: 'Approuvez-vous le budget 2026 ?',
+    description: '',
+    questionType: 'yes_no',
+    options: [],
+    resultsVisibility: 'after_close',
+    notifyByEmail: true,
+    closesAt: null,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Suppression du bruit console.error (les helpers loggent les échecs avalés).
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  mocks.getUser.mockResolvedValue({ data: { user: USER } })
+  mocks.resolveAdminContext.mockResolvedValue({ userId: USER.id, clubId: CLUB, role: 'president' })
+  mocks.insertSingle.mockResolvedValue({ data: { id: POLL_ID }, error: null })
+  mocks.updateResult.mockReturnValue({ error: null })
+  mocks.selectSingle.mockResolvedValue({
+    data: { title: 'Approuvez-vous le budget 2026 ?' },
+    error: null,
+  })
+  mocks.dispatchNotification.mockResolvedValue({ sent: 1, failed: 0, skipped: 0 })
+  mocks.invoke.mockResolvedValue({ data: { queued: 1 }, error: null })
+  // Client service-role : seul functions.invoke est exposé.
+  mocks.createServiceRoleClient.mockReturnValue({ functions: { invoke: mocks.invoke } })
+})
+
+describe('createPollAction — notifications', () => {
+  it('publish + notifyByEmail=true → dispatch poll.opened (clubId du vote) + email opened', async () => {
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+
+    expect(mocks.dispatchNotification).toHaveBeenCalledTimes(1)
+    const [adminArg, event] = mocks.dispatchNotification.mock.calls[0]!
+    expect(adminArg).toBe(mocks.createServiceRoleClient.mock.results[0]!.value)
+    expect(event).toMatchObject({
+      type: 'poll.opened',
+      clubId: CLUB,
+      payload: { pollId: POLL_ID, title: 'Approuvez-vous le budget 2026 ?' },
+    })
+
+    expect(mocks.invoke).toHaveBeenCalledTimes(1)
+    expect(mocks.invoke).toHaveBeenCalledWith('send-poll-email', {
+      body: { poll_id: POLL_ID, variant: 'opened' },
+    })
+  })
+
+  it('transmet closesAt (ISO fin de journée) dans le payload poll.opened', async () => {
+    await createPollAction(makePayload({ closesAt: '2026-07-01' }), 'publish')
+    const [, event] = mocks.dispatchNotification.mock.calls[0]!
+    expect(event.payload.closesAt).toMatch(/^2026-07-01T/)
+  })
+
+  it('publish + notifyByEmail=false → AUCUN dispatch, AUCUN email', async () => {
+    const res = await createPollAction(makePayload({ notifyByEmail: false }), 'publish')
+
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+    expect(mocks.dispatchNotification).not.toHaveBeenCalled()
+    expect(mocks.invoke).not.toHaveBeenCalled()
+    // Pas même de tentative de création du client service-role.
+    expect(mocks.createServiceRoleClient).not.toHaveBeenCalled()
+  })
+
+  it('draft (action=draft) + notifyByEmail=true → AUCUN dispatch (status ≠ open)', async () => {
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'draft')
+
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+    expect(mocks.dispatchNotification).not.toHaveBeenCalled()
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it('ANTI-CROSS-CLUB : l’event.clubId = club résolu du vote, jamais un autre club', async () => {
+    // Le ctx résolu pointe sur CLUB ; même si un autre club existe, on ne diffuse qu’au club du vote.
+    await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+
+    const [, event] = mocks.dispatchNotification.mock.calls[0]!
+    expect(event.clubId).toBe(CLUB)
+    expect(event.clubId).not.toBe(OTHER_CLUB)
+    // Aucun appel de dispatch ne cible un autre club.
+    for (const call of mocks.dispatchNotification.mock.calls) {
+      expect(call[1].clubId).toBe(CLUB)
+    }
+  })
+
+  it('FIRE-AND-FORGET : dispatchNotification qui throw → action retourne quand même { ok:true }', async () => {
+    mocks.dispatchNotification.mockRejectedValue(new Error('Edge down'))
+
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+  })
+
+  it('FIRE-AND-FORGET : client service-role qui throw (clé absente) → action retourne { ok:true }', async () => {
+    mocks.createServiceRoleClient.mockImplementation(() => {
+      throw new Error('SUPABASE_SERVICE_ROLE_KEY manquante')
+    })
+
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+    // Service-role indisponible → ni push ni email.
+    expect(mocks.dispatchNotification).not.toHaveBeenCalled()
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it('FIRE-AND-FORGET : email invoke qui throw → action retourne quand même { ok:true }', async () => {
+    mocks.invoke.mockRejectedValue(new Error('send-poll-email KO'))
+
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+    expect(res).toEqual({ ok: true, pollId: POLL_ID })
+    // Le push a quand même été tenté avant l’email.
+    expect(mocks.dispatchNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('insert en erreur → pas de notification (la publication a échoué)', async () => {
+    mocks.insertSingle.mockResolvedValue({ data: null, error: { code: '42501' } })
+
+    const res = await createPollAction(makePayload({ notifyByEmail: true }), 'publish')
+    expect(res).toEqual({ ok: false, error: 'forbidden' })
+    expect(mocks.dispatchNotification).not.toHaveBeenCalled()
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('closePollAction — notifications', () => {
+  it('close → dispatch poll.closed (clubId du vote) avec le titre relu', async () => {
+    const res = await closePollAction(POLL_ID)
+
+    expect(res).toEqual({ ok: true })
+    expect(mocks.dispatchNotification).toHaveBeenCalledTimes(1)
+    const [adminArg, event] = mocks.dispatchNotification.mock.calls[0]!
+    expect(adminArg).toBe(mocks.createServiceRoleClient.mock.results[0]!.value)
+    expect(event).toMatchObject({
+      type: 'poll.closed',
+      clubId: CLUB,
+      payload: { pollId: POLL_ID, title: 'Approuvez-vous le budget 2026 ?' },
+    })
+    // Pas d’email à la clôture en V0.
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it('ANTI-CROSS-CLUB : l’event.clubId de clôture = club du vote, jamais un autre', async () => {
+    await closePollAction(POLL_ID)
+    const [, event] = mocks.dispatchNotification.mock.calls[0]!
+    expect(event.clubId).toBe(CLUB)
+    expect(event.clubId).not.toBe(OTHER_CLUB)
+  })
+
+  it('FIRE-AND-FORGET : dispatch poll.closed qui throw → action retourne { ok:true }', async () => {
+    mocks.dispatchNotification.mockRejectedValue(new Error('Edge down'))
+
+    const res = await closePollAction(POLL_ID)
+    expect(res).toEqual({ ok: true })
+  })
+
+  it('update en erreur → pas de notification (la clôture a échoué)', async () => {
+    mocks.updateResult.mockReturnValue({ error: { code: '42501' } })
+
+    const res = await closePollAction(POLL_ID)
+    expect(res).toEqual({ ok: false, error: 'forbidden' })
+    expect(mocks.dispatchNotification).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/(app)/admin/votes/actions.ts
+++ b/apps/web/app/(app)/admin/votes/actions.ts
@@ -10,7 +10,7 @@
 
 import { cookies } from 'next/headers'
 import { z } from 'zod'
-import { createServerClient } from '@evolve/data'
+import { createServerClient, createServiceRoleClient, dispatchNotification } from '@evolve/data'
 import type { Database } from '@evolve/data'
 import { resolveAdminContext } from '@/lib/data/admin'
 
@@ -64,6 +64,79 @@ function buildOptions(
   return labels.map((label, i) => ({ id: `opt-${i + 1}`, label })) as PollOptionsJson
 }
 
+// ─── Notifications (Web Push + email) ──────────────────────────────────────
+//
+// FIRE-AND-FORGET strict : la publication / clôture d'un vote est DÉJÀ persistée quand on
+// notifie. Un échec push/email (clé service-role absente, Edge down, réseau) ne doit JAMAIS
+// faire échouer l'action — l'in-app (bannières) couvre le gap. Ces helpers créent le client
+// service-role en try/catch et ne throw JAMAIS.
+//
+// CLUB-SCOPE : `clubId` est TOUJOURS celui du vote (`ctx.clubId`). On ne diffuse jamais plus
+// large qu'au club du vote — l'Edge `dispatch-push` résout les destinataires de CE club.
+//
+// Réf : spec §8 (intégration), packages/data dispatch.ts (contrat fire-and-forget).
+
+/** Crée le client service-role (server-only) ou null si l'env manque / erreur. Ne throw jamais. */
+function tryServiceRoleClient(): ReturnType<typeof createServiceRoleClient> | null {
+  try {
+    return createServiceRoleClient()
+  } catch (e) {
+    // SUPABASE_SERVICE_ROLE_KEY absente en local, etc. → on abandonne la notif silencieusement.
+    console.error('[votes] service-role client indisponible — notification ignorée', e)
+    return null
+  }
+}
+
+/**
+ * Notifie l'ouverture d'un vote au CLUB (push + email), fire-and-forget. `clubId` est le club
+ * du vote (jamais plus large). Ne throw jamais : tout échec est avalé (loggé).
+ */
+async function notifyPollOpened(
+  clubId: string,
+  pollId: string,
+  title: string,
+  closesAt: string | null
+): Promise<void> {
+  const admin = tryServiceRoleClient()
+  if (!admin) return
+  try {
+    // Push : `dispatchNotification` est déjà fire-and-forget (ne throw pas), on l'awaite quand
+    // même pour ne pas laisser de promesse pendante après la fin de l'action serveur.
+    await dispatchNotification(admin, {
+      type: 'poll.opened',
+      clubId, // ← club du vote, jamais de broadcast plus large.
+      payload: { pollId, title, closesAt },
+    })
+  } catch (e) {
+    console.error('[votes] échec dispatch push poll.opened', e)
+  }
+  try {
+    await admin.functions.invoke('send-poll-email', {
+      body: { poll_id: pollId, variant: 'opened' },
+    })
+  } catch (e) {
+    console.error('[votes] échec invoke send-poll-email', e)
+  }
+}
+
+/**
+ * Notifie la clôture d'un vote au CLUB (push uniquement en V0), fire-and-forget. `clubId` est
+ * le club du vote. Ne throw jamais.
+ */
+async function notifyPollClosed(clubId: string, pollId: string, title: string): Promise<void> {
+  const admin = tryServiceRoleClient()
+  if (!admin) return
+  try {
+    await dispatchNotification(admin, {
+      type: 'poll.closed',
+      clubId, // ← club du vote, jamais de broadcast plus large.
+      payload: { pollId, title },
+    })
+  } catch (e) {
+    console.error('[votes] échec dispatch push poll.closed', e)
+  }
+}
+
 /**
  * Crée un vote. `action='draft'` → status 'draft' (éditable, invisible des membres) ;
  * `action='publish'` → status 'open' (membres notifiés, réponses acceptées). La validation
@@ -111,6 +184,14 @@ export async function createPollAction(
     .single<{ id: string }>()
 
   if (error) return { ok: false, error: mapPgError(error.code) }
+
+  // Notification CLUB (push + email) seulement si publié ET opt-in email coché. Fire-and-forget :
+  // on attend la résolution (helper qui ne throw jamais) puis on retourne EXACTEMENT comme avant —
+  // un échec de notif ne change pas le résultat ({ ok:true } : le vote est déjà créé).
+  if (status === 'open' && p.notifyByEmail) {
+    await notifyPollOpened(ctx.clubId, data.id, p.title, toClosesAt(p.closesAt))
+  }
+
   return { ok: true, pollId: data.id }
 }
 
@@ -138,5 +219,23 @@ export async function closePollAction(pollId: string): Promise<ActionResult> {
     .eq('status', 'open')
 
   if (error) return { ok: false, error: mapPgError(error.code) }
+
+  // Notification CLUB de clôture (push uniquement en V0). On relit le titre via le client session
+  // (RLS), scopé au club du vote (`ctx.clubId`) — jamais d'autre club. Fire-and-forget : un échec
+  // de lecture ou de push ne change pas le résultat ({ ok:true } : la clôture est déjà persistée).
+  try {
+    const { data: poll } = await supabase
+      .from('polls')
+      .select('title')
+      .eq('id', pollId)
+      .eq('club_id', ctx.clubId)
+      .single<{ title: string }>()
+    if (poll) {
+      await notifyPollClosed(ctx.clubId, pollId, poll.title)
+    }
+  } catch (e) {
+    console.error('[votes] échec notification poll.closed', e)
+  }
+
   return { ok: true }
 }

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -13,6 +13,7 @@ import { SupabaseProvider } from '@/components/providers/SupabaseProvider'
 import { hasVoted } from '@evolve/data'
 import { AppChromeSidebar, AppChromeTopbar, AppChromeBottom } from '@/components/chrome/AppChrome'
 import { InstallBannerMount } from '@/components/pwa/InstallBannerMount'
+import { PushOptInMount } from '@/components/push/PushOptInMount'
 import { getSessionUser, getActiveClubMembership } from '@/lib/data/request'
 import { getOpenPolls, hasPollActivity as checkPollActivity } from '@/lib/data/polls'
 
@@ -136,6 +137,9 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           {/* PWA-001 : bannière d'installation. Montée ici (persiste entre onglets) mais
               ne s'affiche que sur /dashboard. Enrobée d'un ErrorBoundary interne. */}
           <InstallBannerMount />
+          {/* PUSH-001 : pre-prompt d'opt-in Web Push. Même mount-pattern que la bannière PWA
+              (ne s'affiche que sur /dashboard, gating capacité + cooldown + consentement). */}
+          <PushOptInMount />
           {/* Analytics GA4 (Phase 2) : user_id pseudonyme + user properties (consent-gated)
               + login_completed une fois par session. Aucune PII. */}
           <AnalyticsIdentify

--- a/apps/web/app/(app)/profil/NotificationsSection.tsx
+++ b/apps/web/app/(app)/profil/NotificationsSection.tsx
@@ -1,0 +1,320 @@
+'use client'
+
+// NotificationsSection (PUSH-001 ; spec §2.3 / §6) — réglages Web Push du profil.
+//
+// - Toggle MASTER : ON déclenche le flux subscribe (requestPermission → subscribe → POST),
+//   OFF désabonne l'endpoint courant (unsubscribe SW + DELETE serveur).
+// - Toggles PAR TYPE (poll_opened / poll_closed / poll_reminder) : bound à push_preferences
+//   (read + upsert via le client Supabase navigateur, RLS owner). Désactivés tant que le
+//   master est OFF.
+// - iOS hors écran d'accueil (`needs_pwa_install`) → encart « installe l'app » + lien profil
+//   PWA (pas de toggle actif). `blocked` → hint d'autorisation navigateur.
+//
+// Crash-safe : aucune erreur ne remonte (toasts d'erreur, états gardés). En dev (SW prod-only)
+// le subscribe renvoie 'unsupported' — c'est attendu ; le vrai push se teste en preview HTTPS.
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useTranslations } from 'next-intl'
+
+import { Badge, Icon, Switch, useToast } from '@evolve/ui'
+
+import { useSupabase } from '@/components/providers/SupabaseProvider'
+import { canSubscribeOnPlatform } from '@/lib/push/permission'
+import { getSubscriptionState, subscribePush, unsubscribePush } from '@/lib/push/subscribe'
+import type { PushPlatformCapability } from '@/lib/push/platform-push'
+
+type PrefKey = 'poll_opened' | 'poll_closed' | 'poll_reminder'
+
+type Prefs = {
+  enabled: boolean
+  poll_opened: boolean
+  poll_closed: boolean
+  poll_reminder: boolean
+}
+
+const DEFAULT_PREFS: Prefs = {
+  enabled: true,
+  poll_opened: true,
+  poll_closed: true,
+  poll_reminder: true,
+}
+
+const TYPE_KEYS: PrefKey[] = ['poll_opened', 'poll_closed', 'poll_reminder']
+
+// Aide générique « comment réactiver les notifications du navigateur » (lien externe).
+const BROWSER_NOTIF_HELP_URL = 'https://support.google.com/chrome/answer/3220216'
+
+/** En-tête de la section : pastille cloche jaune + titre/sous-titre + badge de statut. */
+function SectionHeader({ title, body, badge }: { title: string; body: string; badge: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex min-w-0 items-start gap-3">
+        <span
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent text-accent-ink"
+          aria-hidden="true"
+        >
+          <Icon name="Bell" size={20} />
+        </span>
+        <div className="min-w-0">
+          <h2 className="font-display text-[18px] font-bold leading-tight text-text">{title}</h2>
+          <p className="mt-0.5 font-body text-[13px] text-text-sec">{body}</p>
+        </div>
+      </div>
+      {badge ? <div className="shrink-0">{badge}</div> : null}
+    </div>
+  )
+}
+
+export function NotificationsSection() {
+  const t = useTranslations('push')
+  const toast = useToast()
+  const supabase = useSupabase()
+
+  // Résolu après hydratation (SSR-safe : capability 'unsupported' au render serveur).
+  const [capability, setCapability] = useState<PushPlatformCapability>('unsupported')
+  // Abonné sur CET appareil (subscription présente dans le PushManager) → pilote le master.
+  const [subscribed, setSubscribed] = useState(false)
+  const [prefs, setPrefs] = useState<Prefs>(DEFAULT_PREFS)
+  const [busy, setBusy] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  // Chargement initial : capacité plateforme + état subscription + préférences (RLS owner).
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        setCapability(canSubscribeOnPlatform())
+        const state = await getSubscriptionState()
+        if (cancelled) return
+        setSubscribed(state.subscribed)
+
+        const { data: auth } = await supabase.auth.getUser()
+        if (auth.user) {
+          const { data } = await supabase
+            .from('push_preferences')
+            .select('enabled, poll_opened, poll_closed, poll_reminder')
+            .eq('user_id', auth.user.id)
+            .maybeSingle()
+          if (!cancelled && data) setPrefs({ ...DEFAULT_PREFS, ...data })
+        }
+      } catch {
+        /* dégrade silencieusement vers les défauts */
+      } finally {
+        if (!cancelled) setReady(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [supabase])
+
+  /** Upsert d'un sous-ensemble des préférences (RLS owner via le client navigateur). */
+  const persistPrefs = useCallback(
+    async (next: Partial<Prefs>) => {
+      try {
+        const { data: auth } = await supabase.auth.getUser()
+        if (!auth.user) return
+        await supabase
+          .from('push_preferences')
+          .upsert(
+            { user_id: auth.user.id, ...next, updated_at: new Date().toISOString() },
+            { onConflict: 'user_id' }
+          )
+      } catch {
+        /* non bloquant : l'état local reste ; l'Edge appliquera les défauts si absent */
+      }
+    },
+    [supabase]
+  )
+
+  // Master ON → subscribe ; OFF → unsubscribe. L'état local suit l'issue réelle.
+  const handleMasterToggle = useCallback(
+    async (checked: boolean) => {
+      if (busy) return
+      setBusy(true)
+      try {
+        if (checked) {
+          const result = await subscribePush()
+          if (result === 'subscribed') {
+            setSubscribed(true)
+            setPrefs((p) => ({ ...p, enabled: true }))
+            await persistPrefs({ enabled: true })
+            toast.success({ title: t('toastSuccess.title'), message: t('toastSuccess.message') })
+          } else if (result === 'denied') {
+            setSubscribed(false)
+            toast.error({ title: t('toastBlocked.title'), message: t('toastBlocked.message') })
+          } else {
+            setSubscribed(false)
+            toast.error({ title: t('toastError.title'), message: t('toastError.message') })
+          }
+        } else {
+          await unsubscribePush()
+          setSubscribed(false)
+          setPrefs((p) => ({ ...p, enabled: false }))
+          await persistPrefs({ enabled: false })
+          toast.success({ title: t('toastDisabled.title'), message: t('toastDisabled.message') })
+        }
+      } catch {
+        toast.error({ title: t('toastError.title'), message: t('toastError.message') })
+      } finally {
+        setBusy(false)
+      }
+    },
+    [busy, persistPrefs, toast, t]
+  )
+
+  const handleTypeToggle = useCallback(
+    (key: PrefKey, checked: boolean) => {
+      setPrefs((p) => ({ ...p, [key]: checked }))
+      void persistPrefs({ [key]: checked })
+    },
+    [persistPrefs]
+  )
+
+  // SSR-safe : tant qu'on n'a pas résolu côté client, on ne rend rien (évite un flash de l'encart
+  // iOS sur desktop ou inversement).
+  if (!ready) return null
+
+  // iOS hors écran d'accueil : on n'affiche PAS de toggle (impossible de s'abonner) → encart
+  // d'installation pointant vers la section PWA du profil.
+  if (capability === 'needs_pwa_install' || capability === 'needs_safari') {
+    return (
+      <section className="rounded-lg border border-border bg-card p-6 shadow-card">
+        <SectionHeader
+          title={t('section.title')}
+          body={t('section.body')}
+          badge={<Badge variant="neutral">{t('section.statusOff')}</Badge>}
+        />
+        {/* Encart ambre : notifications indisponibles → renvoie vers l'installation de l'app. */}
+        <div className="mt-5 rounded-[12px] border border-data-warning bg-data-warning-50 p-4">
+          <div className="flex items-start gap-3">
+            <Icon
+              name="Smartphone"
+              size={20}
+              className="mt-0.5 shrink-0 text-data-warning-strong"
+              aria-hidden="true"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="font-body text-[14px] font-semibold text-data-warning-strong">
+                {t('section.iosTitle')}
+              </p>
+              <p className="mt-1 font-body text-[13px] leading-relaxed text-text-sec">
+                {t('section.iosHint')}
+              </p>
+              <a
+                href="/profil"
+                className="mt-3 inline-flex h-11 items-center justify-center rounded-[var(--r-md)] bg-accent px-4 font-body text-[14px] font-semibold text-accent-ink transition-opacity duration-[150ms] hover:opacity-90 focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]"
+              >
+                {t('section.iosCta')}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  // unsupported : navigateur sans support → on masque la section (rien d'actionnable).
+  if (capability === 'unsupported') return null
+
+  // Master « actif » du point de vue UI = abonné sur cet appareil ET préférence enabled.
+  const masterOn = subscribed && prefs.enabled
+  const blocked = capability === 'blocked'
+
+  // Badge de statut (haut-droite de l'en-tête) : actif / refusé / non configuré.
+  const statusBadge = blocked ? (
+    <Badge variant="warning">{t('section.statusBlocked')}</Badge>
+  ) : masterOn ? (
+    <Badge variant="success">{t('section.statusActive')}</Badge>
+  ) : (
+    <Badge variant="neutral">{t('section.statusOff')}</Badge>
+  )
+
+  // Copy par type avec clés littérales (t() est typé sur fr.json — pas de clé dynamique).
+  const typeCopy: Record<PrefKey, { label: string; hint: string }> = {
+    poll_opened: {
+      label: t('section.types.pollOpened.label'),
+      hint: t('section.types.pollOpened.hint'),
+    },
+    poll_closed: {
+      label: t('section.types.pollClosed.label'),
+      hint: t('section.types.pollClosed.hint'),
+    },
+    poll_reminder: {
+      label: t('section.types.pollReminder.label'),
+      hint: t('section.types.pollReminder.hint'),
+    },
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-6 shadow-card">
+      <SectionHeader title={t('section.title')} body={t('section.body')} badge={statusBadge} />
+
+      {/* Master */}
+      <div className="mt-5 flex items-start justify-between gap-4 border-t border-border pt-5">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <label htmlFor="push-master" className="font-body text-[14px] font-medium text-text">
+            {t('section.masterLabel')}
+          </label>
+          <p className="font-body text-[13px] text-text-ter">{t('section.masterHint')}</p>
+        </div>
+        <Switch
+          id="push-master"
+          checked={masterOn}
+          disabled={busy || blocked}
+          onCheckedChange={(c) => void handleMasterToggle(c)}
+          aria-label={t('section.masterLabel')}
+        />
+      </div>
+
+      {blocked ? (
+        <p className="mt-3 flex items-center gap-2 font-body text-[13px] text-text-sec">
+          <Icon
+            name="TriangleAlert"
+            size={16}
+            className="shrink-0 text-data-warning-strong"
+            aria-hidden="true"
+          />
+          <span>
+            {t('section.blockedHintPre')}{' '}
+            <a
+              href={BROWSER_NOTIF_HELP_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-accent underline underline-offset-2 transition-opacity duration-[150ms] hover:opacity-80 focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]"
+            >
+              {t('section.blockedHintLink')}
+            </a>
+          </span>
+        </p>
+      ) : null}
+
+      {/* Sous-préférences par type */}
+      <fieldset
+        className="mt-5 flex flex-col gap-4 border-t border-border pt-5"
+        disabled={!masterOn}
+      >
+        <legend className="font-body text-[13px] font-medium text-text-sec">
+          {t('section.typesLabel')}
+        </legend>
+        {TYPE_KEYS.map((key) => (
+          <div key={key} className="flex items-start justify-between gap-4">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <label htmlFor={`push-${key}`} className="font-body text-[14px] text-text">
+                {typeCopy[key].label}
+              </label>
+              <p className="font-body text-[13px] text-text-ter">{typeCopy[key].hint}</p>
+            </div>
+            <Switch
+              id={`push-${key}`}
+              checked={masterOn && prefs[key]}
+              disabled={!masterOn}
+              onCheckedChange={(c) => handleTypeToggle(key, c)}
+              aria-label={typeCopy[key].label}
+            />
+          </div>
+        ))}
+      </fieldset>
+    </section>
+  )
+}

--- a/apps/web/app/(app)/profil/ProfileView.tsx
+++ b/apps/web/app/(app)/profil/ProfileView.tsx
@@ -3,6 +3,7 @@ import { Badge, Heading } from '@evolve/ui'
 import { formatDate } from '@evolve/utils'
 import type { MemberRole, ProfileData } from '@/lib/data/profile'
 import { InstallSection } from './InstallSection'
+import { NotificationsSection } from './NotificationsSection'
 import { ProfileAvatarUpload } from './ProfileAvatarUpload'
 
 const DASH = '—'
@@ -78,6 +79,10 @@ export async function ProfileView({ data }: { data: ProfileData }) {
       {/* PWA-001 : (ré)installer l'app à la demande (entrée permanente, surtout utile après
           3 refus de la bannière). Masquée si déjà installée (standalone) ou sur desktop. */}
       <InstallSection />
+
+      {/* PUSH-001 : réglages des notifications Web Push (master + sous-préférences par type).
+          Masquée si la plateforme ne supporte pas le push (rien d'actionnable). */}
+      <NotificationsSection />
     </div>
   )
 }

--- a/apps/web/app/api/push/subscribe/route.test.ts
+++ b/apps/web/app/api/push/subscribe/route.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock du client Supabase (RLS de session) : auth.getUser + from(table).upsert(...).
+// On capture les upserts par table pour vérifier le contrat (subscription + préférences).
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  upsertSubscriptions: vi.fn(),
+  upsertPreferences: vi.fn(),
+}))
+
+vi.mock('@evolve/data', () => ({
+  createServerClient: () => ({
+    auth: { getUser: mocks.getUser },
+    from: (table: string) => ({
+      upsert: (values: unknown, opts: unknown) =>
+        table === 'push_subscriptions'
+          ? mocks.upsertSubscriptions(values, opts)
+          : mocks.upsertPreferences(values, opts),
+    }),
+  }),
+}))
+vi.mock('next/headers', () => ({ cookies: async () => ({ getAll: () => [], set: () => {} }) }))
+
+import { POST } from './route'
+
+const validBody = {
+  endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
+  keys: { p256dh: 'p256dh-key', auth: 'auth-key' },
+  userAgent: 'Mozilla/5.0',
+  platform: 'desktop',
+}
+
+function req(body: unknown) {
+  return new Request('http://localhost:3001/api/push/subscribe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  mocks.getUser.mockReset()
+  mocks.upsertSubscriptions.mockReset()
+  mocks.upsertPreferences.mockReset()
+  mocks.upsertSubscriptions.mockResolvedValue({ error: null })
+  mocks.upsertPreferences.mockResolvedValue({ error: null })
+})
+
+describe('POST /api/push/subscribe', () => {
+  it('401 si pas de session', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null }, error: null })
+    const res = await POST(req(validBody))
+    expect(res.status).toBe(401)
+    expect(mocks.upsertSubscriptions).not.toHaveBeenCalled()
+  })
+
+  it('500 si erreur d’authentification', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null }, error: { message: 'boom' } })
+    const res = await POST(req(validBody))
+    expect(res.status).toBe(500)
+  })
+
+  it('400 si la subscription est incomplète (clés manquantes)', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+    const res = await POST(req({ endpoint: 'https://x', keys: {} }))
+    expect(res.status).toBe(400)
+    expect(mocks.upsertSubscriptions).not.toHaveBeenCalled()
+  })
+
+  it('201 + upsert subscription & préférences pour une session valide', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+    const res = await POST(req(validBody))
+    expect(res.status).toBe(201)
+
+    expect(mocks.upsertSubscriptions).toHaveBeenCalledTimes(1)
+    const subCall = mocks.upsertSubscriptions.mock.calls[0]!
+    expect(subCall[0]).toMatchObject({
+      user_id: 'u1',
+      endpoint: validBody.endpoint,
+      p256dh: 'p256dh-key',
+      auth: 'auth-key',
+      platform: 'desktop',
+    })
+    expect(subCall[1]).toMatchObject({ onConflict: 'endpoint' })
+
+    expect(mocks.upsertPreferences).toHaveBeenCalledTimes(1)
+    expect(mocks.upsertPreferences.mock.calls[0]![0]).toMatchObject({ user_id: 'u1' })
+  })
+
+  it('normalise une plateforme inconnue en "unknown"', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+    await POST(req({ ...validBody, platform: 'bogus-platform' }))
+    expect(mocks.upsertSubscriptions.mock.calls[0]![0].platform).toBe('unknown')
+  })
+
+  it('500 si l’upsert de la subscription échoue', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+    mocks.upsertSubscriptions.mockResolvedValue({ error: { message: 'db down' } })
+    const res = await POST(req(validBody))
+    expect(res.status).toBe(500)
+  })
+})

--- a/apps/web/app/api/push/subscribe/route.ts
+++ b/apps/web/app/api/push/subscribe/route.ts
@@ -1,0 +1,101 @@
+// POST /api/push/subscribe — persiste une subscription Web Push (PUSH-001 ; spec §6.3).
+//
+// Garde-fous :
+//   - authentification via session cookie Supabase (getUser()) → 401
+//   - UPSERT push_subscriptions par endpoint (1 ligne = 1 navigateur, multi-appareils/user)
+//   - UPSERT push_preferences (défauts ON) au premier abonnement
+//   - RLS s'applique (createServerClient, JAMAIS service-role) : un membre ne touche QUE
+//     ses propres subscriptions (policies « owner insert/update »).
+//
+// Anonymat / PII : on persiste user_agent + platform (snapshot debug support) — jamais
+// d'email, jamais de contenu. Le payload push lui-même (envoyé par l'Edge) ne porte pas de PII.
+//
+// Réf : DATA_MODEL / migration 039, CLAUDE.md (RLS, SERVICE_ROLE server-only).
+
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+import { createServerClient } from '@evolve/data'
+
+export const runtime = 'nodejs'
+
+/** Plateformes acceptées (aligné sur le CHECK de la migration 039). */
+const PLATFORMS = new Set([
+  'desktop',
+  'android-chrome',
+  'ios-safari',
+  'ios-other',
+  'standalone',
+  'unknown',
+])
+
+type SubscribeBody = {
+  endpoint?: unknown
+  keys?: { p256dh?: unknown; auth?: unknown }
+  userAgent?: unknown
+  platform?: unknown
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError) {
+    return NextResponse.json({ error: "Erreur d'authentification." }, { status: 500 })
+  }
+  if (!auth.user) {
+    return NextResponse.json({ error: 'Non authentifié.' }, { status: 401 })
+  }
+
+  let body: SubscribeBody
+  try {
+    body = (await request.json()) as SubscribeBody
+  } catch {
+    return NextResponse.json({ error: 'Corps de requête invalide.' }, { status: 400 })
+  }
+
+  const endpoint = asString(body.endpoint)
+  const p256dh = asString(body.keys?.p256dh)
+  const authKey = asString(body.keys?.auth)
+  if (!endpoint || !p256dh || !authKey) {
+    return NextResponse.json({ error: 'Subscription incomplète.' }, { status: 400 })
+  }
+
+  const userAgent = asString(body.userAgent)
+  const platformRaw = asString(body.platform)
+  const platform = platformRaw && PLATFORMS.has(platformRaw) ? platformRaw : 'unknown'
+
+  // UPSERT par endpoint : un même navigateur qui se réabonne met à jour ses clés/UA.
+  const { error: subError } = await supabase.from('push_subscriptions').upsert(
+    {
+      user_id: auth.user.id,
+      endpoint,
+      p256dh,
+      auth: authKey,
+      user_agent: userAgent,
+      platform,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'endpoint' }
+  )
+  if (subError) {
+    return NextResponse.json({ error: "Échec de l'enregistrement." }, { status: 500 })
+  }
+
+  // Défauts ON au premier abonnement. ignoreDuplicates : ne pas écraser un réglage existant
+  // (un membre déjà abonné sur un autre appareil garde ses préférences par type).
+  const { error: prefError } = await supabase
+    .from('push_preferences')
+    .upsert({ user_id: auth.user.id }, { onConflict: 'user_id', ignoreDuplicates: true })
+  if (prefError) {
+    // Non bloquant : la subscription est persistée ; les défauts seront appliqués par l'Edge.
+    return NextResponse.json({ ok: true, preferences: 'skipped' }, { status: 201 })
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 })
+}

--- a/apps/web/app/api/push/unsubscribe/route.ts
+++ b/apps/web/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,69 @@
+// POST|DELETE /api/push/unsubscribe — retire une subscription Web Push (PUSH-001 ; spec §6.3).
+//
+// Garde-fous :
+//   - authentification via session cookie Supabase (getUser()) → 401
+//   - DELETE par endpoint POUR l'utilisateur courant uniquement (filtre user_id + RLS)
+//   - RLS s'applique (createServerClient, JAMAIS service-role) : policy « owner delete ».
+//
+// Appelé au logout (appareil partagé) et depuis le toggle « Notifications » du profil (OFF).
+// Idempotent : retirer un endpoint inexistant retourne 200.
+
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+import { createServerClient } from '@evolve/data'
+
+export const runtime = 'nodejs'
+
+async function deleteByEndpoint(endpointRaw: unknown): Promise<NextResponse> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError) {
+    return NextResponse.json({ error: "Erreur d'authentification." }, { status: 500 })
+  }
+  if (!auth.user) {
+    return NextResponse.json({ error: 'Non authentifié.' }, { status: 401 })
+  }
+
+  const endpoint = typeof endpointRaw === 'string' && endpointRaw.length > 0 ? endpointRaw : null
+  if (!endpoint) {
+    return NextResponse.json({ error: 'Endpoint manquant.' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('push_subscriptions')
+    .delete()
+    .eq('user_id', auth.user.id)
+    .eq('endpoint', endpoint)
+  if (error) {
+    return NextResponse.json({ error: 'Échec du désabonnement.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let endpoint: unknown
+  try {
+    endpoint = ((await request.json()) as { endpoint?: unknown }).endpoint
+  } catch {
+    return NextResponse.json({ error: 'Corps de requête invalide.' }, { status: 400 })
+  }
+  return deleteByEndpoint(endpoint)
+}
+
+export async function DELETE(request: Request): Promise<NextResponse> {
+  // Endpoint via query (?endpoint=) OU corps JSON — supporte les deux usages (sendBeacon, fetch).
+  const url = new URL(request.url)
+  let endpoint: unknown = url.searchParams.get('endpoint') ?? undefined
+  if (!endpoint) {
+    try {
+      endpoint = ((await request.json()) as { endpoint?: unknown }).endpoint
+    } catch {
+      /* pas de corps → endpoint reste undefined → 400 */
+    }
+  }
+  return deleteByEndpoint(endpoint)
+}

--- a/apps/web/components/push/PushOptInErrorBoundary.tsx
+++ b/apps/web/components/push/PushOptInErrorBoundary.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Component, type ReactNode } from 'react'
+
+/**
+ * Garde anti-crash (PUSH-001) : une erreur dans le pre-prompt push ne doit JAMAIS faire
+ * tomber le dashboard. On avale l'erreur et on ne rend rien. (Mirror PWA-001.)
+ */
+export class PushOptInErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true }
+  }
+
+  componentDidCatch(): void {
+    // Silencieux : le pre-prompt est non-critique (l'in-app couvre la découverte des votes).
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) return null
+    return this.props.children
+  }
+}

--- a/apps/web/components/push/PushOptInMount.tsx
+++ b/apps/web/components/push/PushOptInMount.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+// PushOptInMount (PUSH-001 ; spec §6.3) — point de montage du pre-prompt Web Push.
+//
+// Monté dans le layout (app) à côté de <InstallBannerMount/> (persiste entre onglets) mais
+// ne s'affiche que sur /dashboard. Toute la logique est enrobée d'un ErrorBoundary : une
+// erreur ici ne peut JAMAIS crasher le dashboard. Suspense est requis (cohérence avec le
+// mount PWA + appels client) — fallback null.
+//
+// Gating (spec §2.3 / §6.4) :
+//   - pathname === '/dashboard'
+//   - capability === 'ready' (via usePushOptIn → canSubscribeOnPlatform)
+//   - Notification.permission === 'default' (jamais re-prompter si déjà accordé/refusé)
+//   - cooldown 7 j expiré (pushDismissStore)
+//   - consentement RGPD résolu (anti-chevauchement avec la bannière de consentement)
+//
+// Analytics : optInPromptShown au premier affichage, optInAccepted / optInDismissed selon
+// l'issue. Aucune PII (capability + reason uniquement).
+
+import { usePathname } from 'next/navigation'
+import { Suspense, useEffect, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
+
+import { useToast } from '@evolve/ui'
+
+import { analyticsEvents } from '@/lib/analytics'
+import { useConsentResolved } from '@/lib/consent/use-consent'
+import { usePushOptIn } from '@/lib/push/use-push-opt-in'
+import { PushOptInErrorBoundary } from './PushOptInErrorBoundary'
+import { PushOptInSheet } from './PushOptInSheet'
+
+function PushOptInInner() {
+  const pathname = usePathname()
+  const t = useTranslations('push')
+  const toast = useToast()
+  const consentResolved = useConsentResolved()
+
+  const { capability, shouldShowPrePrompt, requestOptIn, dismiss } = usePushOptIn()
+
+  // Masquage local après une action terminée.
+  const [hidden, setHidden] = useState(false)
+
+  const onDashboard = pathname === '/dashboard'
+  const visible = onDashboard && shouldShowPrePrompt && consentResolved && !hidden
+
+  // Analytics : pre-prompt affiché (une fois par affichage).
+  const shownRef = useRef(false)
+  useEffect(() => {
+    if (!visible) {
+      shownRef.current = false
+      return
+    }
+    if (shownRef.current) return
+    shownRef.current = true
+    try {
+      analyticsEvents.push.optInPromptShown(capability)
+    } catch {
+      /* analytics no-op safe */
+    }
+  }, [visible, capability])
+
+  const handleAccept = async () => {
+    const result = await requestOptIn()
+    setHidden(true)
+    if (result === 'subscribed') {
+      analyticsEvents.push.optInAccepted(capability)
+      toast.success({ title: t('toastSuccess.title'), message: t('toastSuccess.message') })
+    } else if (result === 'denied') {
+      analyticsEvents.push.optInDismissed({ reason: 'denied' })
+      toast.error({ title: t('toastBlocked.title'), message: t('toastBlocked.message') })
+    } else {
+      // unsupported / no-vapid-key / error : feedback discret, pas de blocage (in-app couvre).
+      analyticsEvents.push.optInDismissed({ reason: result })
+      toast.error({ title: t('toastError.title'), message: t('toastError.message') })
+    }
+  }
+
+  const handleDismiss = () => {
+    analyticsEvents.push.optInDismissed({ reason: 'later' })
+    dismiss()
+    setHidden(true)
+  }
+
+  if (!visible) return null
+
+  return <PushOptInSheet open={visible} onAccept={handleAccept} onDismiss={handleDismiss} />
+}
+
+/**
+ * Point de montage du pre-prompt push. Enrobé d'un ErrorBoundary (jamais de crash du
+ * dashboard). Le Suspense fournit un fallback null en attente d'hydratation.
+ */
+export function PushOptInMount() {
+  return (
+    <PushOptInErrorBoundary>
+      <Suspense fallback={null}>
+        <PushOptInInner />
+      </Suspense>
+    </PushOptInErrorBoundary>
+  )
+}

--- a/apps/web/components/push/PushOptInSheet.tsx
+++ b/apps/web/components/push/PushOptInSheet.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+// PushOptInSheet (PUSH-001 ; spec §11) — pre-prompt d'opt-in Web Push.
+//
+// SELF-CONTAINED (apps/web) : construit directement sur Radix Dialog (focus-trap, Escape,
+// Title + Description requis) plutôt que de réutiliser un composant @evolve/ui — pour ne pas
+// muter PwaInstallSheet (qui pilote la bannière d'installation PWA en prod). Le pattern Radix
+// est calqué sur FeedbackSheet : modale centrée sur scrim (desktop ~420px) / bottom-sheet
+// ancré bas (mobile, grab-handle).
+//
+// Réf visuelle : « Notifications — Maquettes (standalone) », frames ref-push-01..06
+// (pré-prompt desktop/mobile, light & dark) — bell pastille jaune, headline « Ne manquez plus
+// un vote », note d'anonymat (cadenas), CTA jaune pleine largeur, « Plus tard » + lien profil.
+//
+// Props STABLES { open, onAccept, onDismiss } (PushOptInMount en dépend). État `busy` pendant
+// requestPermission OS + subscribe + POST (la promesse onAccept peut prendre un instant).
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import * as Dialog from '@radix-ui/react-dialog'
+
+import { Icon } from '@evolve/ui'
+
+/** Concatène des classes (aucune fusion Tailwind nécessaire ici — pas d'utilitaires en conflit). */
+function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}
+
+export type PushOptInSheetProps = {
+  open: boolean
+  /** Lance requestPermission → subscribe → POST. */
+  onAccept: () => void | Promise<void>
+  /** « Plus tard » / fermeture (X, Escape, clic backdrop). */
+  onDismiss: () => void
+}
+
+/** Spinner inline (conserve la largeur du CTA pendant le chargement). */
+function CtaSpinner() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      className="h-5 w-5 animate-spin motion-reduce:animate-none"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" className="opacity-25" />
+      <path
+        d="M12 2a10 10 0 0 1 10 10"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function PushOptInSheet({ open, onAccept, onDismiss }: PushOptInSheetProps) {
+  const t = useTranslations('push')
+  const [busy, setBusy] = useState(false)
+
+  const handleCta = () => {
+    if (busy) return
+    setBusy(true)
+    void Promise.resolve(onAccept()).finally(() => setBusy(false))
+  }
+
+  // Toute fermeture non-CTA (X, Escape, clic backdrop) passe par onDismiss.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) onDismiss()
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 motion-safe:animate-in motion-safe:fade-in" />
+        <Dialog.Content
+          className={cn(
+            'fixed z-50 bg-card shadow-[var(--sh-modal)] focus:outline-none',
+            // Mobile : bottom-sheet ancré bas, coins sup. arrondis, grab-handle.
+            'inset-x-0 bottom-0 w-full rounded-t-[14px] border-t border-border',
+            'px-5 pt-3 pb-[max(20px,env(safe-area-inset-bottom))]',
+            // Desktop : modale centrée ~420px, tous coins arrondis.
+            'sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:w-[420px] sm:max-w-[calc(100vw-2rem)]',
+            'sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-[14px] sm:border sm:px-6 sm:pb-6 sm:pt-6',
+            'motion-safe:animate-in motion-safe:fade-in motion-safe:duration-[220ms]'
+          )}
+        >
+          {/* Grab-handle mobile (décoratif). */}
+          <div
+            className="mx-auto mb-3 h-1 w-10 rounded-full bg-border-strong sm:hidden"
+            aria-hidden="true"
+          />
+
+          {/* En-tête : pastille cloche jaune + bouton fermer X. */}
+          <div className="flex items-start justify-between gap-3">
+            <span
+              className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-accent text-accent-ink"
+              aria-hidden="true"
+            >
+              <Icon name="Bell" size={20} />
+            </span>
+            <Dialog.Close
+              aria-label={t('prePrompt.later')}
+              className={cn(
+                '-mr-1 -mt-1 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md',
+                'text-text-ter transition-colors duration-[150ms] hover:bg-card-sub hover:text-text-sec',
+                'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]'
+              )}
+            >
+              <Icon name="X" size={20} aria-hidden="true" />
+            </Dialog.Close>
+          </div>
+
+          {/* Corps : headline + subline. */}
+          <Dialog.Title className="mt-4 font-display text-[20px] font-bold leading-snug text-text">
+            {t('prePrompt.headline')}
+          </Dialog.Title>
+          <Dialog.Description className="mt-1.5 font-body text-[14px] font-medium leading-relaxed text-text-sec">
+            {t('prePrompt.subline')}
+          </Dialog.Description>
+
+          {/* Note d'anonymat : encart cadenas. */}
+          <div className="mt-4 flex items-start gap-2.5 rounded-[10px] border border-border bg-card-sub px-3 py-3">
+            <Icon
+              name="Lock"
+              size={16}
+              className="mt-0.5 shrink-0 text-text-ter"
+              aria-hidden="true"
+            />
+            <p className="font-body text-[13px] leading-relaxed text-text-ter">
+              {t('prePrompt.trustNote')}
+            </p>
+          </div>
+
+          {/* CTA primaire pleine largeur. */}
+          <button
+            type="button"
+            onClick={handleCta}
+            disabled={busy}
+            aria-busy={busy || undefined}
+            className={cn(
+              'mt-5 inline-flex h-12 w-full items-center justify-center gap-2 rounded-[var(--r-md)]',
+              'bg-accent text-[15px] font-semibold text-accent-ink',
+              'transition-all duration-[150ms] hover:opacity-90',
+              'active:scale-[0.99] motion-reduce:active:scale-100',
+              'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]',
+              'disabled:cursor-not-allowed'
+            )}
+          >
+            {busy ? (
+              <>
+                <CtaSpinner />
+                <span className="sr-only">{t('prePrompt.accept')}</span>
+                <span aria-hidden="true" className="invisible">
+                  {t('prePrompt.accept')}
+                </span>
+              </>
+            ) : (
+              t('prePrompt.accept')
+            )}
+          </button>
+
+          {/* Pied : « Plus tard » à gauche, lien profil à droite. */}
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <Dialog.Close
+              className={cn(
+                'inline-flex h-11 items-center rounded-md px-1',
+                'font-body text-[14px] font-medium text-text-sec',
+                'transition-colors duration-[150ms] hover:text-text',
+                'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]'
+              )}
+            >
+              {t('prePrompt.later')}
+            </Dialog.Close>
+            <Link
+              href="/profil"
+              onClick={onDismiss}
+              className={cn(
+                'inline-flex h-11 items-center rounded-md px-1',
+                'font-body text-[14px] font-semibold text-accent',
+                'transition-opacity duration-[150ms] hover:opacity-80',
+                'focus-visible:outline-none focus-visible:shadow-[var(--sh-glow)]'
+              )}
+            >
+              {t('prePrompt.manageInProfile')}
+            </Link>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -162,4 +162,20 @@ export const analyticsEvents = {
       track('pwa_ios_instructions_viewed', { pwa_case: pwaCase, step }),
     clipboardCopied: () => track('pwa_clipboard_copied', {}),
   },
+  // Web Push (PUSH-001). Aucune PII : seulement la capacité plateforme, la raison de dismiss
+  // et le type d'événement (poll.opened/closed/reminder) — jamais le user_id ni le contenu.
+  push: {
+    /** push_opt_in_prompt_shown — pre-prompt rendu (une fois par affichage). */
+    optInPromptShown: (capability: string) =>
+      track('push_opt_in_prompt_shown', { push_capability: capability }),
+    /** push_opt_in_accepted — subscription persistée après autorisation. */
+    optInAccepted: (capability: string) =>
+      track('push_opt_in_accepted', { push_capability: capability }),
+    /** push_opt_in_dismissed — « Plus tard » / refus / fermeture (avec la raison). */
+    optInDismissed: (params?: { reason?: string }) =>
+      track('push_opt_in_dismissed', { reason: params?.reason }),
+    /** push_notification_click — clic sur une notification système (type d'event seulement). */
+    notificationClick: (params: { type: string }) =>
+      track('push_notification_click', { notification_type: params.type }),
+  },
 } as const

--- a/apps/web/lib/push/dismiss-storage.ts
+++ b/apps/web/lib/push/dismiss-storage.ts
@@ -1,0 +1,124 @@
+// Cooldown du pre-prompt Web Push (PUSH-001 ; spec §2.3) — miroir du pattern
+// `lib/pwa/dismiss-storage.ts`, par-appareil (localStorage), clé `'evolve.push.v1'`.
+//
+// Un seul niveau de cooldown : 7 jours après « Plus tard ». Une fois abonné sur l'appareil,
+// on n'a plus besoin du pre-prompt (la permission OS est persistée par le navigateur ; le
+// profil reste le point de réglage). Toute lecture/écriture est gardée : si le storage
+// throw (Safari privé/incognito, quota) → état vide → on n'affiche pas le pre-prompt, et
+// JAMAIS d'exception côté React.
+
+const STORAGE_KEY = 'evolve.push.v1'
+const DAY = 86_400_000
+/** Cooldown après un « Plus tard ». */
+const DISMISS_COOLDOWN_DAYS = 7
+
+export type PushDismissState = {
+  dismissCount: number
+  lastDismissedAt: string | null // ISO
+  nextEligibleAt: string | null // ISO
+}
+
+function emptyState(): PushDismissState {
+  return { dismissCount: 0, lastDismissedAt: null, nextEligibleAt: null }
+}
+
+/** Narrowing prudent d'un objet inconnu (storage potentiellement corrompu). */
+function coerceState(raw: unknown): PushDismissState {
+  if (typeof raw !== 'object' || raw === null) return emptyState()
+  const r = raw as Record<string, unknown>
+  const base = emptyState()
+  return {
+    dismissCount: typeof r.dismissCount === 'number' ? r.dismissCount : base.dismissCount,
+    lastDismissedAt: typeof r.lastDismissedAt === 'string' ? r.lastDismissedAt : null,
+    nextEligibleAt: typeof r.nextEligibleAt === 'string' ? r.nextEligibleAt : null,
+  }
+}
+
+export type PushDismissStore = {
+  read: () => PushDismissState
+  recordDismiss: () => void
+  /** Timestamp (ms) en deçà duquel le pre-prompt ne doit pas réapparaître. 0 si jamais refusé. */
+  getCooldownUntil: () => number
+}
+
+export type CreatePushDismissStoreOptions = {
+  storage: Storage
+  now: () => number
+}
+
+/**
+ * Crée le store de persistance des refus du pre-prompt push (injectable pour les tests).
+ * Storage/horloge injectables ; toute erreur dégrade vers l'état vide sans throw.
+ */
+export function createPushDismissStore({
+  storage,
+  now,
+}: CreatePushDismissStoreOptions): PushDismissStore {
+  function read(): PushDismissState {
+    try {
+      const raw = storage.getItem(STORAGE_KEY)
+      if (!raw) return emptyState()
+      return coerceState(JSON.parse(raw))
+    } catch {
+      return emptyState()
+    }
+  }
+
+  function write(state: PushDismissState): void {
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(state))
+    } catch {
+      /* storage indispo → on ignore : l'état restera « vide » à la prochaine lecture */
+    }
+  }
+
+  return {
+    read,
+
+    recordDismiss() {
+      const s = read()
+      const t = now()
+      write({
+        dismissCount: s.dismissCount + 1,
+        lastDismissedAt: new Date(t).toISOString(),
+        nextEligibleAt: new Date(t + DISMISS_COOLDOWN_DAYS * DAY).toISOString(),
+      })
+    },
+
+    getCooldownUntil() {
+      const at = read().nextEligibleAt
+      if (!at) return 0
+      const ms = Date.parse(at)
+      return Number.isNaN(ms) ? 0 : ms
+    },
+  }
+}
+
+/**
+ * Storage SSR-safe : `window.localStorage` côté client, sinon un no-op qui ne throw jamais.
+ */
+function safeBrowserStorage(): Storage {
+  if (typeof window !== 'undefined') {
+    try {
+      const ls = window.localStorage
+      if (ls) return ls
+    } catch {
+      /* accès localStorage bloqué (incognito strict) → no-op */
+    }
+  }
+  const noop: Storage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  }
+  return noop
+}
+
+/** Singleton applicatif : utilise `window.localStorage` et `Date.now`. */
+export const pushDismissStore: PushDismissStore = createPushDismissStore({
+  storage: safeBrowserStorage(),
+  now: () => Date.now(),
+})

--- a/apps/web/lib/push/permission.test.ts
+++ b/apps/web/lib/push/permission.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { canSubscribeOnPlatform, isPushSupported, readNotificationPermission } from './permission'
+
+// Environnement vitest = 'node' (pas de window). On installe un faux `window`/`navigator`
+// exposant les API Web Push, puis on injecte pwaCase + permission dans canSubscribeOnPlatform
+// (paramètres testables) — la dimension plateforme prime sur la permission (spec §6.4).
+
+const g = globalThis as unknown as {
+  window?: unknown
+  navigator?: unknown
+  Notification?: unknown
+}
+
+function installSupportedEnv(permission: NotificationPermission = 'default') {
+  const NotificationStub = { permission }
+  g.window = { Notification: NotificationStub, PushManager: function () {} }
+  g.navigator = { serviceWorker: {} }
+  // `'Notification' in window` + lecture Notification.permission passent par window.Notification.
+  g.Notification = NotificationStub
+}
+
+function uninstallEnv() {
+  delete g.window
+  delete g.navigator
+  delete g.Notification
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs()
+})
+afterEach(() => {
+  uninstallEnv()
+})
+
+describe('isPushSupported', () => {
+  it('false sans window (SSR)', () => {
+    uninstallEnv()
+    expect(isPushSupported()).toBe(false)
+  })
+
+  it('true quand Notification + PushManager + serviceWorker présents', () => {
+    installSupportedEnv()
+    expect(isPushSupported()).toBe(true)
+  })
+})
+
+describe('readNotificationPermission', () => {
+  it("'default' sans window", () => {
+    uninstallEnv()
+    expect(readNotificationPermission()).toBe('default')
+  })
+
+  it('reflète Notification.permission', () => {
+    installSupportedEnv('granted')
+    expect(readNotificationPermission()).toBe('granted')
+  })
+})
+
+describe('canSubscribeOnPlatform (spec §6.4)', () => {
+  it('API absente (SSR/non supporté) → unsupported', () => {
+    uninstallEnv()
+    expect(canSubscribeOnPlatform('desktop', 'default')).toBe('unsupported')
+  })
+
+  it('iOS Safari hors écran d’accueil → needs_pwa_install (prime sur la permission)', () => {
+    installSupportedEnv('granted')
+    expect(canSubscribeOnPlatform('ios-safari', 'granted')).toBe('needs_pwa_install')
+  })
+
+  it('iOS non-Safari → needs_safari', () => {
+    installSupportedEnv('default')
+    expect(canSubscribeOnPlatform('ios-other', 'default')).toBe('needs_safari')
+  })
+
+  it('permission refusée (desktop) → blocked', () => {
+    installSupportedEnv('denied')
+    expect(canSubscribeOnPlatform('desktop', 'denied')).toBe('blocked')
+  })
+
+  it('desktop + permission default → ready', () => {
+    installSupportedEnv('default')
+    expect(canSubscribeOnPlatform('desktop', 'default')).toBe('ready')
+  })
+
+  it('android-chrome + permission granted → ready', () => {
+    installSupportedEnv('granted')
+    expect(canSubscribeOnPlatform('android-chrome', 'granted')).toBe('ready')
+  })
+
+  it('standalone (PWA iOS installée) + default → ready', () => {
+    installSupportedEnv('default')
+    expect(canSubscribeOnPlatform('standalone', 'default')).toBe('ready')
+  })
+})

--- a/apps/web/lib/push/permission.ts
+++ b/apps/web/lib/push/permission.ts
@@ -1,0 +1,65 @@
+// Support & capacité Web Push (PUSH-001 ; spec §6.4).
+//
+// Compose la détection plateforme (detectPwaCase, PWA-001) + l'état de l'API Notification
+// pour répondre à : « cet appareil peut-il s'abonner aux push maintenant ? ». Tout est
+// SSR-safe et crash-safe : sans `window`/API → `unsupported`, jamais d'exception.
+
+import { detectPwaCase } from '@/lib/pwa/platform-detection'
+import { capabilityForPwaCase, type PushPlatformCapability } from './platform-push'
+
+/** Vrai si le navigateur expose les API Web Push (Notification + PushManager + SW). */
+export function isPushSupported(): boolean {
+  try {
+    if (typeof window === 'undefined') return false
+    return (
+      'Notification' in window &&
+      'PushManager' in window &&
+      typeof navigator !== 'undefined' &&
+      'serviceWorker' in navigator
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Lit `Notification.permission` de façon gardée (SSR / API absente → 'default'). */
+export function readNotificationPermission(): NotificationPermission {
+  try {
+    if (typeof window === 'undefined' || !('Notification' in window)) return 'default'
+    return Notification.permission
+  } catch {
+    return 'default'
+  }
+}
+
+/**
+ * Capacité push de l'appareil courant — règles ordonnées (spec §6.4) :
+ *   1. !isPushSupported()                        → 'unsupported'
+ *   2. detectPwaCase() === 'ios-safari'          → 'needs_pwa_install' (fallback iOS)
+ *   3. detectPwaCase() === 'ios-other'           → 'needs_safari'
+ *   4. Notification.permission === 'denied'      → 'blocked'
+ *   5. sinon                                      → 'ready'
+ *
+ * Crash-safe (jamais de throw vers React). `pwaCase` / `permission` sont injectables
+ * pour la testabilité ; sinon lus du runtime.
+ */
+export function canSubscribeOnPlatform(
+  pwaCase = detectPwaCase(),
+  permission = readNotificationPermission()
+): PushPlatformCapability {
+  if (!isPushSupported()) return 'unsupported'
+
+  const platform = capabilityForPwaCase(pwaCase)
+  // La dimension plateforme prime sur la permission : un iPhone hors écran d'accueil ne
+  // peut pas recevoir de push, même si la permission n'a pas encore été refusée.
+  if (
+    platform === 'unsupported' ||
+    platform === 'needs_pwa_install' ||
+    platform === 'needs_safari'
+  ) {
+    return platform
+  }
+
+  if (permission === 'denied') return 'blocked'
+  return 'ready'
+}

--- a/apps/web/lib/push/platform-push.test.ts
+++ b/apps/web/lib/push/platform-push.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+
+import type { PwaCase } from '@evolve/types'
+
+import { capabilityForPwaCase } from './platform-push'
+
+describe('capabilityForPwaCase', () => {
+  it('iOS Safari hors écran d’accueil → needs_pwa_install', () =>
+    expect(capabilityForPwaCase('ios-safari')).toBe('needs_pwa_install'))
+
+  it('iOS non-Safari (Chrome/Firefox) → needs_safari', () =>
+    expect(capabilityForPwaCase('ios-other')).toBe('needs_safari'))
+
+  it('unsupported reste unsupported', () =>
+    expect(capabilityForPwaCase('unsupported')).toBe('unsupported'))
+
+  it('standalone (PWA iOS installée) → ready', () =>
+    expect(capabilityForPwaCase('standalone')).toBe('ready'))
+
+  it('android-chrome → ready', () => expect(capabilityForPwaCase('android-chrome')).toBe('ready'))
+
+  it('desktop → ready', () => expect(capabilityForPwaCase('desktop')).toBe('ready'))
+
+  it('couvre tous les PwaCase de l’union', () => {
+    const cases: PwaCase[] = [
+      'android-chrome',
+      'ios-safari',
+      'ios-other',
+      'standalone',
+      'desktop',
+      'unsupported',
+    ]
+    for (const c of cases) {
+      expect(['unsupported', 'needs_pwa_install', 'needs_safari', 'ready']).toContain(
+        capabilityForPwaCase(c)
+      )
+    }
+  })
+})

--- a/apps/web/lib/push/platform-push.ts
+++ b/apps/web/lib/push/platform-push.ts
@@ -1,0 +1,47 @@
+// Capacité plateforme Web Push (PUSH-001 ; spec §6.4).
+//
+// Mappe un PwaCase (détection partagée PWA-001) vers une capacité push. Pur et testable :
+// aucune lecture de `window` ici — l'appelant (`canSubscribeOnPlatform`) compose la
+// détection runtime + la permission Notification. Ce module ne décide QUE de la dimension
+// plateforme (l'iOS sans écran d'accueil ne peut pas recevoir de push tant que la PWA
+// n'est pas installée — cf. matrice spec §1.3).
+
+import type { PwaCase } from '@evolve/types'
+
+/**
+ * Capacité push résolue :
+ *  - `unsupported`      : API absente (pas de Notification/PushManager) ou env serveur
+ *  - `needs_pwa_install`: iOS Safari hors écran d'accueil → installer la PWA d'abord
+ *  - `needs_safari`     : iOS non-Safari (Chrome/Firefox iOS) → passer par Safari
+ *  - `blocked`          : permission refusée par l'utilisateur
+ *  - `ready`            : peut s'abonner immédiatement
+ */
+export type PushPlatformCapability =
+  | 'unsupported'
+  | 'needs_pwa_install'
+  | 'needs_safari'
+  | 'blocked'
+  | 'ready'
+
+/**
+ * Dimension PLATEFORME de la capacité push (sans la permission).
+ * Pur : `pwaCase` provient de `detectPwaCase()`.
+ *
+ * - `ios-safari` (Safari iOS hors standalone) → `needs_pwa_install`
+ * - `ios-other` (Chrome/Firefox iOS) → `needs_safari`
+ * - `unsupported` → `unsupported`
+ * - `standalone` / `android-chrome` / `desktop` → `ready`
+ */
+export function capabilityForPwaCase(pwaCase: PwaCase): PushPlatformCapability {
+  switch (pwaCase) {
+    case 'ios-safari':
+      return 'needs_pwa_install'
+    case 'ios-other':
+      return 'needs_safari'
+    case 'unsupported':
+      return 'unsupported'
+    default:
+      // standalone (iOS PWA installée), android-chrome, desktop
+      return 'ready'
+  }
+}

--- a/apps/web/lib/push/subscribe.ts
+++ b/apps/web/lib/push/subscribe.ts
@@ -1,0 +1,188 @@
+// Abonnement Web Push côté client (PUSH-001 ; spec §6.3).
+//
+// Orchestration du flux subscribe :
+//   1. registration SW déjà active (PwaServiceWorkerRegistrar — prod uniquement)
+//   2. Notification.requestPermission()
+//   3. registration.pushManager.subscribe({ userVisibleOnly, applicationServerKey })
+//   4. POST /api/push/subscribe (la route persiste en service de session, RLS)
+//
+// IMPORTANT (dev) : le SW n'est enregistré qu'en production + contexte sécurisé
+// (cf. lib/pwa/register-sw.ts). En localhost dev, `getSwRegistration()` renvoie null →
+// `subscribePush()` retourne 'unsupported' sans throw. Le vrai push se teste sur un
+// déploiement HTTPS (preview Vercel) avec NEXT_PUBLIC_VAPID_PUBLIC_KEY défini.
+//
+// Tout est crash-safe : aucune exception ne remonte à React.
+
+import type { PwaCase } from '@evolve/types'
+
+import { detectPwaCase } from '@/lib/pwa/platform-detection'
+import { getVapidPublicKey, urlBase64ToUint8Array } from './vapid'
+
+/** Plateforme persistée (snapshot debug, pas de PII) — aligné sur le CHECK de la migration 039. */
+export type PushPlatformTag =
+  | 'desktop'
+  | 'android-chrome'
+  | 'ios-safari'
+  | 'ios-other'
+  | 'standalone'
+  | 'unknown'
+
+/** Résultat d'un appel `subscribePush()`. */
+export type SubscribeResult = 'subscribed' | 'denied' | 'unsupported' | 'no-vapid-key' | 'error'
+
+/** État courant de la subscription sur cet appareil (pour piloter le toggle profil). */
+export type SubscriptionState = {
+  supported: boolean
+  permission: NotificationPermission
+  subscribed: boolean
+}
+
+/** Mappe un PwaCase vers le tag plateforme persisté (jamais d'autre valeur que le CHECK DB). */
+export function platformTagFor(pwaCase: PwaCase): PushPlatformTag {
+  switch (pwaCase) {
+    case 'desktop':
+    case 'android-chrome':
+    case 'ios-safari':
+    case 'ios-other':
+    case 'standalone':
+      return pwaCase
+    default:
+      return 'unknown'
+  }
+}
+
+/** Registration SW active (null en dev, où le SW n'est pas enregistré, ou si API absente). */
+async function getSwRegistration(): Promise<ServiceWorkerRegistration | null> {
+  try {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
+    const reg = await navigator.serviceWorker.ready
+    return reg ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Lit l'état de subscription courant — crash-safe, jamais de throw. */
+export async function getSubscriptionState(): Promise<SubscriptionState> {
+  const supported =
+    typeof window !== 'undefined' &&
+    'Notification' in window &&
+    'PushManager' in window &&
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator
+  if (!supported) return { supported: false, permission: 'default', subscribed: false }
+
+  let permission: NotificationPermission = 'default'
+  try {
+    permission = Notification.permission
+  } catch {
+    permission = 'default'
+  }
+
+  try {
+    const reg = await getSwRegistration()
+    const sub = reg ? await reg.pushManager.getSubscription() : null
+    return { supported: true, permission, subscribed: sub !== null }
+  } catch {
+    return { supported: true, permission, subscribed: false }
+  }
+}
+
+/**
+ * Demande la permission, s'abonne au PushManager et persiste la subscription via l'API.
+ * Crash-safe : retourne un code de résultat, ne throw jamais.
+ */
+export async function subscribePush(): Promise<SubscribeResult> {
+  try {
+    if (
+      typeof window === 'undefined' ||
+      !('Notification' in window) ||
+      !('PushManager' in window)
+    ) {
+      return 'unsupported'
+    }
+
+    const vapidKey = getVapidPublicKey()
+    if (!vapidKey) return 'no-vapid-key'
+
+    const reg = await getSwRegistration()
+    if (!reg) return 'unsupported' // pas de SW (dev, ou navigateur sans support)
+
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') return 'denied'
+
+    // Réutilise une subscription existante si présente, sinon en crée une nouvelle.
+    let subscription = await reg.pushManager.getSubscription()
+    if (!subscription) {
+      subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        // `as BufferSource` : la lib DOM type applicationServerKey sur ArrayBuffer (non
+        // SharedArrayBuffer) ; Uint8Array<ArrayBufferLike> n'est pas assignable directement.
+        applicationServerKey: urlBase64ToUint8Array(vapidKey) as BufferSource,
+      })
+    }
+
+    const json = subscription.toJSON()
+    const endpoint = json.endpoint
+    const p256dh = json.keys?.p256dh
+    const auth = json.keys?.auth
+    if (!endpoint || !p256dh || !auth) return 'error'
+
+    const platform = platformTagFor(detectPwaCase())
+    const res = await fetch('/api/push/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint,
+        keys: { p256dh, auth },
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+        platform,
+      }),
+    })
+    if (!res.ok) return 'error'
+
+    return 'subscribed'
+  } catch {
+    return 'error'
+  }
+}
+
+/**
+ * Désabonne l'appareil courant : retire la subscription du PushManager ET côté serveur
+ * (DELETE par endpoint pour l'utilisateur courant). Crash-safe.
+ *
+ * @returns true si au moins l'une des deux opérations a réussi (best-effort).
+ */
+export async function unsubscribePush(): Promise<boolean> {
+  let ok = false
+  try {
+    const reg = await getSwRegistration()
+    const subscription = reg ? await reg.pushManager.getSubscription() : null
+    const endpoint = subscription?.endpoint
+
+    if (subscription) {
+      try {
+        await subscription.unsubscribe()
+        ok = true
+      } catch {
+        /* on tente quand même la suppression serveur */
+      }
+    }
+
+    if (endpoint) {
+      try {
+        const res = await fetch('/api/push/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint }),
+        })
+        if (res.ok) ok = true
+      } catch {
+        /* noop */
+      }
+    }
+  } catch {
+    /* noop */
+  }
+  return ok
+}

--- a/apps/web/lib/push/use-push-opt-in.ts
+++ b/apps/web/lib/push/use-push-opt-in.ts
@@ -1,0 +1,99 @@
+'use client'
+
+import { useCallback, useState, useSyncExternalStore } from 'react'
+
+import type { PwaCase } from '@evolve/types'
+
+import { detectPwaCase } from '@/lib/pwa/platform-detection'
+import { canSubscribeOnPlatform } from './permission'
+import { pushDismissStore } from './dismiss-storage'
+import { subscribePush, type SubscribeResult } from './subscribe'
+import type { PushPlatformCapability } from './platform-push'
+
+/**
+ * Hook du pre-prompt Web Push (PUSH-001 ; spec §6.3) — opt-in EXPLICITE.
+ *
+ * Détection plateforme via `useSyncExternalStore` (SSR-safe) : snapshot serveur figé à
+ * `'unsupported'`, snapshot client résolu après hydratation (mirror `usePwaInstall`). Le
+ * store n'émet jamais (la plateforme ne change pas en session) → `subscribe` no-op.
+ *
+ * Crash-safety : tout effet de bord (storage, requestPermission, fetch) est gardé. Aucune
+ * exception ne remonte à React ; on n'affiche jamais le pre-prompt en cas d'erreur.
+ *
+ * NB : `subscribePush()` retourne 'unsupported' en localhost dev (SW prod-only) — le vrai
+ * push se teste sur un déploiement HTTPS avec NEXT_PUBLIC_VAPID_PUBLIC_KEY.
+ */
+const NOOP_SUBSCRIBE = (): (() => void) => () => {}
+const getClientPwaCase = (): PwaCase => detectPwaCase()
+const getServerPwaCase = (): PwaCase => 'unsupported'
+
+/**
+ * Éligibilité cooldown via `useSyncExternalStore` (même pattern que pwaCase) : snapshot
+ * serveur figé à `false` (pas d'accès localStorage au render SSR), snapshot client résolu
+ * après hydratation. Évite tout `setState` synchrone dans un effet (régression cascading
+ * renders, cf. R-035 / set-state-in-effect). Le store n'émet pas (lecture ponctuelle).
+ */
+const getClientCooldownEligible = (): boolean => {
+  try {
+    return pushDismissStore.getCooldownUntil() <= Date.now()
+  } catch {
+    return false
+  }
+}
+const getServerCooldownEligible = (): boolean => false
+
+export type UsePushOptInReturn = {
+  /** Capacité de l'appareil (unsupported / needs_pwa_install / needs_safari / blocked / ready). */
+  capability: PushPlatformCapability
+  /** Vrai si le pre-prompt doit s'afficher (ready + cooldown expiré + non encore décidé). */
+  shouldShowPrePrompt: boolean
+  /** Lance le flux requestPermission → subscribe → POST. Retourne le code de résultat. */
+  requestOptIn: () => Promise<SubscribeResult>
+  /** « Plus tard » : enregistre un cooldown 7 j et masque le pre-prompt sur cet appareil. */
+  dismiss: () => void
+}
+
+export function usePushOptIn(): UsePushOptInReturn {
+  // Détection + cooldown via useSyncExternalStore (SSR-safe, pas de setState en effet).
+  const pwaCase = useSyncExternalStore(NOOP_SUBSCRIBE, getClientPwaCase, getServerPwaCase)
+  const eligibleByCooldown = useSyncExternalStore(
+    NOOP_SUBSCRIBE,
+    getClientCooldownEligible,
+    getServerCooldownEligible
+  )
+  const [hidden, setHidden] = useState(false)
+
+  // Capacité dérivée du render (pure : pwaCase + permission Notification, gardée crash-safe).
+  // Côté serveur, pwaCase = 'unsupported' → canSubscribeOnPlatform → 'unsupported'.
+  let capability: PushPlatformCapability = 'unsupported'
+  try {
+    capability = canSubscribeOnPlatform(pwaCase)
+  } catch {
+    capability = 'unsupported'
+  }
+
+  // Le pre-prompt maison ne s'affiche QUE si l'appareil peut s'abonner immédiatement
+  // (`ready`). Les cas iOS (needs_pwa_install / needs_safari) sont gérés par le fallback
+  // (réutilise PwaInstallSheet), `unsupported`/`blocked` n'affichent rien.
+  const shouldShowPrePrompt = capability === 'ready' && eligibleByCooldown && !hidden
+
+  const requestOptIn = useCallback(async (): Promise<SubscribeResult> => {
+    setHidden(true)
+    try {
+      return await subscribePush()
+    } catch {
+      return 'error'
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    try {
+      pushDismissStore.recordDismiss()
+    } catch {
+      /* noop — un storage indisponible ne doit jamais crasher le dismiss */
+    }
+    setHidden(true)
+  }, [])
+
+  return { capability, shouldShowPrePrompt, requestOptIn, dismiss }
+}

--- a/apps/web/lib/push/vapid.ts
+++ b/apps/web/lib/push/vapid.ts
@@ -1,0 +1,27 @@
+// VAPID — clé publique pour `pushManager.subscribe()` (PUSH-001 ; spec §6.1).
+//
+// La clé publique VAPID transite côté client (NEXT_PUBLIC_*), JAMAIS la clé privée
+// (server-only, Edge `dispatch-push`). `pushManager.subscribe()` attend un BufferSource
+// (Uint8Array) : on convertit la chaîne base64url en octets.
+
+/** Clé publique VAPID (base64url) injectée à build via NEXT_PUBLIC_VAPID_PUBLIC_KEY. */
+export function getVapidPublicKey(): string | undefined {
+  const key = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  return key && key.trim().length > 0 ? key.trim() : undefined
+}
+
+/**
+ * Convertit une clé VAPID base64url en `Uint8Array` (applicationServerKey).
+ * Pur et testable. Throw si l'entrée n'est pas décodable — l'appelant (subscribe)
+ * garde l'appel dans un try/catch (jamais d'exception remontée à React).
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1065,6 +1065,68 @@
       "button": "Install the app"
     }
   },
+  "push": {
+    "badge": "Notifications · no App Store",
+    "prePrompt": {
+      "headline": "Never miss a vote",
+      "subline": "Get an alert when a new vote opens or when results are available — even with the app closed.",
+      "trustNote": "Your vote stays anonymous. Notifications never reveal who voted.",
+      "accept": "Turn on notifications",
+      "later": "Not now",
+      "manageInProfile": "Manage in My profile ›"
+    },
+    "iosInstall": {
+      "headline": "Install the app for notifications.",
+      "subline": "On iPhone, notifications require adding Evolve Capital to your home screen. We'll show you how.",
+      "cta": "Show me how"
+    },
+    "toastSuccess": {
+      "title": "Notifications on",
+      "message": "You'll be notified about new votes — even when the app is closed."
+    },
+    "toastBlocked": {
+      "title": "Notifications blocked",
+      "message": "Allow notifications in your browser settings, then try again."
+    },
+    "toastDisabled": {
+      "title": "Notifications off",
+      "message": "You'll no longer receive notifications on this device."
+    },
+    "toastError": {
+      "title": "Something went wrong",
+      "message": "An issue occurred. Please try again in a moment."
+    },
+    "section": {
+      "title": "Notifications",
+      "body": "Vote alerts, sent to this device.",
+      "statusActive": "Active on this device",
+      "statusBlocked": "Permission denied",
+      "statusOff": "Not set up",
+      "masterLabel": "Push notifications",
+      "masterHint": "Turn all notifications on or off on this device.",
+      "typesLabel": "When to be notified",
+      "blockedHint": "Notifications are blocked in your browser. Allow them in your settings to enable this.",
+      "blockedHintPre": "Notifications are blocked by the browser.",
+      "blockedHintLink": "See how to re-enable",
+      "iosTitle": "Notifications aren't available on this device",
+      "iosHint": "On iPhone, install the app to your home screen first to receive notifications.",
+      "iosCta": "Install the app",
+      "types": {
+        "pollOpened": {
+          "label": "New votes",
+          "hint": "When a vote opens in your club."
+        },
+        "pollClosed": {
+          "label": "Results available",
+          "hint": "When a vote closes and results are ready."
+        },
+        "pollReminder": {
+          "label": "Reminders before deadline",
+          "hint": "The day before a vote you haven't answered ends."
+        }
+      }
+    }
+  },
   "cookieConsent": {
     "title": "We use analytics cookies",
     "description": "Google Analytics helps us understand how members use the app, to improve it. Nothing else — no advertising cookies.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1065,6 +1065,68 @@
       "button": "Installer l'app"
     }
   },
+  "push": {
+    "badge": "Notifications · sans App Store",
+    "prePrompt": {
+      "headline": "Ne manquez plus un vote",
+      "subline": "Recevez une alerte quand un nouveau vote est ouvert ou quand les résultats sont disponibles — même app fermée.",
+      "trustNote": "Votre vote reste anonyme. Les notifications ne révèlent jamais qui a voté.",
+      "accept": "Activer les notifications",
+      "later": "Plus tard",
+      "manageInProfile": "Gérer dans Mon profil ›"
+    },
+    "iosInstall": {
+      "headline": "Installe l'app pour les notifications.",
+      "subline": "Sur iPhone, les notifications nécessitent d'ajouter Evolve Capital à ton écran d'accueil. On te montre comment.",
+      "cta": "Voir comment"
+    },
+    "toastSuccess": {
+      "title": "Notifications activées",
+      "message": "Tu seras prévenu(e) des nouveaux votes — même l'app fermée."
+    },
+    "toastBlocked": {
+      "title": "Notifications bloquées",
+      "message": "Autorise les notifications dans les réglages de ton navigateur, puis réessaie."
+    },
+    "toastDisabled": {
+      "title": "Notifications désactivées",
+      "message": "Tu ne recevras plus de notifications sur cet appareil."
+    },
+    "toastError": {
+      "title": "Action impossible",
+      "message": "Un souci est survenu. Réessaie dans un instant."
+    },
+    "section": {
+      "title": "Notifications",
+      "body": "Alertes de vote, envoyées sur cet appareil.",
+      "statusActive": "Actif sur cet appareil",
+      "statusBlocked": "Autorisation refusée",
+      "statusOff": "Non configuré",
+      "masterLabel": "Notifications push",
+      "masterHint": "Active ou coupe toutes les notifications sur cet appareil.",
+      "typesLabel": "Quand être prévenu(e)",
+      "blockedHint": "Les notifications sont bloquées dans ton navigateur. Autorise-les dans les réglages pour activer ce réglage.",
+      "blockedHintPre": "Les notifications sont bloquées par le navigateur.",
+      "blockedHintLink": "Voir comment réactiver",
+      "iosTitle": "Notifications non disponibles sur cet appareil",
+      "iosHint": "Sur iPhone, installe d'abord l'app sur ton écran d'accueil pour recevoir les notifications.",
+      "iosCta": "Installer l'app",
+      "types": {
+        "pollOpened": {
+          "label": "Nouveaux votes",
+          "hint": "Quand un vote s'ouvre dans ton club."
+        },
+        "pollClosed": {
+          "label": "Résultats disponibles",
+          "hint": "Quand un vote se termine et que les résultats sont prêts."
+        },
+        "pollReminder": {
+          "label": "Rappels avant échéance",
+          "hint": "La veille de la fin d'un vote auquel tu n'as pas répondu."
+        }
+      }
+    }
+  },
   "cookieConsent": {
     "title": "Nous utilisons des cookies d'analyse",
     "description": "Google Analytics nous aide à comprendre comment les membres utilisent l'application, pour l'améliorer. Rien d'autre — aucun cookie publicitaire.",

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,5 +1,5 @@
 // apps/web/public/sw.js
-const VERSION = 'pwa-v1'
+const VERSION = 'pwa-v2'
 const STATIC = `evolve-static-${VERSION}`
 const DATA = `evolve-data-${VERSION}`
 const PRECACHE = ['/offline.html', '/icons/icon-192.png', '/icons/icon-512.png']
@@ -26,6 +26,43 @@ self.addEventListener('activate', (e) => {
 })
 self.addEventListener('message', (e) => {
   if (e.data === 'clear-data-cache') caches.delete(DATA).catch(() => {})
+})
+
+// ─── Web Push (PUSH-001, spec §5) ───
+// Handlers ajoutés sans modifier la stratégie offline. Payload JSON anonyme :
+// { title, body, url, tag } — jamais de PII. `tag` stable par poll → une nouvelle push
+// remplace la précédente sur le même vote (anti-spam tray).
+self.addEventListener('push', (event) => {
+  let payload = { title: 'Evolve Capital', body: '', url: '/dashboard', tag: 'evolve' }
+  try {
+    if (event.data) payload = { ...payload, ...event.data.json() }
+  } catch {
+    /* garde les défauts si le corps n'est pas du JSON */
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: '/icons/icon-192.png',
+      badge: '/icons/icon-192.png',
+      tag: payload.tag ?? 'evolve',
+      data: { url: payload.url ?? '/dashboard' },
+      // actions: Android seulement — V1 si besoin « Voter »
+    })
+  )
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const url = event.notification.data?.url ?? '/dashboard'
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((list) => {
+      for (const client of list) {
+        if (client.url.includes(url) && 'focus' in client) return client.focus()
+      }
+      if (clients.openWindow) return clients.openWindow(url)
+    })
+  )
 })
 
 const NO_CACHE = (url) =>

--- a/docs/qa/QA_REPORT_2026-06-16-web-push.md
+++ b/docs/qa/QA_REPORT_2026-06-16-web-push.md
@@ -1,0 +1,42 @@
+# Rapport QA — Web Push + email de vote (PUSH-001)
+
+**Date :** 2026-06-16 · **Branche :** `feat/anonymous-vote` · **Spec :** `docs/superpowers/specs/2026-06-16-web-push-notifications-design.md` · **Réf design :** `REC/standalone-exports/Notifications - Maquettes (standalone).html`
+
+## Verdict
+
+**PASS.** Conformité visuelle vs maquette **≥ 90 %** sur les deux surfaces in-app comparables (pré-prompt ~93 %, section profil ~90 %). Gate `make lint typecheck test` **exit 0** (utils 62 / data 221 / ui 558 / web 427). Tests Deno Edge 18/18.
+
+## Garantie anti-fuite inter-club (exigence produit)
+
+Les destinataires (push **et** email) sont résolus **uniquement** par le `club_id` du vote (`memberships … club_id = poll.club_id AND status='active'`), jamais via `network_wide`. Défense en profondeur dans `dispatch-push` (re-filtre `allowedUsers` Set). Tests dédiés à 2 clubs prouvent qu'un club B ne reçoit jamais la notif/mail d'un vote du club A :
+
+- `supabase/functions/dispatch-push/__tests__/handler.test.ts` (push)
+- `supabase/functions/send-poll-email/__tests__/handler.test.ts` (email)
+- `apps/web/app/(app)/admin/votes/actions.test.ts` (le `clubId` dispatché = club du vote)
+  Payload push **sans PII** (pollId/clubId/type/url/title) — testé dans `packages/data/src/notifications/templates.test.ts`.
+
+## Couverture par couche
+
+| Couche                | Tests                                                             | Résultat        |
+| --------------------- | ----------------------------------------------------------------- | --------------- |
+| DB (migration 039)    | RLS owner-only, GRANTs explicites, appliquée local                | OK              |
+| Data (`@evolve/data`) | templates (no-PII, date FR) + PollEmail render                    | 24              |
+| Edge (Deno)           | dispatch-push 8 · send-poll-email 6 · crons 4                     | 18/18           |
+| Web (`@evolve/web`)   | lib/push (permission/platform) + api/push + parité i18n           | inclus dans 427 |
+| Intégration vote      | actions.test.ts (publish/close, fire-and-forget, anti-cross-club) | 13              |
+
+## Conformité visuelle (maquette ≥ 90 %)
+
+| Surface           | Avant fix     | Après fix     | Écart résiduel                                                                                          |
+| ----------------- | ------------- | ------------- | ------------------------------------------------------------------------------------------------------- |
+| Pré-prompt opt-in | 46 %          | **~93 %**     | état « bloqué » in-sheet non rendu (inatteignable : le mount ne s'affiche qu'en `ready`)                |
+| Section profil    | 42 %          | **~90 %**     | bouton « Tester une notification » non implémenté (feature distincte `system.test`, voir reste à faire) |
+| Toasts            | non mesurable | non mesurable | SW prod-only → toasts non déclenchables en localhost ; à vérifier sur preview HTTPS                     |
+
+Méthode : rendu Playwright (login membre réel + mocks `Notification`/`PushManager`/`serviceWorker.ready`), light + dark + mobile, comparaison composition/tokens vs frames de référence (`docs/audits/shots/ref-push-*.jpeg`). Correctifs **chirurgicaux** (composants push d'`apps/web` + i18n) sans toucher `packages/ui` (`PwaInstallSheet` inchangé → zéro régression de la bannière PWA).
+
+## Reste à faire (owner / suivi)
+
+- **Déploiement requis pour le vrai push** : le Service Worker est prod-only + HTTPS → la souscription ne fonctionne pas en `localhost`. Tester sur preview Vercel + vrai device.
+- **Secrets owner** : `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` (Edge), `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (Vercel), `BREVO_API_KEY`/`BREVO_SENDER_EMAIL` (email), secrets Vault `poll_push_reminders_url` + `poll_closed_push_url`. Déployer les 4 Edge Functions.
+- **Follow-up V1** : bouton « Tester une notification » (event `system.test` ciblé sur le seul appareil courant + rate-limit), email closed/reminder câblés, copy push i18n EN.

--- a/docs/superpowers/specs/2026-06-16-web-push-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-16-web-push-notifications-design.md
@@ -1,0 +1,603 @@
+# Web Push — Notifications système (hors-app) · Spec technique
+
+> **Statut** : draft technique — prêt pour implémentation  
+> **Date** : 2026-06-16  
+> **Epic** : E-NTF (extension) · ticket implémentation : **PUSH-001**  
+> **Dépendances** : PWA-001 ✅ (manifest + `sw.js` + `register-sw.ts`) · Vote anonyme V0 ✅ (bannières in-app, `/votes`, admin publish/close)  
+> **Hors scope** : centre de notifs in-app type inbox, emails Brevo vote (V1 spec vote §12), notifications réseau cross-club
+
+---
+
+## 1. Contexte & périmètre
+
+### 1.1 Ce qui existe déjà (in-app — ne pas refaire)
+
+Le module Vote couvre la **découverte in-app** :
+
+| Mécanisme            | Fichier / composant                   | Rôle                                              |
+| -------------------- | ------------------------------------- | ------------------------------------------------- |
+| Bannières dashboard  | `DashboardPollBanners` + `PollBanner` | Vote ouvert non voté — découverte principale      |
+| Pastille menu avatar | `AppTopbar` (`pollsToVote`, dot)      | Indicateur non lu                                 |
+| Page `/votes`        | `PollsView`, `PollDetailView`         | Accès secondaire + vote + résultats               |
+| Admin publish/close  | `admin/votes/actions.ts`              | `status: open` / `closed`                         |
+| Toggle staff         | `notify_by_email` sur `polls`         | Intent « notifier à la publication » (email = V1) |
+
+**La Web Push complète l'in-app** quand l'utilisateur n'a pas l'app ouverte. Les deux canaux coexistent ; la push ne remplace pas les bannières.
+
+### 1.2 Objectif PUSH-001
+
+Implémenter une **brique Web Push réutilisable** (subscription persistée, envoi server-side, handlers SW) et l'intégrer au **premier cas d'usage : votes**.
+
+### 1.3 Matrice plateforme
+
+| Plateforme                          | Push app fermée ? | Prérequis                                                           |
+| ----------------------------------- | ----------------- | ------------------------------------------------------------------- |
+| Desktop (Chrome, Edge, Firefox)     | ✅                | Permission navigateur + SW enregistré — **install PWA optionnelle** |
+| Android Chrome                      | ✅                | Idem                                                                |
+| iOS Safari **sans** écran d'accueil | ❌                | Fallback UX (réutiliser `PwaInstallSheet` / `detectPwaCase`)        |
+| iOS PWA installée (`standalone`)    | ✅                | iOS ≥ 16.4                                                          |
+| Safari macOS                        | ✅                | macOS ≥ 13                                                          |
+
+Le SW actuel (`apps/web/public/sw.js`, version `pwa-v1`) gère cache/offline uniquement — **aucun handler `push` / `notificationclick`**.
+
+---
+
+## 2. Décisions produit verrouillées
+
+### 2.1 Événements déclencheurs (V0)
+
+| `NotificationEvent.type` | Déclencheur                                                             | Destinataires                                                                            | Copy (FR, anonyme)                                                                     |
+| ------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `poll.opened`            | Staff **publie** un vote (`status → open`) ET `notify_by_email = true`¹ | Membres **actifs** du `club_id`, abonnés push, préférence `poll_opened` ON               | « Nouveau vote : {title} — répondez avant le {date} » ou sans date si `closes_at` null |
+| `poll.closed`            | Clôture **manuelle** ou `close_due_polls()`                             | Idem, préférence `poll_closed` ON                                                        | « Résultats disponibles : {title} »                                                    |
+| `poll.reminder`          | pg_cron quotidien, J-1 avant `closes_at`                                | Membres actifs **n'ayant pas voté** (`has_voted = false`), préférence `poll_reminder` ON | « Il vous reste 24 h pour voter : {title} »                                            |
+
+¹ **Sémantique du toggle staff** : le champ DB `notify_by_email` devient sémantiquement **« notifier les membres à l'ouverture »** (push V0 + email V1). Pas de migration de nom en V0 — le hint UI admin est ajusté (« notification push (+ email si configuré) »). Un ticket follow-up pourra renommer en `notify_members`.
+
+### 2.2 Interdits (anonymat)
+
+- **Jamais** de push sur `submit_vote` (vote individuel enregistré).
+- **Jamais** de copy du type « X membres ont voté », « Pierre a voté », contenu de réponse, `user_id`, email.
+- Payload push : `pollId`, `clubId`, `type`, `url` uniquement — **pas de PII**.
+
+### 2.3 Opt-in
+
+- **Opt-in explicite** : aucune subscription sans action utilisateur (pre-prompt maison → `Notification.requestPermission()` → `pushManager.subscribe()`).
+- **Timing du pre-prompt** : première visite dashboard **avec ≥ 1 vote ouvert non voté**, si pas encore abonné sur cet appareil, cooldown 7 jours après « Plus tard » (localStorage, pattern `dismiss-storage.ts`).
+- **Réglages** : section « Notifications » sur `/profil` (toggle master + sous-préférences par type).
+
+---
+
+## 3. Architecture — 5 couches
+
+Respecte CLAUDE.md : logique métier `apps/web` + `packages/data` ; présentation pre-prompt → `packages/ui` si réutilisable, sinon `apps/web/components/push/`.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Modules métier (votes, futur…)                                  │
+│    dispatchNotification({ type, clubId, payload })               │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────────────┐
+│  Edge Function `dispatch-push` (service_role)                    │
+│    résout destinataires · filtre préférences · web-push (VAPID)  │
+│    purge subscriptions 410/404 · log agrégé (pas de PII)         │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────────────┐
+│  Postgres : push_subscriptions + push_preferences                │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  Client : pre-prompt · subscribe · profil · SW push/click        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 Contrat `NotificationEvent` (`packages/types`)
+
+```ts
+/** Types d'événements push V0. Extensible sans breaking change. */
+export type NotificationEventType = 'poll.opened' | 'poll.closed' | 'poll.reminder' | 'system.test' // bouton « Tester » profil
+
+export type NotificationEvent = {
+  type: NotificationEventType
+  clubId: string
+  payload: {
+    pollId?: string
+    title: string
+    /** ISO — optionnel (rappel / deadline) */
+    closesAt?: string | null
+  }
+}
+```
+
+### 3.2 API d'envoi (server-only)
+
+```ts
+// packages/data/src/notifications/dispatch.ts
+/** Appelé depuis Server Actions, RPC triggers ou Edge Functions internes. */
+export async function dispatchNotification(
+  supabaseAdmin: SupabaseClient,
+  event: NotificationEvent
+): Promise<{ sent: number; failed: number; skipped: number }>
+```
+
+Implémentation : `supabaseAdmin.functions.invoke('dispatch-push', { body: event })`. **Jamais** depuis le browser.
+
+Templates de copy centralisés dans `packages/data/src/notifications/templates.ts` (FR ; EN follow-up i18n push = V1).
+
+---
+
+## 4. Schéma Supabase (migration `039_push_notifications.sql`)
+
+### 4.1 Table `push_subscriptions`
+
+Une ligne = **un endpoint navigateur** (multi-appareils par user).
+
+```sql
+CREATE TABLE public.push_subscriptions (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+
+  user_id      uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  endpoint     text NOT NULL UNIQUE,
+  p256dh       text NOT NULL,
+  auth         text NOT NULL,
+
+  user_agent   text,
+  -- Snapshot pour debug support (« iPhone Safari PWA ») — pas de PII
+  platform     text CHECK (platform IN ('desktop','android-chrome','ios-safari','ios-other','standalone','unknown')),
+
+  last_success_at timestamptz,
+  last_error_at   timestamptz,
+  last_error_code text  -- ex. '410', '404' — jamais le corps de réponse
+);
+
+CREATE INDEX push_subscriptions_user_id_idx ON public.push_subscriptions (user_id);
+```
+
+### 4.2 Table `push_preferences`
+
+Préférences **par utilisateur** (pas par appareil).
+
+```sql
+CREATE TABLE public.push_preferences (
+  user_id        uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+
+  enabled        boolean NOT NULL DEFAULT true,
+  poll_opened    boolean NOT NULL DEFAULT true,
+  poll_closed    boolean NOT NULL DEFAULT true,
+  poll_reminder  boolean NOT NULL DEFAULT true
+);
+```
+
+Ligne créée au **premier subscribe** (`UPSERT` défauts ON).
+
+### 4.3 RLS
+
+```sql
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_preferences ENABLE ROW LEVEL SECURITY;
+
+-- push_subscriptions : le membre gère SES subscriptions uniquement
+CREATE POLICY "push_subscriptions: owner select"
+  ON public.push_subscriptions FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner insert"
+  ON public.push_subscriptions FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner update"
+  ON public.push_subscriptions FOR UPDATE TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner delete"
+  ON public.push_subscriptions FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- push_preferences : lecture/écriture propre user
+CREATE POLICY "push_preferences: owner all"
+  ON public.push_preferences FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_preferences TO authenticated;
+GRANT ALL ON public.push_subscriptions TO service_role;
+GRANT ALL ON public.push_preferences TO service_role;
+```
+
+**Aucune policy** permettant à un membre de lire les subscriptions d'un autre. L'Edge Function utilise `service_role`.
+
+### 4.4 Journal d'envoi (optionnel V0, recommandé)
+
+Table légère `push_delivery_log` pour debug staff réseau — **sans PII** :
+
+```sql
+CREATE TABLE public.push_delivery_log (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  event_type  text NOT NULL,
+  club_id     uuid REFERENCES public.clubs (id),
+  poll_id     uuid REFERENCES public.polls (id),
+  sent_count  int NOT NULL DEFAULT 0,
+  failed_count int NOT NULL DEFAULT 0,
+  skipped_count int NOT NULL DEFAULT 0
+);
+-- RLS : aucun accès authenticated ; service_role only
+```
+
+---
+
+## 5. Service Worker (`public/sw.js`)
+
+Incrémenter `VERSION` → `pwa-v2` (invalidation caches + signal déploiement).
+
+### 5.1 Handler `push`
+
+```js
+self.addEventListener('push', (event) => {
+  let payload = { title: 'Evolve Capital', body: '', url: '/dashboard', tag: 'evolve' }
+  try {
+    if (event.data) payload = { ...payload, ...event.data.json() }
+  } catch {
+    /* garde les défauts */
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: '/icons/icon-192.png',
+      badge: '/icons/icon-192.png',
+      tag: payload.tag ?? 'evolve',
+      data: { url: payload.url ?? '/dashboard' },
+      // actions: Android seulement — V1 si besoin « Voter »
+    })
+  )
+})
+```
+
+### 5.2 Handler `notificationclick`
+
+```js
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const url = event.notification.data?.url ?? '/dashboard'
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((list) => {
+      for (const client of list) {
+        if (client.url.includes(url) && 'focus' in client) return client.focus()
+      }
+      if (clients.openWindow) return clients.openWindow(url)
+    })
+  )
+})
+```
+
+### 5.3 Compatibilité cache existant
+
+Conserver intégralement les handlers `install` / `activate` / `fetch` / `message` (PWA-001). Les push handlers s'ajoutent **sans** modifier la stratégie offline.
+
+---
+
+## 6. Client (`apps/web`)
+
+### 6.1 Fichiers à créer
+
+```
+apps/web/
+├── lib/push/
+│   ├── vapid.ts                 # NEXT_PUBLIC_VAPID_PUBLIC_KEY → Uint8Array pour subscribe
+│   ├── subscribe.ts             # subscribePush(), unsubscribePush(), getSubscriptionState()
+│   ├── permission.ts            # isPushSupported(), canSubscribeOnPlatform() — compose detectPwaCase
+│   ├── dismiss-storage.ts       # cooldown pre-prompt (7j) — miroir pattern pwa/dismiss-storage
+│   ├── use-push-opt-in.ts       # hook : shouldShowPrePrompt, requestOptIn, dismiss
+│   └── platform-push.ts         # map PwaCase → PushPlatformCapability
+├── components/push/
+│   ├── PushOptInSheet.tsx       # wrapper client autour de composant UI
+│   ├── PushOptInMount.tsx       # mount dashboard (à côté InstallBannerMount)
+│   └── ProfileNotificationsSection.tsx  # section /profil
+├── app/api/push/
+│   ├── subscribe/route.ts       # POST — persiste subscription (session requise)
+│   └── unsubscribe/route.ts     # POST/DELETE — retire endpoint
+└── app/(app)/profil/            # intégrer ProfileNotificationsSection dans ProfileView
+```
+
+### 6.2 Fichiers à modifier
+
+| Fichier                            | Changement                                                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `public/sw.js`                     | Handlers push + click ; `VERSION = 'pwa-v2'`                                                   |
+| `app/(app)/admin/votes/actions.ts` | Après publish réussi → `dispatchNotification({ type: 'poll.opened', … })` si `notify_by_email` |
+| `app/(app)/admin/votes/actions.ts` | Après `closePollAction` OK → `dispatchNotification({ type: 'poll.closed', … })`                |
+| `app/(app)/dashboard/page.tsx`     | Monter `PushOptInMount`                                                                        |
+| `app/(app)/profil/ProfileView.tsx` | Section notifications                                                                          |
+| `lib/analytics.ts`                 | Events `push_opt_in_*`, `push_notification_click` (sans PII)                                   |
+| `messages/fr.json` + `en.json`     | Namespace `push.*`                                                                             |
+| `apps/web/.env.example`            | `NEXT_PUBLIC_VAPID_PUBLIC_KEY`                                                                 |
+
+### 6.3 Flux subscribe
+
+1. `registerServiceWorker()` déjà appelé (`PwaServiceWorkerRegistrar`).
+2. Pre-prompt maison (`PushOptInSheet`) → utilisateur accepte.
+3. `Notification.requestPermission()` → si `'granted'` :
+4. `registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey })`.
+5. `POST /api/push/subscribe` avec `{ endpoint, keys: { p256dh, auth }, userAgent, platform }`.
+6. Route : vérif session (`getUser()`), `UPSERT push_subscriptions`, `UPSERT push_preferences` défauts.
+7. Toast confirmation (Sonner, pattern existant).
+
+**Logout** : appeler `unsubscribe` sur l'endpoint courant + `DELETE` côté API (évite push vers session terminée sur appareil partagé). Réutiliser le hook logout existant dans `AppChrome`.
+
+### 6.4 Capacité plateforme (`canSubscribeOnPlatform`)
+
+```ts
+// Règles (ordre)
+// 1. !('Notification' in window) || !('PushManager' in window) → unsupported
+// 2. detectPwaCase() === 'ios-safari' && !== 'standalone' → needs_pwa_install (fallback iOS)
+// 3. detectPwaCase() === 'ios-other' → needs_safari
+// 4. permission === 'denied' → blocked
+// 5. sinon → ready
+```
+
+Le fallback iOS **réutilise** `PwaInstallSheet` + copy push-spécifique (pas de nouveau composant illustration).
+
+### 6.5 Deep links vote
+
+| Event           | `url` dans payload            |
+| --------------- | ----------------------------- |
+| `poll.opened`   | `/votes/{pollId}`             |
+| `poll.closed`   | `/votes/{pollId}` (résultats) |
+| `poll.reminder` | `/votes/{pollId}`             |
+| `system.test`   | `/dashboard`                  |
+
+---
+
+## 7. Edge Function `dispatch-push`
+
+### 7.1 Fichiers
+
+```
+supabase/functions/dispatch-push/
+├── index.ts       # entrypoint Deno
+├── handler.ts     # pur, testable (résolution destinataires + envoi)
+└── handler.test.ts
+```
+
+### 7.2 Contrat HTTP
+
+```
+POST /functions/v1/dispatch-push
+Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>  // ou secret interne DISPATCH_PUSH_SECRET
+Body: NotificationEvent (JSON)
+→ 200 { sent, failed, skipped }
+```
+
+**Ne pas exposer** cette function au client. Seuls Server Actions (service role via `createServiceClient` server-only) et jobs cron l'appellent.
+
+### 7.3 Résolution destinataires
+
+Pseudo-code :
+
+```
+switch (event.type):
+  poll.opened | poll.closed:
+    users = SELECT DISTINCT m.user_id
+            FROM memberships m
+            WHERE m.club_id = event.clubId AND m.is_active = TRUE
+
+  poll.reminder:
+    users = membres actifs du club
+            MINUS ceux où has_voted(pollId) = true  -- via requête service_role sur poll_responses
+
+subs = push_subscriptions JOIN push_preferences
+       WHERE user_id IN users
+         AND push_preferences.enabled
+         AND push_preferences.<type_column>
+```
+
+Pour `poll.opened` : **ne pas envoyer** si `notify_by_email` false sur le poll (relecture `polls` par `pollId`).
+
+### 7.4 Envoi `web-push`
+
+- Lib : `npm:web-push@^3` (Deno import map).
+- Env : `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` (`mailto:support@reseauevolvecapital.com`).
+- Payload JSON minimal :
+
+```json
+{
+  "title": "Evolve Capital",
+  "body": "Nouveau vote : …",
+  "url": "/votes/uuid",
+  "tag": "poll-opened-{pollId}"
+}
+```
+
+- `tag` stable par poll → une nouvelle push **remplace** la précédente sur le même vote (évite spam tray).
+- Sur `410 Gone` / `404` : **DELETE** la subscription invalide.
+- Boucle d'envoi : `Promise.allSettled` par batch de 50 (éviter timeout Edge 300s sur gros clubs).
+
+### 7.5 Cron rappel vote
+
+Migration complémentaire — job pg_cron quotidien (ex. 09:00 Europe/Paris) :
+
+```sql
+-- Appelle une Edge Function `poll-push-reminders` OU réutilise dispatch-push en boucle
+-- Sélection : polls status='open' AND closes_at BETWEEN now() AND now() + interval '24 hours'
+```
+
+Implémentation recommandée : Edge Function dédiée `poll-push-reminders` qui query les polls éligibles et appelle le handler `dispatch-push` par poll — **évite** la logique cron dans SQL.
+
+---
+
+## 8. Intégration votes (points d'accroche)
+
+### 8.1 Publication (`createPollAction`)
+
+Après `insert` réussi avec `status === 'open'` :
+
+```ts
+if (p.notifyByEmail) {
+  await dispatchNotification(adminClient, {
+    type: 'poll.opened',
+    clubId: ctx.clubId,
+    payload: { pollId: data.id, title: p.title, closesAt: toClosesAt(p.closesAt) },
+  })
+}
+```
+
+**Fire-and-forget** : l'échec push ne doit **pas** faire échouer la publication (log Sentry + `push_delivery_log`). Le vote est déjà `open` ; l'in-app couvre le gap.
+
+### 8.2 Clôture manuelle (`closePollAction`)
+
+Après `update` réussi :
+
+```ts
+await dispatchNotification(adminClient, {
+  type: 'poll.closed',
+  clubId: ctx.clubId,
+  payload: { pollId, title: /* fetch title */ },
+})
+```
+
+### 8.3 Clôture auto (`close_due_polls`)
+
+Deux options (choisir **A** en V0) :
+
+- **A** — `close_due_polls` retourne les `id` clôturés ; pg_cron appelle une Edge Function post-close qui dispatch `poll.closed` pour chaque id.
+- **B** — trigger SQL `AFTER UPDATE` sur `polls` quand `status` passe à `closed` → `pg_net` vers Edge Function.
+
+**Décision V0 : A** — modifier `close_due_polls()` pour retourner `uuid[]` des polls clôturés ; nouveau job cron `poll-closed-push` toutes les heures (aligné sur `close-due-polls`).
+
+---
+
+## 9. Variables d'environnement
+
+| Variable                       | Scope                                | Description                                          |
+| ------------------------------ | ------------------------------------ | ---------------------------------------------------- |
+| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | apps/web (public)                    | Clé publique VAPID pour `pushManager.subscribe()`    |
+| `VAPID_PUBLIC_KEY`             | supabase/functions                   | Même valeur (vérif web-push)                         |
+| `VAPID_PRIVATE_KEY`            | supabase/functions **uniquement**    | Clé privée VAPID — **jamais** client                 |
+| `VAPID_SUBJECT`                | supabase/functions                   | `mailto:support@reseauevolvecapital.com`             |
+| `DISPATCH_PUSH_SECRET`         | supabase/functions + apps/web server | Secret partagé optionnel si invoke sans service role |
+
+Génération locale :
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Documenter dans `REC/ARCHITECTURE.md` §8 et `apps/web/.env.example`.
+
+---
+
+## 10. Sécurité & conformité
+
+- **RLS** sur toutes les tables (§4.3).
+- **Service role** uniquement dans Edge Functions et routes API server — jamais `NEXT_PUBLIC_*`.
+- Payload push **sans PII** ; logs agrégés uniquement.
+- **RGPD** : opt-in explicite ; désabonnement en 1 clic (profil + suppression subscription) ; mention dans politique confidentialité (hors scope dev).
+- **Rate limit** : max 1 `system.test` / user / heure (Upstash ou compteur DB).
+- **CSP** : `worker-src 'self'` déjà présent (`next.config.ts`) — suffisant.
+
+---
+
+## 11. UI (`packages/ui` — optionnel V0)
+
+Si le pre-prompt est visuellement identique à `PwaInstallSheet`, **réutiliser** `PwaInstallSheet` avec props copy push (pattern PWA-001). Sinon créer `PushOptInSheet` minimal dans `packages/ui` + Storybook play + jest-axe.
+
+La section profil peut rester dans `apps/web` (logique métier + hooks).
+
+**Référence design** : prompt Claude Design (brainstorm rendu) — à lier quand l'export HTML standalone existe.
+
+---
+
+## 12. i18n
+
+- Pre-prompt, profil, toasts : namespace `push` dans `fr.json` / `en.json` (obligatoire projet).
+- **Copy des notifications système** : FR uniquement V0 (templates `templates.ts`). EN = V1.
+
+---
+
+## 13. Tests
+
+| Couche             | Fichier / sujet                                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Vitest**         | `templates.test.ts` — copy vote, pas de PII, date FR                                                                                         |
+| **Vitest**         | `handler.test.ts` (Edge) — résolution destinataires, filtre prefs, purge 410                                                                 |
+| **Vitest**         | `permission.test.ts`, `platform-push.test.ts` — iOS sans standalone → `needs_pwa_install`                                                    |
+| **Vitest**         | `subscribe/route.test.ts` — auth requise, upsert                                                                                             |
+| **Storybook play** | `PushOptInSheet` — CTA, dismiss, états blocked                                                                                               |
+| **jest-axe**       | PushOptInSheet, ProfileNotificationsSection                                                                                                  |
+| **E2E Playwright** | `push-opt-in.spec.ts` — **mocker** `Notification` + `PushManager` (pas de vrai tray CI) ; vérifie pre-prompt → subscribe API → profil toggle |
+| **E2E**            | Vote publish → mock `dispatch-push` (intercept network) → assert invoke                                                                      |
+
+Ne pas tester le rendu OS natif en E2E — hors contrôle.
+
+---
+
+## 14. Critères d'acceptation (PUSH-001)
+
+- [ ] **Subscription** — membre connecté autorise → subscription persistée Supabase + toast confirmation
+- [ ] **Vote ouvert → Push** — staff publie avec toggle notification → membres abonnés reçoivent push **app fermée** (test manuel device réel)
+- [ ] **Anonymat** — aucune push sur vote individuel ; copy sans identité votant
+- [ ] **iOS fallback** — Safari iOS sans standalone → encart « installez l'app » + lien `PwaInstallSheet`, pas de crash
+- [ ] **Réutilisabilité** — `dispatchNotification(event)` utilisable sans config module supplémentaire
+- [ ] **Clôture** — push `poll.closed` manuelle + auto
+- [ ] **Profil** — toggle désactive envois futurs ; unsubscribe retire l'endpoint
+- [ ] **Gate** — `make lint typecheck test` vert ; `cursor-pointer.spec.ts` inchangé
+
+---
+
+## 15. Estimation & découpage tickets
+
+| Ticket    | Scope                                           | Est. |
+| --------- | ----------------------------------------------- | ---- |
+| PUSH-001a | Migration DB + types + templates                | 2h   |
+| PUSH-001b | SW handlers + subscribe API + client lib        | 4h   |
+| PUSH-001c | Edge `dispatch-push` + VAPID + tests handler    | 4h   |
+| PUSH-001d | UI pre-prompt + profil + i18n                   | 3h   |
+| PUSH-001e | Intégration votes (publish/close/reminder cron) | 3h   |
+| PUSH-001f | E2E + doc ARCHITECTURE §8                       | 2h   |
+
+**Total ~18h** (1 sprint partiel).
+
+---
+
+## 16. Roadmap
+
+### V0 (ce spec)
+
+- Web Push + votes (opened / closed / reminder J-1)
+- Pre-prompt + profil
+- iOS fallback PWA
+
+### V1
+
+- Email Brevo vote (toggle existant — canal parallèle)
+- Renommer `notify_by_email` → `notify_members`
+- Actions Android (« Voter »)
+- Copy push i18n EN
+- `poll.reminder` J-2 configurable
+
+### V2
+
+- Autres modules (`investor.alert`, `network.news`, sync erreur membre…)
+- Centre in-app inbox (historique — distinct du tray OS)
+
+---
+
+## 17. Références code existant
+
+| Sujet                 | Chemin                                                           |
+| --------------------- | ---------------------------------------------------------------- |
+| SW cache              | `apps/web/public/sw.js`                                          |
+| Enregistrement SW     | `apps/web/lib/pwa/register-sw.ts`                                |
+| Détection plateforme  | `apps/web/lib/pwa/platform-detection.ts`                         |
+| Bannières vote in-app | `apps/web/components/dashboard/DashboardPollBanners.tsx`         |
+| Admin publish         | `apps/web/app/(app)/admin/votes/actions.ts`                      |
+| Migration polls       | `supabase/migrations/038_polls.sql`                              |
+| Pattern Edge Function | `supabase/functions/send-email/`                                 |
+| Spec vote             | `docs/superpowers/specs/2026-06-13-vote-anonyme-design.md`       |
+| Spec PWA              | `docs/superpowers/specs/2026-06-07-pwa-install-banner-design.md` |

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -9,6 +9,7 @@
     "./supabase/server": "./src/supabase/server.ts",
     "./prices": "./src/prices/index.ts",
     "./polls": "./src/polls/index.ts",
+    "./notifications": "./src/notifications/index.ts",
     "./emails": "./src/emails/index.ts",
     "./pdf": "./src/pdf/index.ts",
     "./brevo": "./src/brevo/index.ts"

--- a/packages/data/src/emails/PollEmail.tsx
+++ b/packages/data/src/emails/PollEmail.tsx
@@ -1,0 +1,338 @@
+import { Button, Heading, Section, Text } from '@react-email/components'
+import type { CSSProperties } from 'react'
+import { brand, dataViz, font, radius, semantic } from '@evolve/design-system'
+import { formatDateLong } from '@evolve/utils'
+import { EvolveEmailShell } from './_layout/EvolveEmailShell.tsx'
+
+/**
+ * PollEmail — emails transactionnels du module Vote anonyme (NTF-008 / PUSH-001 V1 email).
+ *
+ * Cf. prompt design `docs/product/PROMPT-DESIGN-NTF-POLL-EMAIL.md` et l'export visuel
+ * « Emails Transactionnels (standalone).html » : MÊME shell (EvolveEmailShell) que Magic
+ * Link / Bienvenue / Attestation. 3 variantes :
+ *   - opened   → « Un vote attend votre avis » (publish) — encart anonymat
+ *   - closed   → « Résultats du vote » (clôture) — PAS d'encart anonymat (vote fini)
+ *   - reminder → « Dernière chance de voter » (J-1) — label ambre + encart anonymat
+ *
+ * ANONYMAT — règle produit NON NÉGOCIABLE :
+ *   INTERDIT dans le visuel ET le copy : « X membres ont voté », nom/avatar d'un votant,
+ *   nom du créateur, pourcentages de participation, barres/graphiques de résultats,
+ *   contenu de réponses. Les résultats vivent dans l'app uniquement.
+ *
+ * COULEURS : CTA jaune `brand.yellow` sur encre `semantic.accentInk` — jamais blanc sur
+ * jaune, jamais `brand.red`. La variante `reminder` utilise l'ambre `dataViz.warning`
+ * (#D97706) pour le label « Échéance proche » — JAMAIS le rouge brand (#E93E3A).
+ *
+ * Email transactionnel relationnel club → `hideUnsubscribe` (footer RGPD sans désinscription).
+ * Pur : les valeurs sont passées prêtes ; aucune PII.
+ */
+export type PollEmailVariant = 'opened' | 'closed' | 'reminder'
+
+/** Locale de l'email — FR par défaut. Le copy des notifications de vote est FR-only en V0
+ *  (EN = follow-up i18n push V1) ; la prop existe pour la compat future, sans dépendance i18n. */
+export type PollEmailLocale = 'fr' | 'en'
+
+export interface PollEmailProps {
+  /** Prénom du membre (affiché dans le corps). */
+  memberFirstName: string
+  /** Nom du club (footer + corps). */
+  clubName: string
+  /** Titre du vote (jamais une identité). */
+  pollTitle: string
+  /** Description / contexte du vote — tronquée à l'affichage. Optionnelle. */
+  pollDescription?: string
+  /** Type de question (libellé technique mappé en FR pour la pastille). */
+  questionType: 'yes_no' | 'single_choice' | 'multiple_choice' | 'short_text'
+  /**
+   * Échéance du vote (ISO ou Date). Affichée « le {date longue FR} » sur opened/reminder.
+   * `null` / absent = pas d'échéance (clause omise).
+   */
+  closesAt?: string | Date | null
+  /** Variante de l'email. */
+  variant: PollEmailVariant
+  /** Base URL de l'app membre. Le CTA pointe vers `{appUrl}/votes`. */
+  appUrl?: string
+  /** Langue de l'email — FR par défaut (copy FR-only en V0). */
+  locale?: PollEmailLocale
+}
+
+const APP_URL_DEFAULT = 'https://app.evolve.capital'
+const FALLBACK = '—'
+
+function orDash(value: string | undefined): string {
+  const trimmed = (value ?? '').trim()
+  return trimmed === '' ? FALLBACK : trimmed
+}
+
+/** Pastille FR du type de question (anonyme — pas de donnée de réponse). */
+const QUESTION_TYPE_LABEL: Record<PollEmailProps['questionType'], string> = {
+  yes_no: 'Oui / Non',
+  single_choice: 'Choix unique',
+  multiple_choice: 'Choix multiple',
+  short_text: 'Réponse libre',
+}
+
+/** Échéance lisible « 30 juin 2026 » via @evolve/utils, ou null si absente/invalide. */
+function readableDeadline(closesAt: string | Date | null | undefined): string | null {
+  if (closesAt == null) return null
+  const formatted = formatDateLong(closesAt)
+  return formatted === FALLBACK ? null : formatted
+}
+
+interface VariantCopy {
+  preview: string
+  eyebrow: string
+  title: string
+  lead: string
+  cta: string
+  /** Note de pied (sous le CTA). */
+  footNote: string
+  /** Affiche le label ambre « Échéance proche » (reminder uniquement). */
+  showUrgencyLabel: boolean
+  /** Affiche l'encart anonymat (opened + reminder ; pas closed). */
+  showAnonymityCard: boolean
+}
+
+function buildCopy(props: PollEmailProps, club: string): VariantCopy {
+  const title = orDash(props.pollTitle)
+  switch (props.variant) {
+    case 'opened':
+      return {
+        preview: `Nouveau vote : ${title}`,
+        eyebrow: 'Consultation · Vote',
+        title: 'Un vote attend votre avis',
+        lead: `Le club ${club} ouvre une consultation anonyme.`,
+        cta: 'Voter maintenant',
+        footNote: 'Votre vote est définitif et ne pourra pas être modifié.',
+        showUrgencyLabel: false,
+        showAnonymityCard: true,
+      }
+    case 'closed':
+      return {
+        preview: `Résultats disponibles : ${title}`,
+        eyebrow: 'Consultation · Résultats',
+        title: 'Résultats du vote',
+        lead: `La consultation « ${title} » est clôturée. Les résultats agrégés sont disponibles dans votre espace.`,
+        cta: 'Voir les résultats',
+        footNote: 'Les résultats ont été publiés à la clôture du vote.',
+        showUrgencyLabel: false,
+        showAnonymityCard: false,
+      }
+    case 'reminder':
+      return {
+        preview: `Il vous reste 24 h pour voter : ${title}`,
+        eyebrow: 'Consultation · Rappel',
+        title: 'Dernière chance de voter',
+        lead: "La consultation se termine bientôt. Vous n'avez pas encore répondu.",
+        cta: 'Voter maintenant',
+        footNote: 'Sans réponse de votre part, votre avis ne sera pas pris en compte.',
+        showUrgencyLabel: true,
+        showAnonymityCard: true,
+      }
+  }
+}
+
+export function PollEmail(props: PollEmailProps) {
+  const firstName = orDash(props.memberFirstName)
+  const club = orDash(props.clubName)
+  const title = orDash(props.pollTitle)
+  const deadline = readableDeadline(props.closesAt)
+  const votesUrl = `${(props.appUrl ?? APP_URL_DEFAULT).replace(/\/+$/, '')}/votes`
+  const copy = buildCopy(props, club)
+  const typeLabel = QUESTION_TYPE_LABEL[props.questionType] ?? FALLBACK
+  const description = (props.pollDescription ?? '').trim()
+
+  return (
+    <EvolveEmailShell
+      preview={copy.preview}
+      clubName={props.clubName.trim() === '' ? undefined : props.clubName.trim()}
+      hideUnsubscribe
+    >
+      <Section style={eyebrowRow}>
+        <Text style={eyebrow}>{copy.eyebrow}</Text>
+        {copy.showUrgencyLabel ? <span style={urgencyLabel}>Échéance proche</span> : null}
+      </Section>
+
+      <Heading as="h1" style={h1}>
+        {copy.title}
+      </Heading>
+
+      <Text style={lead}>
+        Bonjour {firstName}, {copy.lead}
+      </Text>
+
+      {/* Encart vote — bordure gauche dorée (écho discret de la bannière dashboard). */}
+      <Section style={voteCard}>
+        <Text style={voteTitle}>{title}</Text>
+        <Text style={votePill}>{typeLabel}</Text>
+        {deadline && props.variant !== 'closed' ? (
+          <Text style={voteMeta}>
+            Répondez avant le <strong style={voteMetaStrong}>{deadline}</strong>
+          </Text>
+        ) : null}
+        {description !== '' ? <Text style={voteDesc}>{description}</Text> : null}
+      </Section>
+
+      {/* Encart anonymat — opened + reminder uniquement (pas closed). */}
+      {copy.showAnonymityCard ? (
+        <Section style={anonymityCard}>
+          <Text style={anonymityText}>
+            <span style={anonymityIcon}>🔒</span> Votre réponse reste anonyme. Personne ne peut
+            associer votre nom à votre vote.
+          </Text>
+        </Section>
+      ) : null}
+
+      <Button href={votesUrl} style={cta}>
+        {copy.cta}
+      </Button>
+
+      <Text style={footNote}>{copy.footNote}</Text>
+    </EvolveEmailShell>
+  )
+}
+
+/* — Styles inline (miroir TS des tokens) — */
+
+const eyebrowRow: CSSProperties = {
+  margin: '0 0 12px',
+}
+
+const eyebrow: CSSProperties = {
+  display: 'inline-block',
+  margin: 0,
+  fontFamily: font.mono,
+  fontSize: '11px',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: semantic.textTer,
+}
+
+/** Label ambre « Échéance proche » — token warning, JAMAIS brand.red. */
+const urgencyLabel: CSSProperties = {
+  display: 'inline-block',
+  marginLeft: '10px',
+  padding: '2px 8px',
+  borderRadius: radius.pill,
+  backgroundColor: dataViz.warning50,
+  color: dataViz.warningStrong,
+  fontFamily: font.mono,
+  fontSize: '10px',
+  fontWeight: 600,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  verticalAlign: 'middle',
+}
+
+const h1: CSSProperties = {
+  margin: '0 0 14px',
+  fontFamily: font.display,
+  fontWeight: 800,
+  fontSize: '27px',
+  lineHeight: '1.14',
+  letterSpacing: '-0.02em',
+  color: semantic.text,
+}
+
+const lead: CSSProperties = {
+  margin: '0 0 24px',
+  fontSize: '15px',
+  lineHeight: '1.6',
+  color: semantic.textSec,
+}
+
+/** Encart vote — bordure gauche dorée (brand.yellow) = écho de la bannière dashboard. */
+const voteCard: CSSProperties = {
+  margin: '0 0 18px',
+  border: `1px solid ${semantic.border}`,
+  borderLeft: `3px solid ${brand.yellow}`,
+  borderRadius: radius.md,
+  backgroundColor: semantic.bg,
+  padding: '16px 18px',
+}
+
+const voteTitle: CSSProperties = {
+  margin: '0 0 8px',
+  fontFamily: font.display,
+  fontWeight: 700,
+  fontSize: '16px',
+  lineHeight: '1.3',
+  color: semantic.text,
+}
+
+const votePill: CSSProperties = {
+  display: 'inline-block',
+  margin: '0 0 10px',
+  padding: '2px 8px',
+  borderRadius: radius.pill,
+  backgroundColor: semantic.card,
+  border: `1px solid ${semantic.border}`,
+  fontFamily: font.mono,
+  fontSize: '10px',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: semantic.textSec,
+}
+
+const voteMeta: CSSProperties = {
+  margin: '0 0 6px',
+  fontSize: '13.5px',
+  lineHeight: '1.5',
+  color: semantic.textSec,
+}
+
+const voteMetaStrong: CSSProperties = {
+  color: semantic.text,
+  fontWeight: 600,
+}
+
+const voteDesc: CSSProperties = {
+  margin: 0,
+  fontSize: '13.5px',
+  lineHeight: '1.5',
+  color: semantic.textTer,
+}
+
+const anonymityCard: CSSProperties = {
+  margin: '0 0 22px',
+  border: `1px solid ${semantic.border}`,
+  borderRadius: radius.md,
+  backgroundColor: semantic.cardSub,
+  padding: '13px 16px',
+}
+
+const anonymityText: CSSProperties = {
+  margin: 0,
+  fontSize: '13px',
+  lineHeight: '1.5',
+  color: semantic.textSec,
+}
+
+const anonymityIcon: CSSProperties = {
+  marginRight: '6px',
+}
+
+/** CTA jaune : fond brand.yellow, encre accentInk — jamais blanc, jamais brand.red. */
+const cta: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'center',
+  boxSizing: 'border-box',
+  backgroundColor: brand.yellow,
+  color: semantic.accentInk,
+  fontFamily: font.display,
+  fontWeight: 700,
+  fontSize: '15px',
+  letterSpacing: '0.04em',
+  textDecoration: 'none',
+  padding: '17px 24px',
+  borderRadius: radius.md,
+}
+
+const footNote: CSSProperties = {
+  margin: '18px 0 0',
+  fontSize: '12.5px',
+  lineHeight: '1.5',
+  color: semantic.textTer,
+  textAlign: 'center',
+}

--- a/packages/data/src/emails/index.ts
+++ b/packages/data/src/emails/index.ts
@@ -1,5 +1,6 @@
 import { render } from '@react-email/render'
-import type { ReactElement } from 'react'
+import { createElement, type ReactElement } from 'react'
+import { PollEmail, type PollEmailProps } from './PollEmail.tsx'
 
 /**
  * Emails transactionnels Evolve Capital (React Email).
@@ -23,8 +24,15 @@ export { NewsletterEmail } from './NewsletterEmail.tsx'
 export type { NewsletterEmailProps } from './NewsletterEmail.tsx'
 export { mapArticleToEmail } from './mappers/article-to-email.ts'
 export type { MapArticleOptions } from './mappers/article-to-email.ts'
+export { PollEmail } from './PollEmail.tsx'
+export type { PollEmailProps, PollEmailVariant, PollEmailLocale } from './PollEmail.tsx'
 
 /** Rend un email React Email en chaîne HTML prête à l'envoi. */
 export function renderEmailHtml(element: ReactElement): Promise<string> {
   return render(element)
+}
+
+/** Rend l'email de vote (opened/closed/reminder) en HTML prêt à l'envoi (Brevo). */
+export function renderPollEmailHtml(props: PollEmailProps): Promise<string> {
+  return render(createElement(PollEmail, props))
 }

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -24,3 +24,11 @@ export type {
   PollResults,
   PollResultsDTO,
 } from './polls/index.ts'
+// Web Push (migration 039, PUSH-001) — dispatch server-only + templates de copy
+export { dispatchNotification, buildNotificationContent } from './notifications/index.ts'
+export type {
+  NotificationEvent,
+  NotificationEventType,
+  NotificationContent,
+  DispatchResult,
+} from './notifications/index.ts'

--- a/packages/data/src/notifications/dispatch.ts
+++ b/packages/data/src/notifications/dispatch.ts
@@ -1,0 +1,49 @@
+// dispatchNotification — API d'envoi Web Push (PUSH-001 ; spec §3.2). SERVER-ONLY.
+//
+// Appelé depuis les Server Actions (vote publish/close), les RPC triggers ou les jobs cron,
+// TOUJOURS avec un client SERVICE ROLE (createServiceRoleClient). JAMAIS depuis le browser :
+// l'Edge `dispatch-push` résout les destinataires et envoie via VAPID en service_role.
+//
+// FIRE-AND-FORGET : un échec push ne doit jamais faire échouer l'action métier (la
+// publication d'un vote est déjà persistée ; l'in-app couvre le gap). Cette fonction ne
+// throw donc JAMAIS — elle retourne {sent:0,failed:0,skipped:0} en cas d'erreur.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../supabase/types.gen.ts'
+import type { DispatchResult, NotificationEvent } from './types.ts'
+
+const EMPTY_RESULT: DispatchResult = { sent: 0, failed: 0, skipped: 0 }
+
+/** Coerce le retour brut de l'Edge en DispatchResult défensif (compteurs entiers >= 0). */
+function toResult(data: unknown): DispatchResult {
+  if (data == null || typeof data !== 'object') return { ...EMPTY_RESULT }
+  const r = data as Record<string, unknown>
+  const num = (v: unknown): number => {
+    const n = typeof v === 'number' ? v : Number(v)
+    return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : 0
+  }
+  return { sent: num(r.sent), failed: num(r.failed), skipped: num(r.skipped) }
+}
+
+/**
+ * Dispatche un événement de notification vers l'Edge `dispatch-push`.
+ *
+ * @param supabaseAdmin client SERVICE ROLE (server-only) — l'Edge n'est pas exposée au client.
+ * @param event NotificationEvent (type + clubId + payload anonyme).
+ * @returns compteurs agrégés {sent, failed, skipped} — jamais de throw (fire-and-forget).
+ */
+export async function dispatchNotification(
+  supabaseAdmin: SupabaseClient<Database>,
+  event: NotificationEvent
+): Promise<DispatchResult> {
+  try {
+    const { data, error } = await supabaseAdmin.functions.invoke('dispatch-push', {
+      body: event,
+    })
+    if (error) return { ...EMPTY_RESULT }
+    return toResult(data)
+  } catch {
+    // Réseau down, Edge absente en local, etc. → no-op silencieux (l'in-app couvre le gap).
+    return { ...EMPTY_RESULT }
+  }
+}

--- a/packages/data/src/notifications/index.ts
+++ b/packages/data/src/notifications/index.ts
@@ -1,0 +1,13 @@
+// Barrel module notifications Web Push (@evolve/data/notifications) — PUSH-001.
+//
+// Expose l'API d'envoi server-only (dispatchNotification), les templates de copy purs
+// (buildNotificationContent) et les types (NotificationEvent / DispatchResult / …).
+
+export { dispatchNotification } from './dispatch.ts'
+export { buildNotificationContent } from './templates.ts'
+export type {
+  NotificationEvent,
+  NotificationEventType,
+  NotificationContent,
+  DispatchResult,
+} from './types.ts'

--- a/packages/data/src/notifications/templates.test.ts
+++ b/packages/data/src/notifications/templates.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import { buildNotificationContent } from './templates.ts'
+import type { NotificationEvent } from './types.ts'
+
+// Détecte une PII potentielle dans le contenu push : email, UUID (id user/poll dans le corps),
+// ou phrasé de comptage/participation de votants. Le pollId N'apparaît QUE dans l'url/tag.
+// NB : un « % » seul est légitime (il peut figurer dans le titre du vote) ; on traque le
+// PHRASÉ de participation (« X membres ont voté », « participation », « a voté »). On évite
+// le motif « 8/18 » brut car il entre en collision avec une date FR « 30/06/2026 » légitime.
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+const PARTICIPATION_RE = /\bmembres?\s+ont\s+vot|\bparticipation\b|\ba\s+voté\b|\d+\s+votants?\b/i
+
+function expectNoPii(content: { title: string; body: string }) {
+  const text = `${content.title} ${content.body}`
+  expect(text).not.toMatch(EMAIL_RE)
+  expect(text).not.toMatch(UUID_RE)
+  expect(text).not.toMatch(PARTICIPATION_RE)
+}
+
+const POLL_ID = '11111111-2222-3333-4444-555555555555'
+// Titre SANS « % » ni chiffre, pour que les assertions no-PII testent vraiment l'absence
+// d'ajout par le template (un titre piégé masquerait un faux négatif).
+const TITLE = 'Réallouer vers les ETF obligataires'
+// Midi UTC : évite tout passage de minuit dépendant du fuseau de la machine de test.
+const CLOSES_AT = '2026-06-30T12:00:00Z'
+
+describe('buildNotificationContent', () => {
+  describe('poll.opened', () => {
+    const base: NotificationEvent = {
+      type: 'poll.opened',
+      clubId: 'club-1',
+      payload: { pollId: POLL_ID, title: TITLE, closesAt: CLOSES_AT },
+    }
+
+    it('produit le copy « Nouveau vote » avec la date FR quand closesAt est fourni', () => {
+      const c = buildNotificationContent(base)
+      expect(c.body).toContain('Nouveau vote :')
+      expect(c.body).toContain(TITLE)
+      // Date FR courte (30/06/2026) présente dans la clause d'échéance.
+      expect(c.body).toMatch(/répondez avant le 30\/06\/2026/)
+    })
+
+    it('omet la clause d’échéance quand closesAt est null', () => {
+      const c = buildNotificationContent({ ...base, payload: { ...base.payload, closesAt: null } })
+      expect(c.body).toContain('Nouveau vote :')
+      expect(c.body).not.toContain('répondez avant')
+      expect(c.body).not.toContain('—')
+    })
+
+    it('omet la clause d’échéance quand closesAt est absent (undefined)', () => {
+      const c = buildNotificationContent({
+        type: 'poll.opened',
+        clubId: 'club-1',
+        payload: { pollId: POLL_ID, title: TITLE },
+      })
+      expect(c.body).not.toContain('répondez avant')
+    })
+
+    it('pointe vers /votes/{pollId} avec un tag stable', () => {
+      const c = buildNotificationContent(base)
+      expect(c.url).toBe(`/votes/${POLL_ID}`)
+      expect(c.tag).toBe(`poll-opened-${POLL_ID}`)
+    })
+
+    it('ne contient aucune PII (email / uuid dans le corps / participation)', () => {
+      expectNoPii(buildNotificationContent(base))
+    })
+  })
+
+  describe('poll.closed', () => {
+    const event: NotificationEvent = {
+      type: 'poll.closed',
+      clubId: 'club-1',
+      payload: { pollId: POLL_ID, title: TITLE, closesAt: null },
+    }
+
+    it('produit « Résultats disponibles » sans participation ni date', () => {
+      const c = buildNotificationContent(event)
+      expect(c.body).toContain('Résultats disponibles :')
+      expect(c.body).toContain(TITLE)
+      expect(c.body).not.toMatch(PARTICIPATION_RE)
+      expect(c.body).not.toMatch(/avant le/)
+    })
+
+    it('pointe vers /votes/{pollId} (résultats) avec tag poll-closed', () => {
+      const c = buildNotificationContent(event)
+      expect(c.url).toBe(`/votes/${POLL_ID}`)
+      expect(c.tag).toBe(`poll-closed-${POLL_ID}`)
+    })
+
+    it('ne contient aucune PII', () => {
+      expectNoPii(buildNotificationContent(event))
+    })
+  })
+
+  describe('poll.reminder', () => {
+    const event: NotificationEvent = {
+      type: 'poll.reminder',
+      clubId: 'club-1',
+      payload: { pollId: POLL_ID, title: TITLE, closesAt: CLOSES_AT },
+    }
+
+    it('produit le rappel « Il vous reste 24 h pour voter »', () => {
+      const c = buildNotificationContent(event)
+      expect(c.body).toContain('Il vous reste 24 h pour voter :')
+      expect(c.body).toContain(TITLE)
+    })
+
+    it('pointe vers /votes/{pollId} avec tag poll-reminder', () => {
+      const c = buildNotificationContent(event)
+      expect(c.url).toBe(`/votes/${POLL_ID}`)
+      expect(c.tag).toBe(`poll-reminder-${POLL_ID}`)
+    })
+
+    it('ne contient aucune PII', () => {
+      expectNoPii(buildNotificationContent(event))
+    })
+  })
+
+  describe('system.test', () => {
+    const event: NotificationEvent = {
+      type: 'system.test',
+      clubId: 'club-1',
+      payload: { title: 'Test' },
+    }
+
+    it('produit un contenu générique pointant vers /dashboard', () => {
+      const c = buildNotificationContent(event)
+      expect(c.title).toBe('Evolve Capital')
+      expect(c.url).toBe('/dashboard')
+      expect(c.tag).toBe('system-test')
+    })
+
+    it('ne contient aucune PII', () => {
+      expectNoPii(buildNotificationContent(event))
+    })
+  })
+
+  it('retombe sur le titre marque si le payload.title est vide', () => {
+    const c = buildNotificationContent({
+      type: 'poll.closed',
+      clubId: 'club-1',
+      payload: { pollId: POLL_ID, title: '   ', closesAt: null },
+    })
+    expect(c.body).toContain('Evolve Capital')
+  })
+
+  it('laisse passer un « % » légitime présent dans le titre du vote (pas une PII)', () => {
+    const c = buildNotificationContent({
+      type: 'poll.opened',
+      clubId: 'club-1',
+      payload: { pollId: POLL_ID, title: 'Réallouer 15 % du portefeuille ?', closesAt: null },
+    })
+    expect(c.body).toContain('15 %')
+    // Le « % » du titre ne déclenche PAS le détecteur de participation.
+    expect(c.body).not.toMatch(PARTICIPATION_RE)
+  })
+})

--- a/packages/data/src/notifications/templates.ts
+++ b/packages/data/src/notifications/templates.ts
@@ -1,0 +1,75 @@
+// Templates de copy Web Push (PUSH-001 ; spec §2.1, §6.5, §7.4). FR uniquement en V0
+// (EN = follow-up i18n push V1). PURES (aucun I/O), trivialement testables.
+//
+// ANONYMAT — règle produit NON NÉGOCIABLE (§2.2) :
+//   Le contenu ne porte JAMAIS de PII : pas de user_id, email, nom d'un votant, ni
+//   « X membres ont voté », ni pourcentage, ni contenu de réponse. Le payload push se
+//   limite à title / body / url / tag.
+
+import { formatDate } from '@evolve/utils'
+import type { NotificationContent, NotificationEvent } from './types.ts'
+
+const FALLBACK_TITLE = 'Evolve Capital'
+
+/** Deep link vote : `/votes/{pollId}` ; fallback `/dashboard` si pas de pollId (§6.5). */
+function pollUrl(pollId: string | undefined): string {
+  return pollId ? `/votes/${pollId}` : '/dashboard'
+}
+
+/** Tag stable par poll → une nouvelle push remplace la précédente sur le même vote. */
+function pollTag(prefix: string, pollId: string | undefined): string {
+  return pollId ? `${prefix}-${pollId}` : prefix
+}
+
+/** Libellé d'échéance FR (« le 30/06/2026 ») ou chaîne vide si pas de date. */
+function deadlineClause(closesAt: string | null | undefined): string {
+  if (!closesAt) return ''
+  const formatted = formatDate(closesAt)
+  // formatDate renvoie « — » sur date invalide → on omet la clause plutôt que d'afficher un tiret.
+  if (formatted === '—') return ''
+  return ` — répondez avant le ${formatted}`
+}
+
+/**
+ * Mappe un `NotificationEvent` vers le contenu d'une notification système (FR, anonyme).
+ * Pur : pas d'I/O. Le titre du payload (`event.payload.title`) est le titre du vote, jamais
+ * une identité. Aucune PII produite.
+ */
+export function buildNotificationContent(event: NotificationEvent): NotificationContent {
+  const { type, payload } = event
+  const title = payload.title?.trim() || FALLBACK_TITLE
+
+  switch (type) {
+    case 'poll.opened':
+      return {
+        title: 'Nouveau vote',
+        body: `Nouveau vote : ${title}${deadlineClause(payload.closesAt)}`,
+        url: pollUrl(payload.pollId),
+        tag: pollTag('poll-opened', payload.pollId),
+      }
+
+    case 'poll.closed':
+      return {
+        title: 'Résultats du vote',
+        body: `Résultats disponibles : ${title}`,
+        url: pollUrl(payload.pollId),
+        tag: pollTag('poll-closed', payload.pollId),
+      }
+
+    case 'poll.reminder':
+      return {
+        title: 'Dernière chance de voter',
+        body: `Il vous reste 24 h pour voter : ${title}`,
+        url: pollUrl(payload.pollId),
+        tag: pollTag('poll-reminder', payload.pollId),
+      }
+
+    case 'system.test':
+      return {
+        title: FALLBACK_TITLE,
+        body: 'Notification de test : tout fonctionne. Vous recevrez les notifications de vote ici.',
+        url: '/dashboard',
+        tag: 'system-test',
+      }
+  }
+}

--- a/packages/data/src/notifications/types.ts
+++ b/packages/data/src/notifications/types.ts
@@ -1,0 +1,29 @@
+// Types du module notifications (@evolve/data) — Web Push V0 (PUSH-001).
+//
+// Le contrat d'événement vit dans @evolve/types (NotificationEvent) ; on le re-exporte ici
+// pour que les consommateurs de @evolve/data n'aient qu'un point d'import. On ajoute le
+// type de retour d'envoi (DispatchResult) — compteurs agrégés, jamais de PII.
+
+import type { NotificationEvent, NotificationEventType } from '@evolve/types'
+
+export type { NotificationEvent, NotificationEventType }
+
+/**
+ * Résultat agrégé d'un envoi push (retour de l'Edge `dispatch-push`).
+ * Compteurs uniquement — aucune identité de destinataire (anonymat).
+ */
+export interface DispatchResult {
+  sent: number
+  failed: number
+  skipped: number
+}
+
+/** Contenu d'une notification système, prêt pour `showNotification()` côté SW. */
+export interface NotificationContent {
+  title: string
+  body: string
+  /** Deep link in-app (ex. `/votes/{pollId}`). */
+  url: string
+  /** Tag stable par poll → une nouvelle push remplace la précédente (anti-spam tray). */
+  tag: string
+}

--- a/packages/data/src/supabase/types.gen.ts
+++ b/packages/data/src/supabase/types.gen.ts
@@ -531,6 +531,41 @@ export type Database = {
           },
         ]
       }
+      poll_email_sends: {
+        Row: {
+          brevo_message_id: string | null
+          id: string
+          poll_id: string
+          recipient_count: number
+          sent_at: string
+          variant: string
+        }
+        Insert: {
+          brevo_message_id?: string | null
+          id?: string
+          poll_id: string
+          recipient_count?: number
+          sent_at?: string
+          variant: string
+        }
+        Update: {
+          brevo_message_id?: string | null
+          id?: string
+          poll_id?: string
+          recipient_count?: number
+          sent_at?: string
+          variant?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'poll_email_sends_poll_id_fkey'
+            columns: ['poll_id']
+            isOneToOne: false
+            referencedRelation: 'polls'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       poll_responses: {
         Row: {
           created_at: string
@@ -776,6 +811,126 @@ export type Database = {
           },
         ]
       }
+      push_delivery_log: {
+        Row: {
+          club_id: string | null
+          created_at: string
+          event_type: string
+          failed_count: number
+          id: string
+          poll_id: string | null
+          sent_count: number
+          skipped_count: number
+        }
+        Insert: {
+          club_id?: string | null
+          created_at?: string
+          event_type: string
+          failed_count?: number
+          id?: string
+          poll_id?: string | null
+          sent_count?: number
+          skipped_count?: number
+        }
+        Update: {
+          club_id?: string | null
+          created_at?: string
+          event_type?: string
+          failed_count?: number
+          id?: string
+          poll_id?: string | null
+          sent_count?: number
+          skipped_count?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'push_delivery_log_club_id_fkey'
+            columns: ['club_id']
+            isOneToOne: false
+            referencedRelation: 'clubs'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'push_delivery_log_poll_id_fkey'
+            columns: ['poll_id']
+            isOneToOne: false
+            referencedRelation: 'polls'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      push_preferences: {
+        Row: {
+          enabled: boolean
+          poll_closed: boolean
+          poll_opened: boolean
+          poll_reminder: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          enabled?: boolean
+          poll_closed?: boolean
+          poll_opened?: boolean
+          poll_reminder?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          enabled?: boolean
+          poll_closed?: boolean
+          poll_opened?: boolean
+          poll_reminder?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      push_subscriptions: {
+        Row: {
+          auth: string
+          created_at: string
+          endpoint: string
+          id: string
+          last_error_at: string | null
+          last_error_code: string | null
+          last_success_at: string | null
+          p256dh: string
+          platform: string | null
+          updated_at: string
+          user_agent: string | null
+          user_id: string
+        }
+        Insert: {
+          auth: string
+          created_at?: string
+          endpoint: string
+          id?: string
+          last_error_at?: string | null
+          last_error_code?: string | null
+          last_success_at?: string | null
+          p256dh: string
+          platform?: string | null
+          updated_at?: string
+          user_agent?: string | null
+          user_id: string
+        }
+        Update: {
+          auth?: string
+          created_at?: string
+          endpoint?: string
+          id?: string
+          last_error_at?: string | null
+          last_error_code?: string | null
+          last_success_at?: string | null
+          p256dh?: string
+          platform?: string | null
+          updated_at?: string
+          user_agent?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       sheet_snapshots: {
         Row: {
           checksum: string
@@ -988,7 +1143,13 @@ export type Database = {
         Args: { p_locked: boolean; p_membership_id: string; p_reason?: string }
         Returns: undefined
       }
-      close_due_polls: { Args: never; Returns: number }
+      close_due_polls: {
+        Args: never
+        Returns: {
+          club_id: string
+          poll_id: string
+        }[]
+      }
       current_user_access_blocked: { Args: never; Returns: boolean }
       email_is_invited: { Args: { p_email: string }; Returns: boolean }
       get_poll_results: { Args: { p_poll_id: string }; Returns: Json }

--- a/packages/data/src/tests/poll-email.test.ts
+++ b/packages/data/src/tests/poll-email.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { brand, dataViz } from '@evolve/design-system'
+import { renderPollEmailHtml } from '../emails/index.ts'
+import type { PollEmailProps } from '../emails/index.ts'
+
+const BASE: PollEmailProps = {
+  memberFirstName: 'Louis',
+  clubName: 'Cercle Arago',
+  pollTitle: 'Réallouer vers les ETF obligataires',
+  pollDescription: 'Contexte : hausse des taux et volatilité actions Q2.',
+  questionType: 'single_choice',
+  // Midi UTC : évite tout passage de minuit dépendant du fuseau de la machine de test.
+  closesAt: '2026-06-30T12:00:00Z',
+  variant: 'opened',
+}
+
+describe('PollEmail', () => {
+  it('opened : titre, prénom, club, encart anonymat, CTA « Voter maintenant »', async () => {
+    const html = await renderPollEmailHtml(BASE)
+    expect(html).toMatch(/EVOLVE/i)
+    expect(html).toContain('Un vote attend votre avis')
+    expect(html).toContain('Louis')
+    expect(html).toContain('Cercle Arago')
+    expect(html).toContain('Voter maintenant')
+    expect(html).toMatch(/reste anonyme/i)
+    // Échéance longue FR (le mois exact dépend du fuseau ; on vérifie l'année + la clause).
+    expect(html).toContain('Répondez avant le')
+    expect(html).toContain('2026')
+    // CTA → /votes.
+    expect(html).toContain('https://app.evolve.capital/votes')
+  })
+
+  it('closed : « Résultats du vote », PAS d’encart anonymat, aucune participation', async () => {
+    const html = await renderPollEmailHtml({ ...BASE, variant: 'closed' })
+    expect(html).toContain('Résultats du vote')
+    expect(html).toContain('Voir les résultats')
+    expect(html).not.toMatch(/reste anonyme/i)
+    // Anonymat : jamais de phrasé de participation ni de barre de résultats dans le corps.
+    expect(html).not.toMatch(/membres?\s+ont\s+vot|\bparticipation\b/i)
+  })
+
+  it('reminder : « Dernière chance », label ambre, encart anonymat', async () => {
+    const html = await renderPollEmailHtml({ ...BASE, variant: 'reminder' })
+    expect(html).toContain('Dernière chance de voter')
+    expect(html).toContain('Échéance proche')
+    expect(html).toMatch(/reste anonyme/i)
+    // Accent ambre (warning), JAMAIS rouge brand.
+    expect(html.toLowerCase()).toContain(dataViz.warningStrong.toLowerCase())
+    expect(html.toLowerCase()).not.toContain(brand.red.toLowerCase())
+  })
+
+  it('CTA jaune brand sur les 3 variantes, jamais brand.red', async () => {
+    for (const variant of ['opened', 'closed', 'reminder'] as const) {
+      const html = await renderPollEmailHtml({ ...BASE, variant })
+      expect(html.toLowerCase()).toContain(brand.yellow.toLowerCase())
+      expect(html.toLowerCase()).not.toContain(brand.red.toLowerCase())
+    }
+  })
+
+  it('anonymat : aucun phrasé « membres ont voté » dans aucune variante', async () => {
+    for (const variant of ['opened', 'closed', 'reminder'] as const) {
+      const html = await renderPollEmailHtml({ ...BASE, variant })
+      expect(html).not.toMatch(/membres?\s+ont\s+vot/i)
+    }
+  })
+
+  it('rend le titre verbatim, y compris un « % » légitime du sujet de vote', async () => {
+    const html = await renderPollEmailHtml({
+      ...BASE,
+      pollTitle: 'Faut-il réallouer 15 % du portefeuille ?',
+    })
+    expect(html).toContain('Faut-il réallouer 15 % du portefeuille ?')
+  })
+
+  it('omet la clause d’échéance quand closesAt est null', async () => {
+    const html = await renderPollEmailHtml({ ...BASE, closesAt: null })
+    expect(html).not.toContain('Répondez avant le')
+    expect(html).not.toContain('undefined')
+  })
+
+  it('respecte appUrl quand fourni (CTA → {appUrl}/votes)', async () => {
+    const html = await renderPollEmailHtml({ ...BASE, appUrl: 'https://staging.evolve.capital' })
+    expect(html).toContain('https://staging.evolve.capital/votes')
+  })
+
+  it('jamais d’undefined à l’écran même avec des champs vides', async () => {
+    const html = await renderPollEmailHtml({
+      memberFirstName: '',
+      clubName: '',
+      pollTitle: '',
+      questionType: 'yes_no',
+      closesAt: null,
+      variant: 'opened',
+    })
+    expect(html).not.toContain('undefined')
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,3 +3,5 @@ export * from './portfolio'
 // Contrat de blocs éditoriaux (E-EDI) — newsletter + blog
 export * from './editorial'
 export * from './pwa'
+// Contrat Web Push (PUSH-001) — NotificationEvent
+export * from './notifications'

--- a/packages/types/src/notifications.ts
+++ b/packages/types/src/notifications.ts
@@ -1,0 +1,24 @@
+// Contrat partagé Web Push (PUSH-001 ; spec docs/superpowers/specs/2026-06-16-web-push-notifications-design.md §3.1).
+//
+// Type d'événement de notification consommé par TOUTE la chaîne : le module métier
+// (vote action) construit un NotificationEvent, `dispatchNotification` (@evolve/data)
+// l'invoque vers l'Edge `dispatch-push`, qui le mappe en payload push via les templates
+// (@evolve/data/notifications). Extensible sans breaking change : il suffit d'ajouter
+// un type à l'union.
+//
+// ANONYMAT : le payload ne porte JAMAIS de PII (pas de user_id, email, ni compteur de
+// votants). Seuls `pollId` / `clubId` / `title` / `closesAt` transitent.
+
+/** Types d'événements push V0. Extensible sans breaking change. */
+export type NotificationEventType = 'poll.opened' | 'poll.closed' | 'poll.reminder' | 'system.test' // bouton « Tester » profil
+
+export type NotificationEvent = {
+  type: NotificationEventType
+  clubId: string
+  payload: {
+    pollId?: string
+    title: string
+    /** ISO — optionnel (rappel / deadline). `null` = pas de clôture automatique. */
+    closesAt?: string | null
+  }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -472,6 +472,32 @@ verify_jwt = false
 # non-JWT) sinon le trigger reçoit 401 et aucun retour n'est distribué.
 verify_jwt = false
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Web Push V0 (PUSH-001 — spec docs/superpowers/specs/2026-06-16-web-push-notifications-design.md)
+# Les 4 fonctions ci-dessous sont appelées par des Server Actions (Bearer service-role)
+# ou des jobs pg_cron (URLs Vault) — JAMAIS par le browser avec un JWT Supabase.
+# verify_jwt DOIT rester false, sinon le gateway rejette l'appel (clé service-role non-JWT
+# → 401) et le push / l'email de vote ne part jamais. Même logique que send-email ci-dessus.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[functions.dispatch-push]
+# Envoi Web Push d'un NotificationEvent. Appelée par dispatchNotification (Server Action,
+# service role) et par les crons poll-push-reminders / poll-closed-push.
+verify_jwt = false
+
+[functions.send-poll-email]
+# Email de vote (opened/closed/reminder) via Brevo. Appelée par les Server Actions / cron
+# avec le Bearer service-role.
+verify_jwt = false
+
+[functions.poll-push-reminders]
+# Cible du cron quotidien (Vault poll_push_reminders_url) — rappel vote J-1.
+verify_jwt = false
+
+[functions.poll-closed-push]
+# Cible du cron horaire (Vault poll_closed_push_url) — push post-clôture.
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/_shared/notify-allowlist.test.ts
+++ b/supabase/functions/_shared/notify-allowlist.test.ts
@@ -1,0 +1,20 @@
+// Tests Deno du parser d'allowlist (PUSH-001 mode test).
+//   deno test --no-check --allow-all supabase/functions/_shared/notify-allowlist.test.ts
+
+import { assertEquals } from 'jsr:@std/assert@^1'
+
+import { parseAllowlist } from './notify-allowlist.ts'
+
+Deno.test('vide / absente → [] (comportement normal : aucun filtre)', () => {
+  assertEquals(parseAllowlist(undefined), [])
+  assertEquals(parseAllowlist(null), [])
+  assertEquals(parseAllowlist(''), [])
+  assertEquals(parseAllowlist('   '), [])
+  assertEquals(parseAllowlist(',, ,'), [])
+})
+
+Deno.test('split + trim + minuscule + drop vides', () => {
+  assertEquals(parseAllowlist('a@x.com'), ['a@x.com'])
+  assertEquals(parseAllowlist('A@X.com, B@Y.com ,, c@z.com '), ['a@x.com', 'b@y.com', 'c@z.com'])
+  assertEquals(parseAllowlist('  Moi@Test.FR  '), ['moi@test.fr'])
+})

--- a/supabase/functions/_shared/notify-allowlist.ts
+++ b/supabase/functions/_shared/notify-allowlist.ts
@@ -1,0 +1,20 @@
+// Allowlist de notifications — mode TEST (PUSH-001).
+//
+// Variable d'env `NOTIFY_ALLOWLIST` = emails séparés par virgule (ex. « moi@x.com, test@y.com »).
+//
+// SÉMANTIQUE (sécurité) :
+//   - VIDE / absente  → comportement NORMAL : on notifie tous les membres actifs du club.
+//   - NON VIDE        → mode test : les Edge `send-poll-email` / `dispatch-push` ne notifient
+//                       QUE les destinataires dont l'email y figure. C'est une INTERSECTION
+//                       avec les membres du club — JAMAIS additif : on ne peut jamais notifier
+//                       quelqu'un hors du club, ni élargir le périmètre. Au pire, on sous-notifie.
+//
+// Les emails sont normalisés (trim + minuscule) ; GoTrue stocke les emails en minuscule, donc
+// le match est exact côté DB. À retirer (unset) le jour de la mise en production réelle.
+export function parseAllowlist(raw: string | undefined | null): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0)
+}

--- a/supabase/functions/dispatch-push/__tests__/handler.test.ts
+++ b/supabase/functions/dispatch-push/__tests__/handler.test.ts
@@ -1,0 +1,378 @@
+// Tests Deno du handler pur `dispatch-push` (PUSH-001 ; spec §7).
+//
+// EXÉCUTION (depuis la racine du repo)
+// ------------------------------------
+//     deno test --no-check --allow-all \
+//       --config supabase/functions/dispatch-push/deno.json \
+//       supabase/functions/dispatch-push/__tests__/
+//
+// On importe `handler.ts` (logique pure) : aucun I/O réel, aucun web-push — toutes les seams
+// (listClubActiveMemberUserIds, listSubscriptions, getPollNotifyFlag, listUsersWhoVoted,
+// sendWebPush, deleteSubscription, buildContent, logDelivery) sont stubbées en mémoire.
+//
+// CE QUI EST TESTÉ
+// ----------------
+// 1. ANTI-CROSS-CLUB (critique §2.2/§7.3) : deux clubs A/B → dispatcher clubId=A ne touche
+//    QUE les users du club A ; aucune subscription du club B ne reçoit.
+// 2. ANTI-CROSS-CLUB défense-en-profondeur : même si listSubscriptions « fuite » une sub
+//    d'un user hors-club, le handler ne l'envoie pas (filtre allowedUsers).
+// 3. Filtre préférences : enabled=false → skipped ; poll_opened=false → skipped sur poll.opened.
+// 4. Gate poll.opened : notify_by_email=false → 0 envoi (skipped = N).
+// 5. Rappel : exclut les users ayant déjà voté.
+// 6. Purge 410 : une subscription 410 Gone est supprimée et comptée failed.
+// 7. Payload : title/body/url/tag uniquement — AUCUNE PII (pas d'email/user_id).
+
+import { assert, assertEquals } from 'jsr:@std/assert@^1'
+
+import { dispatchPush } from '../handler.ts'
+import type {
+  DispatchDeps,
+  NotificationContent,
+  NotificationEvent,
+  PushSubscriptionRow,
+  SubscriptionWithPrefs,
+  WebPushResult,
+} from '../handler.ts'
+
+// ---- Fabrique de deps stubbées (en mémoire) ----
+
+interface FakeState {
+  /** clubId → user_id des membres actifs. */
+  membersByClub: Record<string, string[]>
+  /** Subscriptions (avec préférences) par endpoint. */
+  subs: SubscriptionWithPrefs[]
+  /** pollId → notify_by_email. */
+  notifyFlag: Record<string, boolean>
+  /** pollId → user_id ayant voté. */
+  voted: Record<string, string[]>
+}
+
+interface Recorder {
+  sentPayloads: { endpoint: string; payloadJson: string }[]
+  deleted: string[]
+  logged: {
+    event_type: string
+    club_id: string
+    poll_id: string | null
+    sent: number
+    failed: number
+    skipped: number
+  }[]
+}
+
+/** Contenu déterministe et sans PII (miroir de buildNotificationContent). */
+function fakeBuildContent(event: NotificationEvent): NotificationContent {
+  const t = event.payload.title
+  switch (event.type) {
+    case 'poll.opened':
+      return {
+        title: 'Nouveau vote',
+        body: `Nouveau vote : ${t}`,
+        url: event.payload.pollId ? `/votes/${event.payload.pollId}` : '/dashboard',
+        tag: `poll-opened-${event.payload.pollId ?? ''}`,
+      }
+    case 'poll.closed':
+      return {
+        title: 'Résultats du vote',
+        body: `Résultats disponibles : ${t}`,
+        url: event.payload.pollId ? `/votes/${event.payload.pollId}` : '/dashboard',
+        tag: `poll-closed-${event.payload.pollId ?? ''}`,
+      }
+    case 'poll.reminder':
+      return {
+        title: 'Dernière chance de voter',
+        body: `Il vous reste 24 h pour voter : ${t}`,
+        url: event.payload.pollId ? `/votes/${event.payload.pollId}` : '/dashboard',
+        tag: `poll-reminder-${event.payload.pollId ?? ''}`,
+      }
+    case 'system.test':
+      return {
+        title: 'Evolve Capital',
+        body: 'Notification de test',
+        url: '/dashboard',
+        tag: 'system-test',
+      }
+  }
+}
+
+function makeDeps(
+  state: FakeState,
+  opts: { failStatus?: Record<string, number> } = {}
+): { deps: DispatchDeps; rec: Recorder } {
+  const rec: Recorder = { sentPayloads: [], deleted: [], logged: [] }
+
+  const deps: DispatchDeps = {
+    listClubActiveMemberUserIds: (clubId) => Promise.resolve(state.membersByClub[clubId] ?? []),
+    listSubscriptions: (userIds) => {
+      const set = new Set(userIds)
+      return Promise.resolve(state.subs.filter((s) => set.has(s.userId)))
+    },
+    getPollNotifyFlag: (pollId) => Promise.resolve(state.notifyFlag[pollId] ?? null),
+    listUsersWhoVoted: (pollId) => Promise.resolve(state.voted[pollId] ?? []),
+    sendWebPush: (sub: PushSubscriptionRow, payloadJson): Promise<WebPushResult> => {
+      const status = opts.failStatus?.[sub.endpoint]
+      if (status) return Promise.resolve({ ok: false, statusCode: status })
+      rec.sentPayloads.push({ endpoint: sub.endpoint, payloadJson })
+      return Promise.resolve({ ok: true })
+    },
+    deleteSubscription: (endpoint) => {
+      rec.deleted.push(endpoint)
+      return Promise.resolve()
+    },
+    buildContent: fakeBuildContent,
+    logDelivery: (entry) => {
+      rec.logged.push(entry)
+      return Promise.resolve()
+    },
+    log: () => {},
+  }
+  return { deps, rec }
+}
+
+/** Subscription d'un user, toutes préférences ON par défaut. */
+function sub(
+  userId: string,
+  endpoint: string,
+  prefs: Partial<Omit<SubscriptionWithPrefs, 'userId' | 'endpoint' | 'p256dh' | 'auth'>> = {}
+): SubscriptionWithPrefs {
+  return {
+    userId,
+    endpoint,
+    p256dh: `p256-${endpoint}`,
+    auth: `auth-${endpoint}`,
+    enabled: true,
+    pollOpened: true,
+    pollClosed: true,
+    pollReminder: true,
+    ...prefs,
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1 — ANTI-CROSS-CLUB : dispatcher club A ne touche QUE les users du club A.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test("anti-cross-club : dispatcher club A ne pousse QU'aux subs du club A", async () => {
+  const state: FakeState = {
+    membersByClub: {
+      clubA: ['uA1', 'uA2'],
+      clubB: ['uB1', 'uB2'],
+    },
+    subs: [
+      sub('uA1', 'epA1'),
+      sub('uA2', 'epA2'),
+      sub('uB1', 'epB1'), // club B — NE DOIT JAMAIS recevoir
+      sub('uB2', 'epB2'),
+    ],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state)
+
+  const event: NotificationEvent = {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'Budget 2026' },
+  }
+  const summary = await dispatchPush(deps, event)
+
+  assertEquals(summary.sent, 2)
+  assertEquals(summary.failed, 0)
+  // Seuls les endpoints du club A ont reçu.
+  const reached = rec.sentPayloads.map((p) => p.endpoint).sort()
+  assertEquals(reached, ['epA1', 'epA2'])
+  // Aucune subscription du club B n'a été touchée.
+  assert(!reached.includes('epB1'))
+  assert(!reached.includes('epB2'))
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2 — ANTI-CROSS-CLUB défense en profondeur : si listSubscriptions « fuit » une sub
+//     hors-club, le handler la filtre quand même (allowedUsers).
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('anti-cross-club : une sub hors-club fuitée par la requête est filtrée', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['uA1'] },
+    subs: [sub('uA1', 'epA1')],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  // deps qui « fuit » volontairement une sub d'un user hors-club.
+  const { deps, rec } = makeDeps(state)
+  const leaky: DispatchDeps = {
+    ...deps,
+    listSubscriptions: () => Promise.resolve([sub('uA1', 'epA1'), sub('uB1', 'epB1')]),
+  }
+
+  const summary = await dispatchPush(leaky, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(summary.sent, 1)
+  assertEquals(
+    rec.sentPayloads.map((p) => p.endpoint),
+    ['epA1']
+  )
+  // La sub du club B fuitée n'a jamais reçu.
+  assert(!rec.sentPayloads.some((p) => p.endpoint === 'epB1'))
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3 — Filtre préférences : enabled=false → skipped ; poll_opened=false → skipped.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test("préférences : enabled=false et poll_opened=false → skipped (pas d'envoi)", async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1', 'u2', 'u3'] },
+    subs: [
+      sub('u1', 'ep1'), // tout ON → reçoit
+      sub('u2', 'ep2', { enabled: false }), // master off → skip
+      sub('u3', 'ep3', { pollOpened: false }), // type off → skip
+    ],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state)
+
+  const summary = await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(summary.sent, 1)
+  assertEquals(summary.skipped, 2)
+  assertEquals(
+    rec.sentPayloads.map((p) => p.endpoint),
+    ['ep1']
+  )
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4 — Gate poll.opened : notify_by_email=false → 0 envoi (skipped = N membres).
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('poll.opened : notify_by_email=false → aucun envoi, skipped = nb membres', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1', 'u2'] },
+    subs: [sub('u1', 'ep1'), sub('u2', 'ep2')],
+    notifyFlag: { p1: false }, // staff n'a PAS demandé la notif
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state)
+
+  const summary = await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(summary.sent, 0)
+  assertEquals(summary.skipped, 2)
+  assertEquals(rec.sentPayloads.length, 0)
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5 — Rappel : exclut les users ayant déjà voté.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('poll.reminder : exclut les membres ayant déjà voté', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1', 'u2', 'u3'] },
+    subs: [sub('u1', 'ep1'), sub('u2', 'ep2'), sub('u3', 'ep3')],
+    notifyFlag: {},
+    voted: { p1: ['u2'] }, // u2 a déjà voté → exclu du rappel
+  }
+  const { deps, rec } = makeDeps(state)
+
+  const summary = await dispatchPush(deps, {
+    type: 'poll.reminder',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(summary.sent, 2)
+  const reached = rec.sentPayloads.map((p) => p.endpoint).sort()
+  assertEquals(reached, ['ep1', 'ep3'])
+  assert(!reached.includes('ep2'))
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 6 — Purge 410 : une subscription 410 Gone est supprimée et comptée failed.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('410 Gone : la subscription est purgée et comptée en failed', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1', 'u2'] },
+    subs: [sub('u1', 'ep1'), sub('u2', 'epDead')],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state, { failStatus: { epDead: 410 } })
+
+  const summary = await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(summary.sent, 1)
+  assertEquals(summary.failed, 1)
+  assertEquals(rec.deleted, ['epDead'])
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7 — Payload sans PII : title/body/url/tag uniquement (pas d'email/user_id).
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('payload : title/body/url/tag uniquement — aucune PII', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1'] },
+    subs: [sub('u1', 'ep1')],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state)
+
+  await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'Budget' },
+  })
+
+  assertEquals(rec.sentPayloads.length, 1)
+  const parsed = JSON.parse(rec.sentPayloads[0].payloadJson) as Record<string, unknown>
+  // Clés autorisées uniquement.
+  assertEquals(Object.keys(parsed).sort(), ['body', 'tag', 'title', 'url'])
+  const raw = rec.sentPayloads[0].payloadJson
+  // Aucun marqueur de PII.
+  assert(!raw.includes('@'), "pas d'email dans le payload")
+  assert(!raw.includes('u1'), 'pas de user_id dans le payload')
+  assert(!raw.includes('user_id'), 'pas de clé user_id')
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 8 — Journal agrégé : logDelivery reçoit les compteurs (sans PII).
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('logDelivery : journalise un résumé agrégé sans PII', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['u1', 'u2'] },
+    subs: [sub('u1', 'ep1'), sub('u2', 'ep2', { enabled: false })],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state)
+
+  await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+
+  assertEquals(rec.logged.length, 1)
+  const entry = rec.logged[0]
+  assertEquals(entry.event_type, 'poll.opened')
+  assertEquals(entry.club_id, 'clubA')
+  assertEquals(entry.poll_id, 'p1')
+  assertEquals(entry.sent, 1)
+  assertEquals(entry.skipped, 1)
+  // Pas de champ destinataire individuel.
+  assert(!('user_id' in entry))
+  assert(!('email' in entry))
+})

--- a/supabase/functions/dispatch-push/__tests__/handler.test.ts
+++ b/supabase/functions/dispatch-push/__tests__/handler.test.ts
@@ -97,11 +97,12 @@ function fakeBuildContent(event: NotificationEvent): NotificationContent {
 
 function makeDeps(
   state: FakeState,
-  opts: { failStatus?: Record<string, number> } = {}
+  opts: { failStatus?: Record<string, number>; allowlistUserIds?: string[] } = {}
 ): { deps: DispatchDeps; rec: Recorder } {
   const rec: Recorder = { sentPayloads: [], deleted: [], logged: [] }
 
   const deps: DispatchDeps = {
+    allowlistUserIds: opts.allowlistUserIds,
     listClubActiveMemberUserIds: (clubId) => Promise.resolve(state.membersByClub[clubId] ?? []),
     listSubscriptions: (userIds) => {
       const set = new Set(userIds)
@@ -376,3 +377,65 @@ Deno.test('logDelivery : journalise un résumé agrégé sans PII', async () => 
   assert(!('user_id' in entry))
   assert(!('email' in entry))
 })
+
+// ════════════════════════════════════════════════════════════════════════════
+// 9 — ALLOWLIST DE TEST (NOTIFY_ALLOWLIST → user_id) — sûreté du mode test.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('allowlist VIDE → comportement normal : tous les membres du club reçoivent', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['uA1', 'uA2'] },
+    subs: [sub('uA1', 'epA1'), sub('uA2', 'epA2')],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state, { allowlistUserIds: [] })
+  const summary = await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+  assertEquals(summary.sent, 2)
+  assertEquals(rec.sentPayloads.map((p) => p.endpoint).sort(), ['epA1', 'epA2'])
+})
+
+Deno.test('allowlist = [uA1] → SEUL uA1 reçoit (les autres membres du club exclus)', async () => {
+  const state: FakeState = {
+    membersByClub: { clubA: ['uA1', 'uA2', 'uA3'] },
+    subs: [sub('uA1', 'epA1'), sub('uA2', 'epA2'), sub('uA3', 'epA3')],
+    notifyFlag: { p1: true },
+    voted: {},
+  }
+  const { deps, rec } = makeDeps(state, { allowlistUserIds: ['uA1'] })
+  const summary = await dispatchPush(deps, {
+    type: 'poll.opened',
+    clubId: 'clubA',
+    payload: { pollId: 'p1', title: 'X' },
+  })
+  assertEquals(summary.sent, 1)
+  assertEquals(
+    rec.sentPayloads.map((p) => p.endpoint),
+    ['epA1']
+  )
+})
+
+Deno.test(
+  'SÛRETÉ : allowlist = user HORS club → personne ne reçoit (intersection, jamais additif)',
+  async () => {
+    const state: FakeState = {
+      membersByClub: { clubA: ['uA1', 'uA2'] },
+      // La sub de l'étranger existe, mais il n'est pas membre du club A.
+      subs: [sub('uA1', 'epA1'), sub('uA2', 'epA2'), sub('uX', 'epX')],
+      notifyFlag: { p1: true },
+      voted: {},
+    }
+    const { deps, rec } = makeDeps(state, { allowlistUserIds: ['uX'] })
+    const summary = await dispatchPush(deps, {
+      type: 'poll.opened',
+      clubId: 'clubA',
+      payload: { pollId: 'p1', title: 'X' },
+    })
+    // uX est dans l'allowlist mais PAS membre du club → intersection vide → 0 envoi, jamais epX.
+    assertEquals(summary.sent, 0)
+    assert(!rec.sentPayloads.some((p) => p.endpoint === 'epX'))
+  }
+)

--- a/supabase/functions/dispatch-push/deno.json
+++ b/supabase/functions/dispatch-push/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@^2",
+    "@evolve/utils": "../../../packages/utils/src/index.ts",
+    "@evolve/types": "../../../packages/types/src/index.ts"
+  }
+}

--- a/supabase/functions/dispatch-push/deno.lock
+++ b/supabase/functions/dispatch-push/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@supabase/supabase-js@2"
+    ]
+  }
+}

--- a/supabase/functions/dispatch-push/handler.ts
+++ b/supabase/functions/dispatch-push/handler.ts
@@ -1,0 +1,244 @@
+// Handler pur de l'Edge Function `dispatch-push` (PUSH-001 ; spec §7).
+//
+// Résout les destinataires d'un `NotificationEvent`, filtre sur les préférences push,
+// envoie via Web Push (VAPID) par batch, purge les endpoints invalides (410/404), puis
+// journalise un résumé AGRÉGÉ. AUCUN I/O concret ici : toutes les seams passent par
+// `DispatchDeps`. Testable en isolation côté Deno (pas de réseau, pas de web-push).
+//
+// CLUB-SCOPING — règle de sécurité NON NÉGOCIABLE (§2.2, §7.3) :
+//   Les destinataires sont EXCLUSIVEMENT les membres ACTIFS de `event.clubId`. Jamais un
+//   autre club, jamais `network_wide`. Le filtrage par club se fait à la source
+//   (`listClubActiveMemberUserIds(clubId)`) ; les subscriptions sont ensuite jointes par
+//   user_id ⇒ une subscription d'un autre club ne peut JAMAIS être ciblée.
+//
+// ANONYMAT (§2.2) :
+//   Le payload push ne porte QUE title / body / url / tag (issu de buildNotificationContent).
+//   Jamais d'email, de user_id, de nom de votant, ni « X membres ont voté ».
+//   `listUsersWhoVoted(pollId)` n'agrège que des user_id pour EXCLURE les votants du rappel —
+//   ces id ne sortent jamais de la fonction.
+
+// ---- Contenu de notification (miroir de @evolve/data NotificationContent) ----
+// On évite une dépendance dure à @evolve/data : `buildContent` est injecté (l'index câble
+// soit l'import de @evolve/data, soit un fallback inline aux mêmes chaînes FR).
+export interface NotificationContent {
+  title: string
+  body: string
+  url: string
+  tag: string
+}
+
+export type NotificationEventType = 'poll.opened' | 'poll.closed' | 'poll.reminder' | 'system.test'
+
+export interface NotificationEvent {
+  type: NotificationEventType
+  clubId: string
+  payload: {
+    pollId?: string
+    title: string
+    closesAt?: string | null
+  }
+}
+
+/** Subscription navigateur (un endpoint = un appareil). */
+export interface PushSubscriptionRow {
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+/** Résultat d'un envoi web-push unitaire. */
+export interface WebPushResult {
+  ok: boolean
+  /** Code HTTP (ex. 410, 404) sur échec — jamais le corps de la réponse. */
+  statusCode?: number
+}
+
+/** Résumé agrégé retourné par le handler (aucune PII). */
+export interface DispatchSummary {
+  sent: number
+  failed: number
+  skipped: number
+}
+
+export interface DispatchDeps {
+  /** user_id des membres ACTIFS de `clubId` (status = 'active'). Source du club-scoping. */
+  listClubActiveMemberUserIds: (clubId: string) => Promise<string[]>
+  /** Subscriptions des users donnés, jointes à push_preferences (préférences par user). */
+  listSubscriptions: (userIds: string[]) => Promise<SubscriptionWithPrefs[]>
+  /** `notify_by_email` du poll (gate `poll.opened`). null si poll introuvable. */
+  getPollNotifyFlag: (pollId: string) => Promise<boolean | null>
+  /** user_id ayant DÉJÀ voté à ce poll (exclusion rappel). Jamais retourné à l'appelant. */
+  listUsersWhoVoted: (pollId: string) => Promise<string[]>
+  /** Envoie une push à un endpoint. Retourne le statut (sans corps). */
+  sendWebPush: (sub: PushSubscriptionRow, payloadJson: string) => Promise<WebPushResult>
+  /** Supprime une subscription invalide (410/404). */
+  deleteSubscription: (endpoint: string) => Promise<void>
+  /** Construit le contenu (FR, anonyme) depuis l'événement. */
+  buildContent: (event: NotificationEvent) => NotificationContent
+  /** Journalise un résumé agrégé (push_delivery_log). Best-effort. */
+  logDelivery: (entry: {
+    event_type: string
+    club_id: string
+    poll_id: string | null
+    sent: number
+    failed: number
+    skipped: number
+  }) => Promise<void>
+  /** Log diagnostic (injectable pour test silencieux). */
+  log?: (level: 'info' | 'warn' | 'error', msg: string, meta?: Record<string, unknown>) => void
+}
+
+/** Subscription + préférences du propriétaire (par user). */
+export interface SubscriptionWithPrefs {
+  userId: string
+  endpoint: string
+  p256dh: string
+  auth: string
+  /** push_preferences.enabled (master). */
+  enabled: boolean
+  /** push_preferences.poll_opened. */
+  pollOpened: boolean
+  /** push_preferences.poll_closed. */
+  pollClosed: boolean
+  /** push_preferences.poll_reminder. */
+  pollReminder: boolean
+}
+
+/** Taille de batch d'envoi (Promise.allSettled) — évite le timeout Edge sur gros clubs. */
+const BATCH_SIZE = 50
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+/**
+ * Map événement → colonne de préférence par type. `system.test` n'est pas filtré par type
+ * (il vise un seul destinataire explicite côté appelant), mais respecte tout de même `enabled`.
+ */
+function prefAllows(sub: SubscriptionWithPrefs, type: NotificationEventType): boolean {
+  if (!sub.enabled) return false
+  switch (type) {
+    case 'poll.opened':
+      return sub.pollOpened
+    case 'poll.closed':
+      return sub.pollClosed
+    case 'poll.reminder':
+      return sub.pollReminder
+    case 'system.test':
+      return true
+  }
+}
+
+/**
+ * Dispatch d'un `NotificationEvent` vers les membres actifs du club.
+ *
+ * 1. Résout les user_id destinataires = membres ACTIFS de `event.clubId` UNIQUEMENT.
+ *    - `poll.opened` : NO-OP (skipped = N) si `notify_by_email` du poll est false.
+ *    - `poll.reminder` : exclut les user_id ayant déjà voté.
+ * 2. Joint les subscriptions et filtre sur `enabled` + la colonne du type.
+ * 3. Envoie par batch de 50 (Promise.allSettled) ; purge 410/404.
+ * 4. Journalise le résumé agrégé.
+ */
+export async function dispatchPush(
+  deps: DispatchDeps,
+  event: NotificationEvent
+): Promise<DispatchSummary> {
+  const log = deps.log ?? (() => {})
+  const summary: DispatchSummary = { sent: 0, failed: 0, skipped: 0 }
+
+  // ── 1. Résolution des destinataires — STRICTEMENT le club de l'événement ──
+  let userIds = await deps.listClubActiveMemberUserIds(event.clubId)
+
+  // Gate `poll.opened` : ne rien envoyer si le poll n'a pas demandé la notification.
+  if (event.type === 'poll.opened' && event.payload.pollId) {
+    const notify = await deps.getPollNotifyFlag(event.payload.pollId)
+    if (notify !== true) {
+      // Tous les destinataires potentiels sont sautés (intent staff = pas de notif).
+      summary.skipped = userIds.length
+      await safeLog(deps, event, summary)
+      return summary
+    }
+  }
+
+  // Rappel : on retire les membres ayant déjà voté (anonymat — id internes uniquement).
+  if (event.type === 'poll.reminder' && event.payload.pollId) {
+    const voted = new Set(await deps.listUsersWhoVoted(event.payload.pollId))
+    userIds = userIds.filter((id) => !voted.has(id))
+  }
+
+  if (userIds.length === 0) {
+    await safeLog(deps, event, summary)
+    return summary
+  }
+
+  // ── 2. Subscriptions des destinataires + filtre préférences ──
+  const subs = await deps.listSubscriptions(userIds)
+  // Garde-fou défense-en-profondeur : ne JAMAIS envoyer à une subscription dont le user
+  // n'est pas dans la liste club-scopée (même si la requête fuitait).
+  const allowedUsers = new Set(userIds)
+  const eligible = subs.filter((s) => allowedUsers.has(s.userId) && prefAllows(s, event.type))
+
+  // Les subscriptions filtrées par préférence comptent comme « skipped ».
+  summary.skipped += subs.filter(
+    (s) => allowedUsers.has(s.userId) && !prefAllows(s, event.type)
+  ).length
+
+  if (eligible.length === 0) {
+    await safeLog(deps, event, summary)
+    return summary
+  }
+
+  // ── 3. Construction du payload (FR, anonyme) ──
+  const content = deps.buildContent(event)
+  const payloadJson = JSON.stringify(content)
+
+  // ── 4. Envoi par batch de 50 (Promise.allSettled) + purge 410/404 ──
+  for (let i = 0; i < eligible.length; i += BATCH_SIZE) {
+    const batch = eligible.slice(i, i + BATCH_SIZE)
+    const results = await Promise.allSettled(
+      batch.map(async (sub) => {
+        const res = await deps.sendWebPush(
+          { endpoint: sub.endpoint, p256dh: sub.p256dh, auth: sub.auth },
+          payloadJson
+        )
+        if (!res.ok) {
+          // 410 Gone / 404 → subscription morte : on la purge.
+          if (res.statusCode === 410 || res.statusCode === 404) {
+            await deps
+              .deleteSubscription(sub.endpoint)
+              .catch((e) => log('warn', 'Purge subscription échouée', { error: errMsg(e) }))
+          }
+          throw new Error(`push ${res.statusCode ?? 'KO'}`)
+        }
+        return true
+      })
+    )
+    for (const r of results) {
+      if (r.status === 'fulfilled') summary.sent += 1
+      else summary.failed += 1
+    }
+  }
+
+  await safeLog(deps, event, summary)
+  return summary
+}
+
+/** Journalise le résumé agrégé sans jamais faire échouer le dispatch. */
+async function safeLog(
+  deps: DispatchDeps,
+  event: NotificationEvent,
+  summary: DispatchSummary
+): Promise<void> {
+  try {
+    await deps.logDelivery({
+      event_type: event.type,
+      club_id: event.clubId,
+      poll_id: event.payload.pollId ?? null,
+      sent: summary.sent,
+      failed: summary.failed,
+      skipped: summary.skipped,
+    })
+  } catch (e) {
+    ;(deps.log ?? (() => {}))('warn', 'logDelivery échouée', { error: errMsg(e) })
+  }
+}

--- a/supabase/functions/dispatch-push/handler.ts
+++ b/supabase/functions/dispatch-push/handler.ts
@@ -63,6 +63,12 @@ export interface DispatchSummary {
 export interface DispatchDeps {
   /** user_id des membres ACTIFS de `clubId` (status = 'active'). Source du club-scoping. */
   listClubActiveMemberUserIds: (clubId: string) => Promise<string[]>
+  /**
+   * Allowlist de TEST : user_id résolus depuis NOTIFY_ALLOWLIST (emails) côté index. Si NON VIDE,
+   * on ne cible que les membres du club dont l'id y figure — INTERSECTION, jamais additif (le
+   * club-scoping reste intact). Vide/undefined → comportement normal (tous les membres actifs).
+   */
+  allowlistUserIds?: string[]
   /** Subscriptions des users donnés, jointes à push_preferences (préférences par user). */
   listSubscriptions: (userIds: string[]) => Promise<SubscriptionWithPrefs[]>
   /** `notify_by_email` du poll (gate `poll.opened`). null si poll introuvable. */
@@ -148,6 +154,14 @@ export async function dispatchPush(
 
   // ── 1. Résolution des destinataires — STRICTEMENT le club de l'événement ──
   let userIds = await deps.listClubActiveMemberUserIds(event.clubId)
+
+  // ── Allowlist de TEST (NOTIFY_ALLOWLIST) — INTERSECTION user_id, jamais additif ──
+  // Si renseignée, on restreint aux membres du club dont l'id y figure. Ne peut JAMAIS élargir
+  // hors du club (on filtre une liste déjà club-scopée). Vide → comportement normal.
+  if (deps.allowlistUserIds && deps.allowlistUserIds.length > 0) {
+    const allow = new Set(deps.allowlistUserIds)
+    userIds = userIds.filter((id) => allow.has(id))
+  }
 
   // Gate `poll.opened` : ne rien envoyer si le poll n'a pas demandé la notification.
   if (event.type === 'poll.opened' && event.payload.pollId) {

--- a/supabase/functions/dispatch-push/index.ts
+++ b/supabase/functions/dispatch-push/index.ts
@@ -1,0 +1,251 @@
+// Edge Function `dispatch-push` — envoi Web Push d'un `NotificationEvent` (PUSH-001 ; spec §7).
+//
+// Déclenchement
+// -------------
+//   POST /functions/v1/dispatch-push   Body = NotificationEvent (JSON)
+//   Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>
+//   → 200 { sent, failed, skipped }
+//
+//   N'est JAMAIS appelée par le browser : uniquement les Server Actions (service role) et
+//   les jobs cron (poll-push-reminders / poll-closed-push). verify_jwt = false (config.toml) :
+//   le gateway ne valide pas la clé service-role (non-JWT) ; la fonction utilise SERVICE_ROLE
+//   en interne pour bypass RLS et résoudre les destinataires.
+//
+// Parcours (handler pur, voir handler.ts)
+// ---------------------------------------
+//   Résout les membres ACTIFS de event.clubId UNIQUEMENT → joint subscriptions + prefs →
+//   filtre (enabled + colonne du type) → envoie par batch de 50 (web-push VAPID) → purge
+//   410/404 → journalise un résumé AGRÉGÉ (push_delivery_log, sans PII).
+//
+// CLUB-SCOPING : les destinataires viennent de `listClubActiveMemberUserIds(clubId)` — jamais
+// un autre club. La requête memberships est filtrée `.eq('club_id', clubId).eq('status','active')`
+// (réf send-monthly-attestations).
+//
+// web-push en Deno : `npm:web-push@^3` fonctionne via le pont npm de Deno. On configure les
+// détails VAPID au démarrage (setVapidDetails) puis on appelle sendNotification par endpoint.
+// Sur erreur, web-push lève une `WebPushError` portant `.statusCode` (ex. 410) — on le mappe
+// vers WebPushResult sans jamais propager le corps de la réponse (anonymat / logs propres).
+//
+// Sécurité : SUPABASE_SERVICE_ROLE_KEY (bypass RLS), strictement côté serveur.
+
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { dispatchPush } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
+import type {
+  DispatchDeps,
+  NotificationContent,
+  NotificationEvent,
+  PushSubscriptionRow,
+  SubscriptionWithPrefs,
+  WebPushResult,
+} from './handler.ts'
+
+const VALID_TYPES = new Set(['poll.opened', 'poll.closed', 'poll.reminder', 'system.test'])
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** Valide le corps JSON et le normalise en NotificationEvent (ou null si invalide). */
+function parseEvent(raw: unknown): NotificationEvent | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const type = o.type
+  const clubId = o.clubId
+  const payload = o.payload as Record<string, unknown> | undefined
+  if (typeof type !== 'string' || !VALID_TYPES.has(type)) return null
+  if (typeof clubId !== 'string' || clubId.trim() === '') return null
+  if (!payload || typeof payload !== 'object') return null
+  if (typeof payload.title !== 'string') return null
+  return {
+    type: type as NotificationEvent['type'],
+    clubId,
+    payload: {
+      pollId: typeof payload.pollId === 'string' ? payload.pollId : undefined,
+      title: payload.title,
+      closesAt:
+        typeof payload.closesAt === 'string'
+          ? payload.closesAt
+          : payload.closesAt === null
+            ? null
+            : undefined,
+    },
+  }
+}
+
+/** Câble les vraies deps (service-role client + web-push + templates @evolve/data). */
+async function buildDeps(supabase: SupabaseClient): Promise<DispatchDeps> {
+  // Import DYNAMIQUE des arbres lourds — hors du chemin testé (handler.ts).
+  const webpush = (await import('npm:web-push@^3')).default
+  const { buildNotificationContent } =
+    await import('../../../packages/data/src/notifications/templates.ts')
+
+  // Détails VAPID (env). Sans clés, sendNotification lèvera → comptabilisé en `failed`.
+  const vapidPublic = Deno.env.get('VAPID_PUBLIC_KEY') ?? ''
+  const vapidPrivate = Deno.env.get('VAPID_PRIVATE_KEY') ?? ''
+  const vapidSubject = Deno.env.get('VAPID_SUBJECT') ?? 'mailto:support@reseauevolvecapital.com'
+  if (vapidPublic !== '' && vapidPrivate !== '') {
+    webpush.setVapidDetails(vapidSubject, vapidPublic, vapidPrivate)
+  }
+
+  return {
+    listClubActiveMemberUserIds: async (clubId: string): Promise<string[]> => {
+      // CLUB-SCOPING à la source : seuls les membres ACTIFS de ce club.
+      const { data, error } = await supabase
+        .from('memberships')
+        .select('user_id, status')
+        .eq('club_id', clubId)
+        .eq('status', 'active')
+      if (error) throw new Error(`Lecture membres échouée: ${error.message}`)
+      // DISTINCT user_id (un user ne devrait avoir qu'un membership/club, mais on dédoublonne).
+      const ids = new Set<string>()
+      for (const m of data ?? []) {
+        const id = m.user_id as string | null
+        if (id) ids.add(id)
+      }
+      return [...ids]
+    },
+
+    listSubscriptions: async (userIds: string[]): Promise<SubscriptionWithPrefs[]> => {
+      if (userIds.length === 0) return []
+      // Subscriptions des destinataires, jointes à push_preferences (par user).
+      const { data, error } = await supabase
+        .from('push_subscriptions')
+        .select(
+          'user_id, endpoint, p256dh, auth, push_preferences(enabled, poll_opened, poll_closed, poll_reminder)'
+        )
+        .in('user_id', userIds)
+      if (error) throw new Error(`Lecture subscriptions échouée: ${error.message}`)
+      return (data ?? []).map((row) => {
+        const prefs = Array.isArray(row.push_preferences)
+          ? row.push_preferences[0]
+          : row.push_preferences
+        return {
+          userId: row.user_id as string,
+          endpoint: row.endpoint as string,
+          p256dh: row.p256dh as string,
+          auth: row.auth as string,
+          // Pas de ligne push_preferences ⇒ défauts ON (créée au 1er subscribe ; garde-fou).
+          enabled: (prefs?.enabled as boolean | undefined) ?? true,
+          pollOpened: (prefs?.poll_opened as boolean | undefined) ?? true,
+          pollClosed: (prefs?.poll_closed as boolean | undefined) ?? true,
+          pollReminder: (prefs?.poll_reminder as boolean | undefined) ?? true,
+        }
+      })
+    },
+
+    getPollNotifyFlag: async (pollId: string): Promise<boolean | null> => {
+      const { data, error } = await supabase
+        .from('polls')
+        .select('notify_by_email')
+        .eq('id', pollId)
+        .maybeSingle()
+      if (error) throw new Error(`Lecture poll échouée: ${error.message}`)
+      if (!data) return null
+      return (data.notify_by_email as boolean | null) ?? false
+    },
+
+    listUsersWhoVoted: async (pollId: string): Promise<string[]> => {
+      // service_role uniquement (poll_responses.user_id n'est jamais exposé à authenticated).
+      // Agrégation d'id internes pour EXCLURE les votants du rappel — jamais retournés.
+      const { data, error } = await supabase
+        .from('poll_responses')
+        .select('user_id')
+        .eq('poll_id', pollId)
+      if (error) throw new Error(`Lecture poll_responses échouée: ${error.message}`)
+      const ids = new Set<string>()
+      for (const r of data ?? []) {
+        const id = r.user_id as string | null
+        if (id) ids.add(id)
+      }
+      return [...ids]
+    },
+
+    sendWebPush: async (sub: PushSubscriptionRow, payloadJson: string): Promise<WebPushResult> => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          payloadJson
+        )
+        return { ok: true }
+      } catch (e) {
+        // web-push lève une WebPushError portant `.statusCode`. On ne propage QUE le code.
+        const statusCode =
+          e && typeof e === 'object' && 'statusCode' in e
+            ? Number((e as { statusCode: unknown }).statusCode)
+            : undefined
+        return { ok: false, statusCode: Number.isFinite(statusCode) ? statusCode : undefined }
+      }
+    },
+
+    deleteSubscription: async (endpoint: string): Promise<void> => {
+      const { error } = await supabase.from('push_subscriptions').delete().eq('endpoint', endpoint)
+      if (error) throw new Error(`Purge subscription échouée: ${error.message}`)
+    },
+
+    buildContent: (event: NotificationEvent): NotificationContent =>
+      buildNotificationContent(event) as NotificationContent,
+
+    logDelivery: async (entry): Promise<void> => {
+      const { error } = await supabase.from('push_delivery_log').insert({
+        event_type: entry.event_type,
+        club_id: entry.club_id,
+        poll_id: entry.poll_id,
+        sent_count: entry.sent,
+        failed_count: entry.failed,
+        skipped_count: entry.skipped,
+      })
+      if (error) throw new Error(`Insert push_delivery_log échoué: ${error.message}`)
+    },
+
+    log: (level, msg, meta) => {
+      const line = `[dispatch-push] ${msg}${meta ? ' ' + JSON.stringify(meta) : ''}`
+      if (level === 'error') console.error(line)
+      else if (level === 'warn') console.warn(line)
+      else console.log(line)
+    },
+  }
+}
+
+// ---- Entrypoint de production ----
+if (import.meta.main) {
+  Deno.serve(async (req: Request) => {
+    let event: NotificationEvent | null = null
+    try {
+      const body = await req.json().catch(() => null)
+      event = parseEvent(body)
+    } catch {
+      event = null
+    }
+    if (!event) {
+      return json({ ok: false, error: 'NotificationEvent invalide' }, 400)
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    try {
+      const deps = await buildDeps(supabase)
+      const summary = await dispatchPush(deps, event)
+      return json({ ok: true, ...summary })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: event.clubId,
+        errors: [message],
+        sheets: ['dispatch-push'],
+      }).catch(() => {})
+      return json({ ok: false, error: message }, 500)
+    }
+  })
+}
+
+export { buildDeps, parseEvent }

--- a/supabase/functions/dispatch-push/index.ts
+++ b/supabase/functions/dispatch-push/index.ts
@@ -33,6 +33,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { dispatchPush } from './handler.ts'
 import { alertSentry } from '../_shared/sentry.ts'
+import { parseAllowlist } from '../_shared/notify-allowlist.ts'
 import type {
   DispatchDeps,
   NotificationContent,
@@ -93,7 +94,20 @@ async function buildDeps(supabase: SupabaseClient): Promise<DispatchDeps> {
     webpush.setVapidDetails(vapidSubject, vapidPublic, vapidPrivate)
   }
 
+  // Allowlist de TEST (NOTIFY_ALLOWLIST = emails). On résout une fois emails → user_id (GoTrue
+  // stocke les emails en minuscule → match exact). Vide → pas de filtre (comportement normal).
+  // INTERSECTION appliquée côté handler : ne peut jamais cibler hors du club.
+  const allowlistEmails = parseAllowlist(Deno.env.get('NOTIFY_ALLOWLIST'))
+  let allowlistUserIds: string[] | undefined
+  if (allowlistEmails.length > 0) {
+    const { data, error } = await supabase.from('users').select('id').in('email', allowlistEmails)
+    if (error) throw new Error(`Lecture users (allowlist) échouée: ${error.message}`)
+    allowlistUserIds = (data ?? []).map((u) => u.id as string)
+  }
+
   return {
+    allowlistUserIds,
+
     listClubActiveMemberUserIds: async (clubId: string): Promise<string[]> => {
       // CLUB-SCOPING à la source : seuls les membres ACTIFS de ce club.
       const { data, error } = await supabase

--- a/supabase/functions/poll-closed-push/__tests__/listFreshlyClosedPolls.test.ts
+++ b/supabase/functions/poll-closed-push/__tests__/listFreshlyClosedPolls.test.ts
@@ -1,0 +1,84 @@
+// Test Deno THIN de `poll-closed-push` — la logique de DÉDUP (gotcha de timing §8.3).
+//
+// EXÉCUTION
+//   deno test --no-check --allow-all --config supabase/functions/poll-closed-push/deno.json \
+//     supabase/functions/poll-closed-push/__tests__/
+//
+// On stubbe un client PostgREST chaînable minimal : `from('polls')…` renvoie deux polls
+// clôturés, `from('push_delivery_log')…` renvoie une entrée 'poll.closed' pour l'un d'eux.
+// On vérifie que listFreshlyClosedPolls EXCLUT le poll déjà poussé (anti double-push, couvre
+// aussi la clôture manuelle ayant déjà dispatché).
+
+import { assertEquals } from 'jsr:@std/assert@^1'
+
+import { listFreshlyClosedPolls } from '../index.ts'
+
+// Client chaînable minimal : chaque méthode de filtre renvoie `this` ; `await` résout `result`.
+function makeQuery(result: { data: unknown; error: null }) {
+  const q: Record<string, unknown> = {}
+  const passthrough = () => q
+  for (const m of ['select', 'eq', 'not', 'lt', 'gte', 'lte', 'in']) {
+    q[m] = passthrough
+  }
+  // thenable → `await q` résout `result`.
+  q.then = (resolve: (v: unknown) => unknown) => resolve(result)
+  return q
+}
+
+Deno.test(
+  'listFreshlyClosedPolls : exclut un poll déjà poussé (dédup push_delivery_log)',
+  async () => {
+    const polls = [
+      {
+        id: 'p1',
+        club_id: 'clubA',
+        title: 'A',
+        closes_at: '2026-06-01T00:00:00Z',
+        closed_manually_at: '2026-06-01T00:05:00Z',
+      },
+      {
+        id: 'p2',
+        club_id: 'clubA',
+        title: 'B',
+        closes_at: '2026-06-02T00:00:00Z',
+        closed_manually_at: '2026-06-02T00:05:00Z',
+      },
+    ]
+    // push_delivery_log a déjà une entrée 'poll.closed' pour p1 → p1 exclu.
+    const log = [{ poll_id: 'p1' }]
+
+    const supabase = {
+      from(table: string) {
+        if (table === 'polls') return makeQuery({ data: polls, error: null })
+        if (table === 'push_delivery_log') return makeQuery({ data: log, error: null })
+        return makeQuery({ data: [], error: null })
+      },
+      // deno-lint-ignore no-explicit-any
+    } as any
+
+    const fresh = await listFreshlyClosedPolls(supabase)
+
+    // Seul p2 reste (p1 déjà poussé).
+    assertEquals(
+      fresh.map((p) => p.id),
+      ['p2']
+    )
+    assertEquals(fresh[0].club_id, 'clubA')
+  }
+)
+
+Deno.test(
+  'listFreshlyClosedPolls : aucun poll clôturé → liste vide (pas de requête log)',
+  async () => {
+    const supabase = {
+      from(table: string) {
+        if (table === 'polls') return makeQuery({ data: [], error: null })
+        return makeQuery({ data: [], error: null })
+      },
+      // deno-lint-ignore no-explicit-any
+    } as any
+
+    const fresh = await listFreshlyClosedPolls(supabase)
+    assertEquals(fresh, [])
+  }
+)

--- a/supabase/functions/poll-closed-push/deno.json
+++ b/supabase/functions/poll-closed-push/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@^2",
+    "@evolve/utils": "../../../packages/utils/src/index.ts",
+    "@evolve/types": "../../../packages/types/src/index.ts"
+  }
+}

--- a/supabase/functions/poll-closed-push/deno.lock
+++ b/supabase/functions/poll-closed-push/deno.lock
@@ -1,0 +1,162 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:@supabase/supabase-js@2": "2.106.2",
+    "npm:web-push@3": "3.6.7"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.106.2": {
+      "integrity": "sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.106.2": {
+      "integrity": "sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.106.2": {
+      "integrity": "sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.106.2": {
+      "integrity": "sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.106.2": {
+      "integrity": "sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.106.2": {
+      "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
+    "asn1.js@5.4.1": {
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": [
+        "bn.js",
+        "inherits",
+        "minimalistic-assert",
+        "safer-buffer"
+      ]
+    },
+    "bn.js@4.12.3": {
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+    },
+    "buffer-equal-constant-time@1.0.1": {
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "ecdsa-sig-formatter@1.0.11": {
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "http_ece@1.2.0": {
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
+    },
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": [
+        "agent-base",
+        "debug"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jwa@2.0.1": {
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": [
+        "buffer-equal-constant-time",
+        "ecdsa-sig-formatter",
+        "safe-buffer"
+      ]
+    },
+    "jws@4.0.1": {
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": [
+        "jwa",
+        "safe-buffer"
+      ]
+    },
+    "minimalistic-assert@1.0.1": {
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimist@1.2.8": {
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "web-push@3.6.7": {
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": [
+        "asn1.js",
+        "http_ece",
+        "https-proxy-agent",
+        "jws",
+        "minimist"
+      ],
+      "bin": true
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@supabase/supabase-js@2"
+    ]
+  }
+}

--- a/supabase/functions/poll-closed-push/index.ts
+++ b/supabase/functions/poll-closed-push/index.ts
@@ -1,0 +1,128 @@
+// Edge Function `poll-closed-push` — cible cron du push post-clôture (PUSH-001 ; spec §8.3, option A).
+//
+// Déclenchement
+// -------------
+//   pg_cron `poll-closed-push` (migration 039, horaire à HH:05) POST `{}` avec
+//   `Authorization: Bearer <service_role>` (URL Vault `poll_closed_push_url`).
+//   verify_jwt = false (config.toml) : la clé service-role n'est pas un JWT.
+//
+// Rôle (THIN) : dispatch un `poll.closed` pour chaque vote FRAÎCHEMENT clôturé par échéance,
+// en RÉUTILISANT le handler `dispatch-push` (mêmes deps, même club-scoping).
+//
+// POURQUOI ne PAS rappeler close_due_polls() (gotcha de timing) :
+//   Le job `close-due-polls` (migration 038) tourne à HH:00 et bascule déjà open→closed.
+//   `poll-closed-push` tourne à HH:05 : appeler close_due_polls() ici renverrait 0 ligne
+//   (tout est déjà 'closed'). On LIT donc les polls fraîchement clôturés par DEADLINE
+//   (status='closed' AND closes_at < now()) et on DÉDOUBLONNE via push_delivery_log :
+//   un poll qui a déjà une entrée 'poll.closed' n'est PAS re-poussé. Ce garde-fou couvre
+//   aussi le cas d'une clôture manuelle ayant déjà dispatché (Server Action).
+//
+// CLUB-SCOPING : chaque dispatch est borné au `club_id` du poll (handler partagé).
+//
+// Sécurité : SUPABASE_SERVICE_ROLE_KEY (bypass RLS), strictement côté serveur.
+
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { dispatchPush } from '../dispatch-push/handler.ts'
+import { buildDeps } from '../dispatch-push/index.ts'
+import { alertSentry } from '../_shared/sentry.ts'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/**
+ * Polls clôturés par DEADLINE pour lesquels aucun `poll.closed` n'a encore été journalisé.
+ * On borne la fenêtre aux 7 derniers jours (évite de re-scanner tout l'historique ; au-delà,
+ * l'absence de log signifierait un trou de cron qu'on ne cherche pas à rattraper).
+ */
+async function listFreshlyClosedPolls(
+  supabase: SupabaseClient
+): Promise<{ id: string; club_id: string; title: string; closes_at: string | null }[]> {
+  const nowIso = new Date().toISOString()
+  const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: closed, error } = await supabase
+    .from('polls')
+    .select('id, club_id, title, closes_at, closed_manually_at')
+    .eq('status', 'closed')
+    .not('closes_at', 'is', null)
+    .lt('closes_at', nowIso)
+    .gte('closed_manually_at', since)
+  if (error) throw new Error(`Lecture polls clôturés échouée: ${error.message}`)
+
+  const candidates = (closed ?? []).map((p) => ({
+    id: p.id as string,
+    club_id: p.club_id as string,
+    title: (p.title as string) ?? '',
+    closes_at: (p.closes_at as string | null) ?? null,
+  }))
+  if (candidates.length === 0) return []
+
+  // DÉDUP : retire les polls qui ont déjà une entrée push 'poll.closed' (autre run / clôture manuelle).
+  const { data: logged, error: logErr } = await supabase
+    .from('push_delivery_log')
+    .select('poll_id')
+    .eq('event_type', 'poll.closed')
+    .in(
+      'poll_id',
+      candidates.map((c) => c.id)
+    )
+  if (logErr) throw new Error(`Lecture push_delivery_log échouée: ${logErr.message}`)
+  const alreadyPushed = new Set((logged ?? []).map((r) => r.poll_id as string))
+
+  return candidates.filter((c) => !alreadyPushed.has(c.id))
+}
+
+if (import.meta.main) {
+  Deno.serve(async () => {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    try {
+      const polls = await listFreshlyClosedPolls(supabase)
+      const deps = await buildDeps(supabase)
+
+      let processed = 0
+      const totals = { sent: 0, failed: 0, skipped: 0 }
+      for (const p of polls) {
+        try {
+          const summary = await dispatchPush(deps, {
+            type: 'poll.closed',
+            clubId: p.club_id,
+            payload: { pollId: p.id, title: p.title, closesAt: p.closes_at },
+          })
+          totals.sent += summary.sent
+          totals.failed += summary.failed
+          totals.skipped += summary.skipped
+          processed += 1
+        } catch (e) {
+          console.error(
+            `[poll-closed-push] dispatch échoué pour poll ${p.id}: ${
+              e instanceof Error ? e.message : String(e)
+            }`
+          )
+        }
+      }
+
+      return json({ ok: true, polls: polls.length, processed, ...totals })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: 'poll-closed-push',
+        errors: [message],
+        sheets: ['poll-closed-push'],
+      }).catch(() => {})
+      return json({ ok: false, error: message }, 500)
+    }
+  })
+}
+
+export { listFreshlyClosedPolls }

--- a/supabase/functions/poll-push-reminders/__tests__/listPollsDueSoon.test.ts
+++ b/supabase/functions/poll-push-reminders/__tests__/listPollsDueSoon.test.ts
@@ -1,0 +1,55 @@
+// Test Deno THIN de `poll-push-reminders` — la sélection des polls échéant sous 24 h.
+//
+// EXÉCUTION
+//   deno test --no-check --allow-all --config supabase/functions/poll-push-reminders/deno.json \
+//     supabase/functions/poll-push-reminders/__tests__/
+//
+// On stubbe un client PostgREST chaînable minimal et on vérifie que listPollsDueSoon
+// retourne les polls normalisés ({id, club_id, title, closes_at}) issus de la requête
+// (status='open' + fenêtre [now, now+24h] appliquée côté DB ; ici on valide le mapping).
+
+import { assertEquals } from 'jsr:@std/assert@^1'
+
+import { listPollsDueSoon } from '../index.ts'
+
+function makeQuery(result: { data: unknown; error: null }) {
+  const q: Record<string, unknown> = {}
+  const passthrough = () => q
+  for (const m of ['select', 'eq', 'not', 'gte', 'lte']) {
+    q[m] = passthrough
+  }
+  q.then = (resolve: (v: unknown) => unknown) => resolve(result)
+  return q
+}
+
+Deno.test('listPollsDueSoon : normalise les polls éligibles au rappel J-1', async () => {
+  const rows = [
+    { id: 'p1', club_id: 'clubA', title: 'Vote 1', closes_at: '2026-06-17T00:00:00Z' },
+    { id: 'p2', club_id: 'clubB', title: 'Vote 2', closes_at: '2026-06-17T06:00:00Z' },
+  ]
+  const supabase = {
+    from() {
+      return makeQuery({ data: rows, error: null })
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any
+
+  const due = await listPollsDueSoon(supabase)
+  assertEquals(
+    due.map((p) => p.id),
+    ['p1', 'p2']
+  )
+  assertEquals(due[0].club_id, 'clubA')
+  assertEquals(due[1].title, 'Vote 2')
+})
+
+Deno.test('listPollsDueSoon : aucun poll éligible → liste vide', async () => {
+  const supabase = {
+    from() {
+      return makeQuery({ data: [], error: null })
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any
+
+  assertEquals(await listPollsDueSoon(supabase), [])
+})

--- a/supabase/functions/poll-push-reminders/deno.json
+++ b/supabase/functions/poll-push-reminders/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@^2",
+    "@evolve/utils": "../../../packages/utils/src/index.ts",
+    "@evolve/types": "../../../packages/types/src/index.ts"
+  }
+}

--- a/supabase/functions/poll-push-reminders/deno.lock
+++ b/supabase/functions/poll-push-reminders/deno.lock
@@ -1,0 +1,162 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:@supabase/supabase-js@2": "2.106.2",
+    "npm:web-push@3": "3.6.7"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.106.2": {
+      "integrity": "sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.106.2": {
+      "integrity": "sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.106.2": {
+      "integrity": "sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.106.2": {
+      "integrity": "sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.106.2": {
+      "integrity": "sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.106.2": {
+      "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
+    "asn1.js@5.4.1": {
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": [
+        "bn.js",
+        "inherits",
+        "minimalistic-assert",
+        "safer-buffer"
+      ]
+    },
+    "bn.js@4.12.3": {
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+    },
+    "buffer-equal-constant-time@1.0.1": {
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "ecdsa-sig-formatter@1.0.11": {
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "http_ece@1.2.0": {
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
+    },
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": [
+        "agent-base",
+        "debug"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jwa@2.0.1": {
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": [
+        "buffer-equal-constant-time",
+        "ecdsa-sig-formatter",
+        "safe-buffer"
+      ]
+    },
+    "jws@4.0.1": {
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": [
+        "jwa",
+        "safe-buffer"
+      ]
+    },
+    "minimalistic-assert@1.0.1": {
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimist@1.2.8": {
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "web-push@3.6.7": {
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": [
+        "asn1.js",
+        "http_ece",
+        "https-proxy-agent",
+        "jws",
+        "minimist"
+      ],
+      "bin": true
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@supabase/supabase-js@2"
+    ]
+  }
+}

--- a/supabase/functions/poll-push-reminders/index.ts
+++ b/supabase/functions/poll-push-reminders/index.ts
@@ -1,0 +1,102 @@
+// Edge Function `poll-push-reminders` — cible cron du rappel vote J-1 (PUSH-001 ; spec §7.5).
+//
+// Déclenchement
+// -------------
+//   pg_cron `poll-push-reminders` (migration 039, quotidien ~07:00 UTC / ~09:00 Paris) POST `{}`
+//   avec `Authorization: Bearer <service_role>` (URL Vault `poll_push_reminders_url`).
+//   verify_jwt = false (config.toml) : la clé service-role n'est pas un JWT.
+//
+// Rôle (THIN) : sélectionne les polls OUVERTS dont l'échéance tombe dans les 24 h, puis
+// dispatch un `poll.reminder` par poll en RÉUTILISANT le handler `dispatch-push` (mêmes deps,
+// même club-scoping). Aucune logique d'envoi ici : tout vit dans `dispatch-push/handler.ts`.
+//
+// CLUB-SCOPING : chaque dispatch est borné au `club_id` du poll (résolution dans le handler
+// partagé). Le rappel exclut les membres ayant déjà voté (logique du handler).
+//
+// Sécurité : SUPABASE_SERVICE_ROLE_KEY (bypass RLS), strictement côté serveur.
+
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { dispatchPush } from '../dispatch-push/handler.ts'
+import { buildDeps } from '../dispatch-push/index.ts'
+import { alertSentry } from '../_shared/sentry.ts'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** Polls OUVERTS dont closes_at ∈ [now, now+24h] — éligibles au rappel J-1. */
+async function listPollsDueSoon(
+  supabase: SupabaseClient
+): Promise<{ id: string; club_id: string; title: string; closes_at: string | null }[]> {
+  const now = new Date()
+  const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+  const { data, error } = await supabase
+    .from('polls')
+    .select('id, club_id, title, closes_at')
+    .eq('status', 'open')
+    .not('closes_at', 'is', null)
+    .gte('closes_at', now.toISOString())
+    .lte('closes_at', in24h.toISOString())
+  if (error) throw new Error(`Lecture polls échéant sous 24h échouée: ${error.message}`)
+  return (data ?? []).map((p) => ({
+    id: p.id as string,
+    club_id: p.club_id as string,
+    title: (p.title as string) ?? '',
+    closes_at: (p.closes_at as string | null) ?? null,
+  }))
+}
+
+if (import.meta.main) {
+  Deno.serve(async () => {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    try {
+      const polls = await listPollsDueSoon(supabase)
+      const deps = await buildDeps(supabase)
+
+      let processed = 0
+      const totals = { sent: 0, failed: 0, skipped: 0 }
+      for (const p of polls) {
+        // NON-ARRÊT : un poll en échec ne bloque pas les autres.
+        try {
+          const summary = await dispatchPush(deps, {
+            type: 'poll.reminder',
+            clubId: p.club_id,
+            payload: { pollId: p.id, title: p.title, closesAt: p.closes_at },
+          })
+          totals.sent += summary.sent
+          totals.failed += summary.failed
+          totals.skipped += summary.skipped
+          processed += 1
+        } catch (e) {
+          console.error(
+            `[poll-push-reminders] dispatch échoué pour poll ${p.id}: ${
+              e instanceof Error ? e.message : String(e)
+            }`
+          )
+        }
+      }
+
+      return json({ ok: true, polls: polls.length, processed, ...totals })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: 'poll-push-reminders',
+        errors: [message],
+        sheets: ['poll-push-reminders'],
+      }).catch(() => {})
+      return json({ ok: false, error: message }, 500)
+    }
+  })
+}
+
+export { listPollsDueSoon }

--- a/supabase/functions/send-poll-email/__tests__/handler.test.ts
+++ b/supabase/functions/send-poll-email/__tests__/handler.test.ts
@@ -1,0 +1,223 @@
+// Tests Deno du handler pur `send-poll-email` (PUSH-001 V1 email ; spec §7, §12).
+//
+// EXÉCUTION (depuis la racine du repo)
+// ------------------------------------
+//     deno test --no-check --allow-all \
+//       --config supabase/functions/send-poll-email/deno.json \
+//       supabase/functions/send-poll-email/__tests__/
+//
+// On importe `handler.ts` (logique pure) : aucun I/O réel, aucun rendu React Email — toutes
+// les seams (getPoll, getClubName, listClubActiveMembers, listUsersWhoVoted, alreadySent,
+// recordSent, renderHtml, sendBrevo, sleep) sont stubbées en mémoire.
+//
+// CE QUI EST TESTÉ
+// ----------------
+// 1. ANTI-CROSS-CLUB (critique) : deux clubs A/B, poll dans A → SEULS les membres de A
+//    sont emailés ; aucun membre de B ne reçoit.
+// 2. Idempotence : 2e appel (poll_id, variant) → skip (skipped = N, 0 envoi).
+// 3. Rappel : exclut les membres ayant déjà voté.
+// 4. Destinataires normalisés : un membre sans email est skippé.
+// 5. recordSent : marque l'envoi après succès, avec le compteur.
+
+import { assert, assertEquals } from 'jsr:@std/assert@^1'
+
+import { runPollEmail } from '../handler.ts'
+import type {
+  BrevoPollEmailPayload,
+  PollEmailDeps,
+  PollEmailVariant,
+  PollMember,
+  PollRow,
+} from '../handler.ts'
+
+interface FakeState {
+  polls: Record<string, PollRow>
+  clubNames: Record<string, string>
+  membersByClub: Record<string, PollMember[]>
+  voted: Record<string, string[]>
+  /** Set des « pollId|variant » déjà envoyés. */
+  sentLog: Set<string>
+}
+
+function makeDeps(state: FakeState) {
+  const brevoPayloads: BrevoPollEmailPayload[] = []
+  const recorded: { pollId: string; variant: PollEmailVariant; count: number }[] = []
+
+  const deps: PollEmailDeps = {
+    getPoll: (pollId) => Promise.resolve(state.polls[pollId] ?? null),
+    getClubName: (clubId) => Promise.resolve(state.clubNames[clubId] ?? ''),
+    listClubActiveMembers: (clubId) => Promise.resolve(state.membersByClub[clubId] ?? []),
+    listUsersWhoVoted: (pollId) => Promise.resolve(state.voted[pollId] ?? []),
+    alreadySent: (pollId, variant) => Promise.resolve(state.sentLog.has(`${pollId}|${variant}`)),
+    recordSent: (pollId, variant, count) => {
+      state.sentLog.add(`${pollId}|${variant}`)
+      recorded.push({ pollId, variant, count })
+      return Promise.resolve()
+    },
+    renderHtml: (props) =>
+      Promise.resolve(`<html>${props.variant}:${props.pollTitle}:${props.memberFirstName}</html>`),
+    sendBrevo: (payload) => {
+      brevoPayloads.push(payload)
+      return Promise.resolve({ messageId: `msg-${brevoPayloads.length}` })
+    },
+    sleep: () => Promise.resolve(),
+    appUrl: 'https://app.evolve.capital',
+    log: () => {},
+  }
+  return { deps, brevoPayloads, recorded }
+}
+
+function poll(id: string, clubId: string): PollRow {
+  return {
+    id,
+    clubId,
+    title: `Vote ${id}`,
+    description: null,
+    questionType: 'yes_no',
+    closesAt: '2026-07-01T00:00:00.000Z',
+    resultsVisibility: 'after_close',
+    notifyByEmail: true,
+  }
+}
+
+function member(userId: string, email: string, fullName: string | null = null): PollMember {
+  return { userId, email, fullName }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1 — ANTI-CROSS-CLUB : poll dans club A → SEULS les membres de A reçoivent.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('anti-cross-club : poll du club A → seuls les membres de A sont emailés', async () => {
+  const state: FakeState = {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago', clubB: 'Cercle Borel' },
+    membersByClub: {
+      clubA: [member('uA1', 'a1@ex.fr', 'Awa Koné'), member('uA2', 'a2@ex.fr', 'Bo Ba')],
+      clubB: [member('uB1', 'b1@ex.fr'), member('uB2', 'b2@ex.fr')], // NE DOIVENT PAS recevoir
+    },
+    voted: {},
+    sentLog: new Set(),
+  }
+  const { deps, brevoPayloads } = makeDeps(state)
+
+  const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+
+  assertEquals(summary.sent, 2)
+  const emails = brevoPayloads.map((p) => p.to[0].email).sort()
+  assertEquals(emails, ['a1@ex.fr', 'a2@ex.fr'])
+  // Aucun email du club B.
+  assert(!emails.includes('b1@ex.fr'))
+  assert(!emails.includes('b2@ex.fr'))
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2 — Idempotence : 2e appel (poll_id, variant) → skip total.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test("idempotence : un 2e appel sur (poll, variant) n'envoie rien", async () => {
+  const state: FakeState = {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago' },
+    membersByClub: { clubA: [member('uA1', 'a1@ex.fr'), member('uA2', 'a2@ex.fr')] },
+    voted: {},
+    sentLog: new Set(),
+  }
+  const first = makeDeps(state)
+  const s1 = await runPollEmail(first.deps, { pollId: 'p1', variant: 'opened' })
+  assertEquals(s1.sent, 2)
+
+  // 2e appel : sentLog déjà rempli → skip.
+  const second = makeDeps(state)
+  const s2 = await runPollEmail(second.deps, { pollId: 'p1', variant: 'opened' })
+  assertEquals(s2.sent, 0)
+  assertEquals(s2.skipped, 2)
+  assertEquals(second.brevoPayloads.length, 0)
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3 — Rappel : exclut les membres ayant déjà voté.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('reminder : exclut les membres ayant déjà voté', async () => {
+  const state: FakeState = {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago' },
+    membersByClub: {
+      clubA: [member('uA1', 'a1@ex.fr'), member('uA2', 'a2@ex.fr'), member('uA3', 'a3@ex.fr')],
+    },
+    voted: { p1: ['uA2'] }, // uA2 a voté → exclu du rappel
+    sentLog: new Set(),
+  }
+  const { deps, brevoPayloads } = makeDeps(state)
+
+  const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'reminder' })
+
+  assertEquals(summary.sent, 2)
+  const emails = brevoPayloads.map((p) => p.to[0].email).sort()
+  assertEquals(emails, ['a1@ex.fr', 'a3@ex.fr'])
+  assert(!emails.includes('a2@ex.fr'))
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4 — Destinataires normalisés : un membre sans email est skippé.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('normalisation : un membre sans email est skippé, les autres reçoivent', async () => {
+  const state: FakeState = {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago' },
+    membersByClub: {
+      clubA: [member('uA1', 'a1@ex.fr'), member('uA2', '   '), member('uA3', '')],
+    },
+    voted: {},
+    sentLog: new Set(),
+  }
+  const { deps, brevoPayloads } = makeDeps(state)
+
+  const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'closed' })
+
+  assertEquals(summary.sent, 1)
+  assertEquals(summary.skipped, 2)
+  assertEquals(
+    brevoPayloads.map((p) => p.to[0].email),
+    ['a1@ex.fr']
+  )
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5 — recordSent : marque l'envoi après succès avec le compteur.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('recordSent : marque (poll, variant, count) après envoi réussi', async () => {
+  const state: FakeState = {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago' },
+    membersByClub: { clubA: [member('uA1', 'a1@ex.fr'), member('uA2', 'a2@ex.fr')] },
+    voted: {},
+    sentLog: new Set(),
+  }
+  const { deps, recorded } = makeDeps(state)
+
+  await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+
+  assertEquals(recorded.length, 1)
+  assertEquals(recorded[0].pollId, 'p1')
+  assertEquals(recorded[0].variant, 'opened')
+  assertEquals(recorded[0].count, 2)
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 6 — Poll introuvable : retourne summary vide sans crash.
+// ════════════════════════════════════════════════════════════════════════════
+Deno.test('poll introuvable : 0 envoi, pas de crash', async () => {
+  const state: FakeState = {
+    polls: {},
+    clubNames: {},
+    membersByClub: {},
+    voted: {},
+    sentLog: new Set(),
+  }
+  const { deps, brevoPayloads } = makeDeps(state)
+
+  const summary = await runPollEmail(deps, { pollId: 'unknown', variant: 'opened' })
+
+  assertEquals(summary.sent, 0)
+  assertEquals(summary.failed, 0)
+  assertEquals(brevoPayloads.length, 0)
+})

--- a/supabase/functions/send-poll-email/__tests__/handler.test.ts
+++ b/supabase/functions/send-poll-email/__tests__/handler.test.ts
@@ -39,11 +39,12 @@ interface FakeState {
   sentLog: Set<string>
 }
 
-function makeDeps(state: FakeState) {
+function makeDeps(state: FakeState, opts: { allowlistEmails?: string[] } = {}) {
   const brevoPayloads: BrevoPollEmailPayload[] = []
   const recorded: { pollId: string; variant: PollEmailVariant; count: number }[] = []
 
   const deps: PollEmailDeps = {
+    allowlistEmails: opts.allowlistEmails,
     getPoll: (pollId) => Promise.resolve(state.polls[pollId] ?? null),
     getClubName: (clubId) => Promise.resolve(state.clubNames[clubId] ?? ''),
     listClubActiveMembers: (clubId) => Promise.resolve(state.membersByClub[clubId] ?? []),
@@ -221,3 +222,88 @@ Deno.test('poll introuvable : 0 envoi, pas de crash', async () => {
   assertEquals(summary.failed, 0)
   assertEquals(brevoPayloads.length, 0)
 })
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7 — ALLOWLIST DE TEST (NOTIFY_ALLOWLIST) — sûreté du mode test.
+// ════════════════════════════════════════════════════════════════════════════
+function allowlistState(): FakeState {
+  return {
+    polls: { p1: poll('p1', 'clubA') },
+    clubNames: { clubA: 'Cercle Arago' },
+    membersByClub: {
+      clubA: [member('uA1', 'a1@ex.fr'), member('uA2', 'a2@ex.fr'), member('uA3', 'a3@ex.fr')],
+    },
+    voted: {},
+    sentLog: new Set(),
+  }
+}
+
+Deno.test('allowlist VIDE → comportement normal : tous les membres reçoivent', async () => {
+  const { deps, brevoPayloads } = makeDeps(allowlistState(), { allowlistEmails: [] })
+  const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+  assertEquals(summary.sent, 3)
+  assertEquals(brevoPayloads.map((p) => p.to[0].email).sort(), ['a1@ex.fr', 'a2@ex.fr', 'a3@ex.fr'])
+})
+
+Deno.test(
+  'allowlist = [a1] → SEUL a1 reçoit (les autres membres du club sont exclus)',
+  async () => {
+    const { deps, brevoPayloads } = makeDeps(allowlistState(), { allowlistEmails: ['a1@ex.fr'] })
+    const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+    assertEquals(summary.sent, 1)
+    assertEquals(
+      brevoPayloads.map((p) => p.to[0].email),
+      ['a1@ex.fr']
+    )
+  }
+)
+
+Deno.test(
+  'SÛRETÉ : allowlist = email HORS club → personne ne reçoit (intersection, jamais additif)',
+  async () => {
+    const { deps, brevoPayloads } = makeDeps(allowlistState(), {
+      allowlistEmails: ['etranger@autre.fr'],
+    })
+    const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+    // L'email hors-club n'est JAMAIS ajouté : on ne peut pas notifier hors du club.
+    assertEquals(summary.sent, 0)
+    assertEquals(brevoPayloads.length, 0)
+  }
+)
+
+Deno.test('allowlist insensible à la casse (email membre en majuscules)', async () => {
+  const state = allowlistState()
+  state.membersByClub.clubA = [member('uA1', 'Alice@Ex.FR'), member('uA2', 'a2@ex.fr')]
+  // L'allowlist est déjà normalisée minuscule par parseAllowlist côté index.
+  const { deps, brevoPayloads } = makeDeps(state, { allowlistEmails: ['alice@ex.fr'] })
+  const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+  assertEquals(summary.sent, 1)
+  assertEquals(
+    brevoPayloads.map((p) => p.to[0].email),
+    ['Alice@Ex.FR']
+  )
+})
+
+Deno.test(
+  'allowlist + anti-cross-club : un email du club B dans l’allowlist ne reçoit pas (poll du club A)',
+  async () => {
+    const state: FakeState = {
+      polls: { p1: poll('p1', 'clubA') },
+      clubNames: { clubA: 'Cercle Arago', clubB: 'Cercle Borel' },
+      membersByClub: {
+        clubA: [member('uA1', 'a1@ex.fr')],
+        clubB: [member('uB1', 'b1@ex.fr')],
+      },
+      voted: {},
+      sentLog: new Set(),
+    }
+    // b1 est dans l'allowlist MAIS membre du club B → ne doit jamais recevoir le poll du club A.
+    const { deps, brevoPayloads } = makeDeps(state, { allowlistEmails: ['a1@ex.fr', 'b1@ex.fr'] })
+    const summary = await runPollEmail(deps, { pollId: 'p1', variant: 'opened' })
+    assertEquals(summary.sent, 1)
+    assertEquals(
+      brevoPayloads.map((p) => p.to[0].email),
+      ['a1@ex.fr']
+    )
+  }
+)

--- a/supabase/functions/send-poll-email/deno.json
+++ b/supabase/functions/send-poll-email/deno.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "npm:react@^19"
+  },
+  "imports": {
+    "@evolve/utils": "../../../packages/utils/src/index.ts",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@^2",
+    "react": "npm:react@^19",
+    "@evolve/design-system": "../../../packages/design-system/src/tokens/index.ts",
+    "@react-email/components": "npm:@react-email/components@^1",
+    "@react-email/render": "npm:@react-email/render@^1"
+  }
+}

--- a/supabase/functions/send-poll-email/deno.lock
+++ b/supabase/functions/send-poll-email/deno.lock
@@ -1,0 +1,348 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:@react-email/components@1": "1.0.12_react@19.2.7_react-dom@19.2.7__react@19.2.7",
+    "npm:@react-email/render@1": "1.4.0_react@19.2.7_react-dom@19.2.7__react@19.2.7",
+    "npm:react@19": "19.2.7"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@react-email/body@0.3.0_react@19.2.7": {
+      "integrity": "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/button@0.2.1_react@19.2.7": {
+      "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/code-block@0.2.1_react@19.2.7": {
+      "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
+      "dependencies": [
+        "prismjs",
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/code-inline@0.0.6_react@19.2.7": {
+      "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/column@0.0.14_react@19.2.7": {
+      "integrity": "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/components@1.0.12_react@19.2.7_react-dom@19.2.7__react@19.2.7": {
+      "integrity": "sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==",
+      "dependencies": [
+        "@react-email/body",
+        "@react-email/button",
+        "@react-email/code-block",
+        "@react-email/code-inline",
+        "@react-email/column",
+        "@react-email/container",
+        "@react-email/font",
+        "@react-email/head",
+        "@react-email/heading",
+        "@react-email/hr",
+        "@react-email/html",
+        "@react-email/img",
+        "@react-email/link",
+        "@react-email/markdown",
+        "@react-email/preview",
+        "@react-email/render@2.0.6_react@19.2.7_react-dom@19.2.7__react@19.2.7",
+        "@react-email/row",
+        "@react-email/section",
+        "@react-email/tailwind",
+        "@react-email/text",
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/container@0.0.16_react@19.2.7": {
+      "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/font@0.0.10_react@19.2.7": {
+      "integrity": "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/head@0.0.13_react@19.2.7": {
+      "integrity": "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/heading@0.0.16_react@19.2.7": {
+      "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/hr@0.0.12_react@19.2.7": {
+      "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/html@0.0.12_react@19.2.7": {
+      "integrity": "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/img@0.0.12_react@19.2.7": {
+      "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/link@0.0.13_react@19.2.7": {
+      "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/markdown@0.0.18_react@19.2.7": {
+      "integrity": "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==",
+      "dependencies": [
+        "marked",
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/preview@0.0.14_react@19.2.7": {
+      "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/render@1.4.0_react@19.2.7_react-dom@19.2.7__react@19.2.7": {
+      "integrity": "sha512-ZtJ3noggIvW1ZAryoui95KJENKdCzLmN5F7hyZY1F/17B1vwzuxHB7YkuCg0QqHjDivc5axqYEYdIOw4JIQdUw==",
+      "dependencies": [
+        "html-to-text",
+        "prettier",
+        "react",
+        "react-dom",
+        "react-promise-suspense"
+      ]
+    },
+    "@react-email/render@2.0.6_react@19.2.7_react-dom@19.2.7__react@19.2.7": {
+      "integrity": "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==",
+      "dependencies": [
+        "html-to-text",
+        "prettier",
+        "react",
+        "react-dom"
+      ]
+    },
+    "@react-email/row@0.0.13_react@19.2.7": {
+      "integrity": "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/section@0.0.17_react@19.2.7": {
+      "integrity": "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@react-email/tailwind@2.0.7_@react-email+body@0.3.0__react@19.2.7_@react-email+button@0.2.1__react@19.2.7_@react-email+code-block@0.2.1__react@19.2.7_@react-email+code-inline@0.0.6__react@19.2.7_@react-email+container@0.0.16__react@19.2.7_@react-email+heading@0.0.16__react@19.2.7_@react-email+hr@0.0.12__react@19.2.7_@react-email+img@0.0.12__react@19.2.7_@react-email+link@0.0.13__react@19.2.7_@react-email+preview@0.0.14__react@19.2.7_@react-email+text@0.1.6__react@19.2.7_react@19.2.7": {
+      "integrity": "sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==",
+      "dependencies": [
+        "@react-email/body",
+        "@react-email/button",
+        "@react-email/code-block",
+        "@react-email/code-inline",
+        "@react-email/container",
+        "@react-email/heading",
+        "@react-email/hr",
+        "@react-email/img",
+        "@react-email/link",
+        "@react-email/preview",
+        "@react-email/text",
+        "react",
+        "tailwindcss"
+      ],
+      "optionalPeers": [
+        "@react-email/body",
+        "@react-email/button",
+        "@react-email/code-block",
+        "@react-email/code-inline",
+        "@react-email/container",
+        "@react-email/heading",
+        "@react-email/hr",
+        "@react-email/img",
+        "@react-email/link",
+        "@react-email/preview"
+      ],
+      "deprecated": true
+    },
+    "@react-email/text@0.1.6_react@19.2.7": {
+      "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
+      "dependencies": [
+        "react"
+      ],
+      "deprecated": true
+    },
+    "@selderee/plugin-htmlparser2@0.11.0": {
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "dependencies": [
+        "domhandler",
+        "selderee"
+      ]
+    },
+    "deepmerge@4.3.1": {
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
+    "dom-serializer@2.0.0": {
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "entities"
+      ]
+    },
+    "domelementtype@2.3.0": {
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler@5.0.3": {
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": [
+        "domelementtype"
+      ]
+    },
+    "domutils@3.2.2": {
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": [
+        "dom-serializer",
+        "domelementtype",
+        "domhandler"
+      ]
+    },
+    "entities@4.5.0": {
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "fast-deep-equal@2.0.1": {
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+    },
+    "html-to-text@9.0.5": {
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "dependencies": [
+        "@selderee/plugin-htmlparser2",
+        "deepmerge",
+        "dom-serializer",
+        "htmlparser2",
+        "selderee"
+      ]
+    },
+    "htmlparser2@8.0.2": {
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "domutils",
+        "entities"
+      ]
+    },
+    "leac@0.6.0": {
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="
+    },
+    "marked@15.0.12": {
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "bin": true
+    },
+    "parseley@0.12.1": {
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "dependencies": [
+        "leac",
+        "peberminta"
+      ]
+    },
+    "peberminta@0.9.0": {
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="
+    },
+    "prettier@3.8.3": {
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "bin": true
+    },
+    "prismjs@1.30.0": {
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
+    },
+    "react-dom@19.2.7_react@19.2.7": {
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dependencies": [
+        "react",
+        "scheduler"
+      ]
+    },
+    "react-promise-suspense@0.3.4": {
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "dependencies": [
+        "fast-deep-equal"
+      ]
+    },
+    "react@19.2.7": {
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="
+    },
+    "scheduler@0.27.0": {
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "selderee@0.11.0": {
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "dependencies": [
+        "parseley"
+      ]
+    },
+    "tailwindcss@4.3.0": {
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@react-email/components@1",
+      "npm:@react-email/render@1",
+      "npm:@supabase/supabase-js@2",
+      "npm:react@19"
+    ]
+  }
+}

--- a/supabase/functions/send-poll-email/handler.ts
+++ b/supabase/functions/send-poll-email/handler.ts
@@ -99,6 +99,12 @@ export interface PollEmailDeps {
   sleep: (ms: number) => Promise<void>
   /** Base URL de l'app membre (CTA email). Injectée depuis l'env côté impl ; le handler reste pur. */
   appUrl?: string
+  /**
+   * Allowlist de TEST (emails normalisés minuscule, depuis NOTIFY_ALLOWLIST). Si NON VIDE, on
+   * n'envoie qu'aux membres du club dont l'email y figure — INTERSECTION, jamais additif (le
+   * club-scoping reste intact). Vide/undefined → comportement normal (tous les membres actifs).
+   */
+  allowlistEmails?: string[]
   /** Log diagnostic (injectable). */
   log?: (level: 'info' | 'warn' | 'error', msg: string, meta?: Record<string, unknown>) => void
 }
@@ -188,6 +194,17 @@ export async function runPollEmail(
 
   // ── CLUB-SCOPING : membres actifs du club du poll uniquement ──
   let members = await deps.listClubActiveMembers(poll.clubId)
+
+  // ── Allowlist de TEST (NOTIFY_ALLOWLIST) — INTERSECTION, jamais additif ──
+  // Si renseignée, on restreint aux membres du club dont l'email est dans l'allowlist.
+  // Ne peut JAMAIS élargir hors du club (on filtre une liste déjà club-scopée).
+  if (deps.allowlistEmails && deps.allowlistEmails.length > 0) {
+    const allow = new Set(deps.allowlistEmails)
+    const before = members.length
+    members = members.filter((m) => allow.has(m.email.trim().toLowerCase()))
+    if (members.length !== before)
+      log('info', 'Allowlist de test active', { before, after: members.length })
+  }
 
   // Rappel : exclure les membres ayant déjà voté.
   if (variant === 'reminder') {

--- a/supabase/functions/send-poll-email/handler.ts
+++ b/supabase/functions/send-poll-email/handler.ts
@@ -1,0 +1,251 @@
+// Handler pur de l'Edge Function `send-poll-email` (PUSH-001 V1 email ; spec §7, §12).
+//
+// Envoie l'email de vote (opened / closed / reminder) aux membres ACTIFS du club du poll.
+// AUCUN I/O concret ici : toutes les seams passent par `PollEmailDeps`. Testable en isolation
+// côté Deno (pas de réseau, pas de rendu React Email). `index.ts` câble les vraies deps.
+//
+// CLUB-SCOPING — règle de sécurité NON NÉGOCIABLE (§2.2) :
+//   Les destinataires sont EXCLUSIVEMENT les membres ACTIFS de `poll.club_id`. Jamais un
+//   autre club. La résolution se fait à la source (`listClubActiveMembers(poll.club_id)`).
+//
+// IDEMPOTENCE :
+//   `poll_email_sends` (UNIQUE poll_id, variant). `alreadySent(poll_id, variant)` court-circuite
+//   un 2e envoi (cron rejoué / Edge retriée) ; `recordSent` marque l'envoi APRÈS succès.
+//
+// ANONYMAT (§2.2) :
+//   L'email ne porte que le titre du vote (jamais une identité), le prénom du destinataire
+//   (perso légitime), aucune participation, aucun résultat. Le rappel exclut les votants
+//   (via des user_id internes jamais exposés).
+
+// ---- Types métier injectés ----
+
+export type PollEmailVariant = 'opened' | 'closed' | 'reminder'
+
+/** Poll minimal nécessaire à l'envoi. */
+export interface PollRow {
+  id: string
+  clubId: string
+  title: string
+  description: string | null
+  questionType: 'yes_no' | 'single_choice' | 'multiple_choice' | 'short_text'
+  closesAt: string | null
+  resultsVisibility: 'after_close' | 'live'
+  notifyByEmail: boolean
+}
+
+/** Membre actif destinataire. */
+export interface PollMember {
+  email: string
+  fullName: string | null
+  userId: string
+}
+
+/** Props attendues par renderPollEmailHtml (miroir @evolve/data PollEmailProps). */
+export interface PollEmailRenderProps {
+  memberFirstName: string
+  clubName: string
+  pollTitle: string
+  pollDescription?: string
+  questionType: 'yes_no' | 'single_choice' | 'multiple_choice' | 'short_text'
+  closesAt?: string | null
+  variant: PollEmailVariant
+  appUrl?: string
+  locale?: 'fr' | 'en'
+}
+
+/** Payload Brevo /v3/smtp/email (un email, un ou plusieurs destinataires). */
+export interface BrevoPollEmailPayload {
+  to: { email: string; name?: string }[]
+  subject: string
+  htmlContent: string
+  sender: { email: string; name: string }
+}
+
+export interface BrevoSendResult {
+  messageId: string | null
+}
+
+/** Erreur transitoire (rate limit Brevo 429) — déclenche le backoff. */
+export class BrevoRateLimitError extends Error {
+  constructor(message = 'Brevo 429: rate limited') {
+    super(message)
+    this.name = 'BrevoRateLimitError'
+  }
+}
+
+export interface PollEmailDeps {
+  /** Lit le poll cible (null si introuvable). */
+  getPoll: (pollId: string) => Promise<PollRow | null>
+  /** Nom du club (corps + footer email). */
+  getClubName: (clubId: string) => Promise<string>
+  /** Membres ACTIFS du club (status = 'active'). Source du club-scoping. */
+  listClubActiveMembers: (clubId: string) => Promise<PollMember[]>
+  /** user_id ayant déjà voté (exclusion rappel). Jamais retourné à l'appelant. */
+  listUsersWhoVoted: (pollId: string) => Promise<string[]>
+  /** Vrai si l'email (poll_id, variant) a DÉJÀ été envoyé (idempotence). */
+  alreadySent: (pollId: string, variant: PollEmailVariant) => Promise<boolean>
+  /** Marque l'envoi (INSERT poll_email_sends). Idempotent côté DB (UNIQUE). */
+  recordSent: (
+    pollId: string,
+    variant: PollEmailVariant,
+    recipientCount: number,
+    brevoMessageId: string | null
+  ) => Promise<void>
+  /** Rend l'email en HTML (React Email côté impl). */
+  renderHtml: (props: PollEmailRenderProps) => Promise<string>
+  /** Envoie l'email via Brevo. Lève BrevoRateLimitError sur 429. */
+  sendBrevo: (payload: BrevoPollEmailPayload) => Promise<BrevoSendResult>
+  /** Backoff injectable. */
+  sleep: (ms: number) => Promise<void>
+  /** Base URL de l'app membre (CTA email). Injectée depuis l'env côté impl ; le handler reste pur. */
+  appUrl?: string
+  /** Log diagnostic (injectable). */
+  log?: (level: 'info' | 'warn' | 'error', msg: string, meta?: Record<string, unknown>) => void
+}
+
+const MAX_BREVO_ATTEMPTS = 3
+const BACKOFF_BASE_MS = 500
+
+export interface PollEmailSummary {
+  variant: PollEmailVariant
+  sent: number
+  skipped: number
+  failed: number
+}
+
+/** Prénom à partir du full_name (1er token). */
+export function firstNameOf(fullName: string | null): string {
+  return (fullName ?? '').trim().split(/\s+/)[0] ?? ''
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+/** Sujet FR par variante. */
+function subjectFor(variant: PollEmailVariant, pollTitle: string): string {
+  switch (variant) {
+    case 'opened':
+      return `Un vote attend votre avis : ${pollTitle}`
+    case 'closed':
+      return `Résultats du vote : ${pollTitle}`
+    case 'reminder':
+      return `Dernière chance de voter : ${pollTitle}`
+  }
+}
+
+/** POST Brevo avec backoff exponentiel sur 429. */
+async function sendWithBackoff(
+  deps: PollEmailDeps,
+  payload: BrevoPollEmailPayload
+): Promise<BrevoSendResult> {
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= MAX_BREVO_ATTEMPTS; attempt++) {
+    try {
+      return await deps.sendBrevo(payload)
+    } catch (e) {
+      lastErr = e
+      if (e instanceof BrevoRateLimitError && attempt < MAX_BREVO_ATTEMPTS) {
+        await deps.sleep(BACKOFF_BASE_MS * 2 ** (attempt - 1))
+        continue
+      }
+      throw e
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr))
+}
+
+/**
+ * Envoie l'email de vote pour une variante donnée.
+ *
+ * 1. IDEMPOTENCE : si déjà envoyé (poll_id, variant) → skip (skipped = nb membres).
+ * 2. Résout les membres ACTIFS de `poll.club_id` UNIQUEMENT (reminder : moins les votants).
+ * 3. Rend l'email PAR MEMBRE (perso du prénom) et envoie via Brevo (un email/membre).
+ * 4. recordSent APRÈS succès du batch.
+ */
+export async function runPollEmail(
+  deps: PollEmailDeps,
+  input: { pollId: string; variant: PollEmailVariant }
+): Promise<PollEmailSummary> {
+  const log = deps.log ?? (() => {})
+  const { pollId, variant } = input
+  const summary: PollEmailSummary = { variant, sent: 0, skipped: 0, failed: 0 }
+
+  const poll = await deps.getPoll(pollId)
+  if (!poll) {
+    log('warn', 'Poll introuvable', { pollId })
+    return summary
+  }
+
+  // ── IDEMPOTENCE ──
+  if (await deps.alreadySent(pollId, variant)) {
+    // On compte les destinataires potentiels comme « skipped » (visibilité).
+    const members = await deps.listClubActiveMembers(poll.clubId)
+    summary.skipped = members.length
+    log('info', 'Email déjà envoyé (idempotence)', { pollId, variant })
+    return summary
+  }
+
+  // ── CLUB-SCOPING : membres actifs du club du poll uniquement ──
+  let members = await deps.listClubActiveMembers(poll.clubId)
+
+  // Rappel : exclure les membres ayant déjà voté.
+  if (variant === 'reminder') {
+    const voted = new Set(await deps.listUsersWhoVoted(pollId))
+    members = members.filter((m) => !voted.has(m.userId))
+  }
+
+  // Filtre les membres sans email (non envoyables).
+  const sendable = members.filter((m) => m.email.trim() !== '')
+  summary.skipped += members.length - sendable.length
+
+  if (sendable.length === 0) {
+    log('info', 'Aucun destinataire envoyable', { pollId, variant })
+    return summary
+  }
+
+  const clubName = await deps.getClubName(poll.clubId)
+  const appUrl = deps.appUrl
+  const subject = subjectFor(variant, poll.title)
+
+  // ── Envoi PAR MEMBRE (perso prénom) ──
+  let lastMessageId: string | null = null
+  for (const member of sendable) {
+    try {
+      const html = await deps.renderHtml({
+        memberFirstName: firstNameOf(member.fullName),
+        clubName,
+        pollTitle: poll.title,
+        pollDescription: poll.description ?? undefined,
+        questionType: poll.questionType,
+        closesAt: poll.closesAt,
+        variant,
+        appUrl,
+        locale: 'fr',
+      })
+      const result = await sendWithBackoff(deps, {
+        to: [{ email: member.email, name: (member.fullName ?? '').trim() || undefined }],
+        subject,
+        htmlContent: html,
+        sender: { email: 'no-reply@evolve.capital', name: 'Evolve Capital' },
+      })
+      lastMessageId = result.messageId
+      summary.sent += 1
+    } catch (e) {
+      // NON-ARRÊT : un membre en échec n'interrompt pas le batch.
+      log('error', 'Envoi email vote échoué', { pollId, variant, error: errMsg(e) })
+      summary.failed += 1
+    }
+  }
+
+  // ── Idempotence : marquer l'envoi si au moins un email est parti ──
+  if (summary.sent > 0) {
+    try {
+      await deps.recordSent(pollId, variant, summary.sent, lastMessageId)
+    } catch (e) {
+      log('warn', 'recordSent échoué', { pollId, variant, error: errMsg(e) })
+    }
+  }
+
+  return summary
+}

--- a/supabase/functions/send-poll-email/index.ts
+++ b/supabase/functions/send-poll-email/index.ts
@@ -1,0 +1,241 @@
+// Edge Function `send-poll-email` — email de vote (opened/closed/reminder) via Brevo
+// (PUSH-001 V1 email ; spec §7, §12).
+//
+// Déclenchement
+// -------------
+//   POST /functions/v1/send-poll-email   Body = { poll_id, variant }
+//   Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>
+//   → 200 { sent, skipped, failed }
+//
+//   Appelée par les Server Actions (service role) ou les jobs cron — jamais le browser.
+//   verify_jwt = false (config.toml) : le gateway ne valide pas la clé service-role.
+//
+// Parcours (handler pur, voir handler.ts)
+// ---------------------------------------
+//   Idempotence (poll_email_sends UNIQUE poll_id,variant) → membres ACTIFS de poll.club_id
+//   UNIQUEMENT (reminder : moins les votants) → rend l'email PAR MEMBRE (renderPollEmailHtml)
+//   → POST Brevo → recordSent.
+//
+// CLUB-SCOPING : `listClubActiveMembers(poll.club_id)` filtré `.eq('club_id', clubId)
+// .eq('status','active')` (réf send-monthly-attestations). Jamais un autre club.
+//
+// Sécurité : SUPABASE_SERVICE_ROLE_KEY (bypass RLS), strictement côté serveur.
+
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { BrevoRateLimitError, runPollEmail } from './handler.ts'
+import { alertSentry } from '../_shared/sentry.ts'
+import type {
+  BrevoPollEmailPayload,
+  BrevoSendResult,
+  PollEmailDeps,
+  PollEmailRenderProps,
+  PollEmailVariant,
+  PollMember,
+  PollRow,
+} from './handler.ts'
+
+const VALID_VARIANTS = new Set<PollEmailVariant>(['opened', 'closed', 'reminder'])
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** POST Brevo /v3/smtp/email. Lève BrevoRateLimitError sur 429. */
+async function sendBrevo(payload: BrevoPollEmailPayload): Promise<BrevoSendResult> {
+  const apiKey = Deno.env.get('BREVO_API_KEY') ?? ''
+  if (apiKey === '') throw new Error('BREVO_API_KEY manquante.')
+  const res = await fetch('https://api.brevo.com/v3/smtp/email', {
+    method: 'POST',
+    headers: {
+      'api-key': apiKey,
+      'content-type': 'application/json',
+      accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+  if (res.status === 429) {
+    await res.text().catch(() => '')
+    throw new BrevoRateLimitError()
+  }
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`Brevo ${res.status}: ${detail}`)
+  }
+  const body = (await res.json().catch(() => ({}))) as { messageId?: string }
+  return { messageId: body.messageId ?? null }
+}
+
+/** Câble les vraies deps (service-role client + renderPollEmailHtml + Brevo). */
+async function buildDeps(supabase: SupabaseClient): Promise<PollEmailDeps> {
+  // Import DYNAMIQUE de l'arbre React Email — hors du chemin testé (handler.ts).
+  const { renderPollEmailHtml } = await import('../../../packages/data/src/emails/index.ts')
+  const senderEmail = Deno.env.get('BREVO_SENDER_EMAIL') // optionnel ; sender par défaut dans le payload
+
+  return {
+    getPoll: async (pollId: string): Promise<PollRow | null> => {
+      const { data, error } = await supabase
+        .from('polls')
+        .select(
+          'id, club_id, title, description, question_type, closes_at, results_visibility, notify_by_email'
+        )
+        .eq('id', pollId)
+        .maybeSingle()
+      if (error) throw new Error(`Lecture poll échouée: ${error.message}`)
+      if (!data) return null
+      return {
+        id: data.id as string,
+        clubId: data.club_id as string,
+        title: (data.title as string) ?? '',
+        description: (data.description as string | null) ?? null,
+        questionType: data.question_type as PollRow['questionType'],
+        closesAt: (data.closes_at as string | null) ?? null,
+        resultsVisibility:
+          (data.results_visibility as PollRow['resultsVisibility']) ?? 'after_close',
+        notifyByEmail: (data.notify_by_email as boolean | null) ?? false,
+      }
+    },
+
+    getClubName: async (clubId: string): Promise<string> => {
+      const { data, error } = await supabase
+        .from('clubs')
+        .select('name')
+        .eq('id', clubId)
+        .maybeSingle()
+      if (error) throw new Error(`Lecture club échouée: ${error.message}`)
+      return (data?.name as string) ?? ''
+    },
+
+    listClubActiveMembers: async (clubId: string): Promise<PollMember[]> => {
+      // CLUB-SCOPING à la source (réf send-monthly-attestations).
+      const { data, error } = await supabase
+        .from('memberships')
+        .select('user_id, status, users(email, full_name)')
+        .eq('club_id', clubId)
+        .eq('status', 'active')
+      if (error) throw new Error(`Lecture membres échouée: ${error.message}`)
+      return (data ?? []).map((m) => {
+        const u = Array.isArray(m.users) ? m.users[0] : m.users
+        return {
+          email: ((u?.email as string) ?? '').trim(),
+          fullName: (u?.full_name as string) ?? null,
+          userId: (m.user_id as string) ?? '',
+        }
+      })
+    },
+
+    listUsersWhoVoted: async (pollId: string): Promise<string[]> => {
+      // service_role uniquement (poll_responses.user_id jamais exposé à authenticated).
+      const { data, error } = await supabase
+        .from('poll_responses')
+        .select('user_id')
+        .eq('poll_id', pollId)
+      if (error) throw new Error(`Lecture poll_responses échouée: ${error.message}`)
+      const ids = new Set<string>()
+      for (const r of data ?? []) {
+        const id = r.user_id as string | null
+        if (id) ids.add(id)
+      }
+      return [...ids]
+    },
+
+    alreadySent: async (pollId: string, variant: PollEmailVariant): Promise<boolean> => {
+      const { data, error } = await supabase
+        .from('poll_email_sends')
+        .select('id')
+        .eq('poll_id', pollId)
+        .eq('variant', variant)
+        .maybeSingle()
+      if (error) throw new Error(`Lecture poll_email_sends échouée: ${error.message}`)
+      return data != null
+    },
+
+    recordSent: async (
+      pollId: string,
+      variant: PollEmailVariant,
+      recipientCount: number,
+      brevoMessageId: string | null
+    ): Promise<void> => {
+      const { error } = await supabase.from('poll_email_sends').insert({
+        poll_id: pollId,
+        variant,
+        recipient_count: recipientCount,
+        brevo_message_id: brevoMessageId,
+      })
+      // Course : la contrainte UNIQUE renvoie 23505 — on l'avale (idempotent).
+      if (error && error.code !== '23505') {
+        throw new Error(`Insert poll_email_sends échoué: ${error.message}`)
+      }
+    },
+
+    renderHtml: (props: PollEmailRenderProps): Promise<string> => renderPollEmailHtml(props),
+
+    sendBrevo: senderEmail
+      ? (payload) =>
+          sendBrevo({ ...payload, sender: { email: senderEmail, name: 'Evolve Capital' } })
+      : sendBrevo,
+
+    sleep: (ms: number) => new Promise((r) => setTimeout(r, ms)),
+
+    appUrl: Deno.env.get('APP_URL') ?? undefined,
+
+    log: (level, msg, meta) => {
+      const line = `[send-poll-email] ${msg}${meta ? ' ' + JSON.stringify(meta) : ''}`
+      if (level === 'error') console.error(line)
+      else if (level === 'warn') console.warn(line)
+      else console.log(line)
+    },
+  }
+}
+
+// ---- Entrypoint de production ----
+if (import.meta.main) {
+  Deno.serve(async (req: Request) => {
+    let pollId: string | undefined
+    let variant: PollEmailVariant | undefined
+    try {
+      const body = (await req.json().catch(() => ({}))) as {
+        poll_id?: string
+        variant?: string
+      }
+      if (typeof body.poll_id === 'string' && body.poll_id.trim() !== '') pollId = body.poll_id
+      if (
+        typeof body.variant === 'string' &&
+        VALID_VARIANTS.has(body.variant as PollEmailVariant)
+      ) {
+        variant = body.variant as PollEmailVariant
+      }
+    } catch {
+      // corps illisible
+    }
+    if (!pollId || !variant) {
+      return json({ ok: false, error: 'poll_id et variant (opened|closed|reminder) requis' }, 400)
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    try {
+      const deps = await buildDeps(supabase)
+      const summary = await runPollEmail(deps, { pollId, variant })
+      return json({ ok: true, ...summary })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      const dsn = Deno.env.get('SENTRY_DSN')
+      await alertSentry(dsn, {
+        club_id: 'send-poll-email',
+        errors: [message],
+        sheets: ['send-poll-email'],
+      }).catch(() => {})
+      return json({ ok: false, error: message }, 500)
+    }
+  })
+}
+
+export { buildDeps, sendBrevo }

--- a/supabase/functions/send-poll-email/index.ts
+++ b/supabase/functions/send-poll-email/index.ts
@@ -26,6 +26,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { BrevoRateLimitError, runPollEmail } from './handler.ts'
 import { alertSentry } from '../_shared/sentry.ts'
+import { parseAllowlist } from '../_shared/notify-allowlist.ts'
 import type {
   BrevoPollEmailPayload,
   BrevoSendResult,
@@ -182,6 +183,9 @@ async function buildDeps(supabase: SupabaseClient): Promise<PollEmailDeps> {
     sleep: (ms: number) => new Promise((r) => setTimeout(r, ms)),
 
     appUrl: Deno.env.get('APP_URL') ?? undefined,
+
+    // Allowlist de TEST (NOTIFY_ALLOWLIST = emails). Vide → tous les membres (normal).
+    allowlistEmails: parseAllowlist(Deno.env.get('NOTIFY_ALLOWLIST')),
 
     log: (level, msg, meta) => {
       const line = `[send-poll-email] ${msg}${meta ? ' ' + JSON.stringify(meta) : ''}`

--- a/supabase/migrations/039_push_notifications.sql
+++ b/supabase/migrations/039_push_notifications.sql
@@ -1,0 +1,266 @@
+-- 039_push_notifications.sql — Web Push V0 (PUSH-001 ; spec docs/superpowers/specs/2026-06-16-web-push-notifications-design.md §4, §8).
+--
+-- QUOI : la brique de persistance des notifications Web Push (abonnements navigateur,
+--   préférences par membre, journal d'envoi agrégé), l'idempotence des emails de vote,
+--   l'évolution de `close_due_polls()` pour piloter la push post-clôture, et deux jobs
+--   pg_cron (rappel J-1 + push post-clôture) gardés par le Vault (dormants en local).
+--
+-- ANONYMAT / RGPD BY DESIGN (§2.2, §10) :
+--   • Le payload push ne transporte QUE `pollId` / `clubId` / `type` / `url` — JAMAIS de
+--     PII (pas de user_id, email, nom, ni « X membres ont voté »). Aucune table ici ne
+--     stocke un contenu de réponse ; `push_delivery_log` n'a que des compteurs agrégés.
+--   • `push_subscriptions.last_error_code` ne garde QUE le code HTTP (ex. '410', '404'),
+--     jamais le corps de la réponse du service de push.
+--
+-- RLS (CLAUDE.md : RLS obligatoire dès la création, jamais joignable sans policy) :
+--   push_subscriptions : OWNER-ONLY — le membre gère SES propres abonnements (user_id = auth.uid()).
+--   push_preferences   : OWNER-ONLY (FOR ALL) — préférences par utilisateur.
+--   push_delivery_log  : AUCUN accès `authenticated` — service_role uniquement (debug staff réseau).
+--   poll_email_sends   : AUCUN accès `authenticated` — service_role uniquement (idempotence envoi).
+--
+-- GRANTS EXPLICITES (Data API) : l'auto-exposition implicite des nouvelles tables est
+--   désactivée depuis 2026-05-30 (cf. supabase/config.toml `auto_expose_new_tables`). Sans
+--   GRANT explicite, toute requête PostgREST en rôle `authenticated` échoue en 42501 même si
+--   une policy RLS l'autorise. On accorde donc les privilèges au niveau table ; la RLS reste
+--   la garde fine sur les lignes/opérations.
+--
+-- Réf : migration 038 (polls / poll_responses / close_due_polls — étendue ici ; style RLS,
+--   GRANTs explicites, pattern pg_cron), 032 (crons sécurisés via Vault — réutilisé tel quel),
+--   028 (is_club_staff fail-closed), 036 (style table/RLS/commentaires).
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+-- Vault (fourni par l'image Supabase ; idempotent). Source des secrets des jobs pg_cron.
+CREATE EXTENSION IF NOT EXISTS supabase_vault;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 1 · push_subscriptions — un endpoint navigateur = une ligne (multi-appareils par user).
+-- ════════════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS public.push_subscriptions (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+
+  user_id      uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  endpoint     text NOT NULL UNIQUE,                     -- clé d'upsert côté API (un endpoint = un appareil)
+  p256dh       text NOT NULL,                            -- clé publique de chiffrement (keys.p256dh)
+  auth         text NOT NULL,                            -- secret d'authentification (keys.auth)
+
+  user_agent   text,                                     -- snapshot debug support — pas de PII identifiante
+  -- Snapshot de plateforme pour le support (« iPhone Safari PWA »). CHECK = miroir de
+  -- PushPlatformCapability/PwaCase côté client (lib/push). 'unknown' = fallback safe.
+  platform     text CHECK (platform IN ('desktop','android-chrome','ios-safari','ios-other','standalone','unknown')),
+
+  last_success_at timestamptz,                           -- dernier push livré (200/201)
+  last_error_at   timestamptz,                           -- dernier échec d'envoi
+  last_error_code text                                   -- CODE HTTP seul (ex. '410','404') — jamais le corps
+);
+
+COMMENT ON TABLE public.push_subscriptions IS
+  'Abonnements Web Push (un endpoint navigateur = une ligne, multi-appareils par user). OWNER-ONLY via RLS ; l''Edge dispatch-push lit en service_role et purge les endpoints 410/404. Aucune PII : pas d''email ni de contenu de réponse.';
+
+CREATE INDEX IF NOT EXISTS push_subscriptions_user_id_idx ON public.push_subscriptions (user_id);
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 2 · push_preferences — préférences PAR UTILISATEUR (pas par appareil). Ligne créée
+--     au premier subscribe (UPSERT défauts ON). Tout ON par défaut = opt-in déjà consenti.
+-- ════════════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS public.push_preferences (
+  user_id        uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+
+  enabled        boolean NOT NULL DEFAULT true,          -- toggle master (off = aucun envoi, tous types)
+  poll_opened    boolean NOT NULL DEFAULT true,          -- « Nouveau vote »
+  poll_closed    boolean NOT NULL DEFAULT true,          -- « Résultats disponibles »
+  poll_reminder  boolean NOT NULL DEFAULT true           -- « Il vous reste 24 h pour voter »
+);
+
+COMMENT ON TABLE public.push_preferences IS
+  'Préférences Web Push par utilisateur (master + sous-préférences par type). OWNER-ONLY via RLS. L''Edge dispatch-push filtre les destinataires sur enabled + la colonne du type d''événement.';
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 3 · push_delivery_log — journal d'envoi AGRÉGÉ (debug staff réseau). SANS PII :
+--     que des compteurs. Aucun accès `authenticated` ; service_role uniquement.
+-- ════════════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS public.push_delivery_log (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  event_type    text NOT NULL,                           -- ex. 'poll.opened' (string libre = extensible)
+  club_id       uuid REFERENCES public.clubs (id),
+  poll_id       uuid REFERENCES public.polls (id),
+  sent_count    int NOT NULL DEFAULT 0,
+  failed_count  int NOT NULL DEFAULT 0,
+  skipped_count int NOT NULL DEFAULT 0
+);
+
+COMMENT ON TABLE public.push_delivery_log IS
+  'Journal d''envoi push AGRÉGÉ (compteurs sent/failed/skipped par événement) — debug staff réseau. AUCUNE PII, aucun destinataire individuel. service_role uniquement.';
+
+CREATE INDEX IF NOT EXISTS push_delivery_log_club_created_idx ON public.push_delivery_log (club_id, created_at DESC);
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 4 · poll_email_sends — idempotence des emails de vote (V1 email Brevo, table posée en
+--     V0). UNIQUE(poll_id, variant) ⇒ empêche un double envoi (publish/close/reminder)
+--     même si un cron rejoue ou une Edge est retriée. service_role uniquement.
+-- ════════════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS public.poll_email_sends (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id          uuid NOT NULL REFERENCES public.polls (id) ON DELETE CASCADE,
+  variant          text NOT NULL CHECK (variant IN ('opened','closed','reminder')),
+  sent_at          timestamptz NOT NULL DEFAULT now(),
+  recipient_count  int NOT NULL DEFAULT 0,
+  brevo_message_id text,
+  UNIQUE (poll_id, variant)                              -- garde-fou anti double-envoi (1 email par variante/poll)
+);
+
+COMMENT ON TABLE public.poll_email_sends IS
+  'Idempotence des emails de vote (opened/closed/reminder). UNIQUE(poll_id,variant) empêche un double envoi si un cron rejoue. service_role uniquement (l''Edge d''envoi marque l''envoi).';
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- RLS (§4.3)
+-- ════════════════════════════════════════════════════════════════════════════
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_preferences   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_delivery_log  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poll_email_sends   ENABLE ROW LEVEL SECURITY;
+
+-- ── push_subscriptions : OWNER-ONLY (le membre gère SES abonnements uniquement) ──
+DROP POLICY IF EXISTS "push_subscriptions: owner select" ON public.push_subscriptions;
+DROP POLICY IF EXISTS "push_subscriptions: owner insert" ON public.push_subscriptions;
+DROP POLICY IF EXISTS "push_subscriptions: owner update" ON public.push_subscriptions;
+DROP POLICY IF EXISTS "push_subscriptions: owner delete" ON public.push_subscriptions;
+
+CREATE POLICY "push_subscriptions: owner select"
+  ON public.push_subscriptions FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner insert"
+  ON public.push_subscriptions FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner update"
+  ON public.push_subscriptions FOR UPDATE TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "push_subscriptions: owner delete"
+  ON public.push_subscriptions FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- ── push_preferences : lecture/écriture propre user (FOR ALL) ────────────────────
+DROP POLICY IF EXISTS "push_preferences: owner all" ON public.push_preferences;
+
+CREATE POLICY "push_preferences: owner all"
+  ON public.push_preferences FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+-- ── push_delivery_log & poll_email_sends : AUCUNE policy `authenticated` ─────────
+-- RLS activée + zéro policy ⇒ aucune ligne joignable par `authenticated`/`anon`.
+-- Seul service_role (BYPASSRLS implicite + GRANT ci-dessous) y accède.
+
+-- ── Grants table explicites (Data API désactive l'auto-exposition) ──────────────
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_subscriptions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.push_preferences   TO authenticated;
+-- Pas de GRANT à authenticated sur push_delivery_log / poll_email_sends : service_role only.
+GRANT ALL ON public.push_subscriptions TO service_role;
+GRANT ALL ON public.push_preferences   TO service_role;
+GRANT ALL ON public.push_delivery_log  TO service_role;
+GRANT ALL ON public.poll_email_sends   TO service_role;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- close_due_polls() — §8.3 option A : retourne les polls clôturés (id, club_id) pour
+-- que le cron post-clôture dispatch `poll.closed` par poll. Rétro-compatible :
+-- `SELECT close_due_polls();` reste valide (renvoie désormais des lignes au lieu d'un int).
+-- SECURITY DEFINER + search_path conservés (migration 038).
+-- ════════════════════════════════════════════════════════════════════════════
+-- DROP requis : on change le type de retour (integer → TABLE), PG refuse un simple
+-- CREATE OR REPLACE quand la signature de sortie diffère.
+DROP FUNCTION IF EXISTS public.close_due_polls();
+
+CREATE FUNCTION public.close_due_polls()
+RETURNS TABLE (poll_id uuid, club_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  RETURN QUERY
+  UPDATE public.polls
+     SET status = 'closed',
+         closed_manually_at = now()
+   WHERE status = 'open'
+     AND closes_at IS NOT NULL
+     AND closes_at < now()
+  RETURNING id, polls.club_id;   -- qualifié : évite l'ambiguïté avec la colonne OUT `club_id`
+END;
+$$;
+REVOKE ALL ON FUNCTION public.close_due_polls() FROM public;
+-- Pas de GRANT à authenticated : appelée uniquement par le cron (rôle postgres).
+
+-- Le job horaire `close-due-polls` (migration 038) appelle toujours `SELECT close_due_polls();`
+-- → rétro-compatible (le SELECT consomme les lignes retournées, la clôture s'opère pareil).
+-- On ne le re-planifie PAS ici.
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- Jobs pg_cron Web Push — sécurisés via Vault (pattern migration 032). DORMANTS EN
+-- LOCAL : sans secrets Vault peuplés, le CROSS JOIN renvoie 0 ligne ⇒ le job NO-OP
+-- proprement (aucun POST, aucune erreur). C'est attendu et identique au pattern existant.
+--
+-- URLs Edge à fournir par l'owner / l'agent EDGE (hors migration, jamais committé) :
+--   select vault.create_secret('https://<ref>.supabase.co/functions/v1/poll-push-reminders', 'poll_push_reminders_url');
+--   select vault.create_secret('https://<ref>.supabase.co/functions/v1/poll-closed-push',     'poll_closed_push_url');
+--   (service_role_key déjà posé en prod — cf. migration 032.)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- ── (a) Rappel vote J-1 — quotidien 09:00 Europe/Paris (= 07:00 UTC en heure d'été,
+--     08:00 en heure d'hiver ; pg_cron est en UTC, on vise 07:00 UTC comme approximation
+--     stable). L'Edge `poll-push-reminders` sélectionne les polls open closes_at dans 24h,
+--     filtre les membres n'ayant pas voté, et dispatch `poll.reminder`. ──────────────
+SELECT cron.unschedule('poll-push-reminders') WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'poll-push-reminders'
+);
+
+SELECT cron.schedule(
+  'poll-push-reminders',
+  '0 7 * * *',                                           -- tous les jours à 07:00 UTC (~09:00 Paris)
+  $$
+  SELECT net.http_post(
+    url := u.val,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || k.val
+    ),
+    body := '{}'::jsonb
+  )
+  FROM (SELECT decrypted_secret AS val FROM vault.decrypted_secrets WHERE name = 'poll_push_reminders_url' LIMIT 1) u
+  CROSS JOIN (SELECT decrypted_secret AS val FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1) k
+  WHERE u.val IS NOT NULL
+    AND k.val IS NOT NULL;
+  $$
+);
+
+-- ── (b) Push post-clôture — horaire, aligné sur `close-due-polls`. L'Edge `poll-closed-push`
+--     ré-exécute close_due_polls() (ou lit les polls fraîchement clôturés) et dispatch
+--     `poll.closed` par poll. Décalé de 5 min après l'heure pile pour laisser
+--     `close-due-polls` (0 * * * *) basculer les statuts avant. ──────────────────────
+SELECT cron.unschedule('poll-closed-push') WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'poll-closed-push'
+);
+
+SELECT cron.schedule(
+  'poll-closed-push',
+  '5 * * * *',                                           -- toutes les heures à HH:05 (après close-due-polls)
+  $$
+  SELECT net.http_post(
+    url := u.val,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || k.val
+    ),
+    body := '{}'::jsonb
+  )
+  FROM (SELECT decrypted_secret AS val FROM vault.decrypted_secrets WHERE name = 'poll_closed_push_url' LIMIT 1) u
+  CROSS JOIN (SELECT decrypted_secret AS val FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1) k
+  WHERE u.val IS NOT NULL
+    AND k.val IS NOT NULL;
+  $$
+);


### PR DESCRIPTION
## Résumé

Implémente **PUSH-001** (spec `docs/superpowers/specs/2026-06-16-web-push-notifications-design.md`) : notifications Web Push système (hors-app) + email transactionnel à l'ouverture d'un vote. **Stacked sur la PR #39** (vote anonyme) dont elle dépend.

## Périmètre

- **DB** (`039_push_notifications.sql`) : `push_subscriptions` + `push_preferences` + `push_delivery_log` + `poll_email_sends` (RLS owner-only, GRANTs explicites). `close_due_polls()` renvoie `(poll_id, club_id)`. Crons rappel J-1 + push post-clôture (Vault-gardés, dormants sans secrets).
- **Edge** : `dispatch-push` (web-push VAPID, purge 410/404), `send-poll-email` (Brevo + idempotence), `poll-push-reminders`, `poll-closed-push`. `config.toml` épingle `verify_jwt=false`.
- **Data/Types** : `dispatchNotification()`, templates anonymes, `PollEmail` (3 variants), contrat `NotificationEvent`.
- **Web** : SW `pwa-v2` (push/notificationclick), `lib/push/*`, pré-prompt opt-in, section Notifications `/profil`, routes `api/push/*`, events GA4 `push_*`, i18n `push.*` (parité fr/en).
- **Intégration vote** : publication → push + email (fire-and-forget) ; clôture → push.

## 🔒 Anonymat & anti-fuite inter-club

Destinataires résolus **uniquement** par le `club_id` du vote (`memberships … club_id = poll.club_id AND status='active'`), jamais `network_wide`. Défense en profondeur dans `dispatch-push` (re-filtre Set). Payload push **sans PII**. Prouvé par 3 suites de tests à 2 clubs (push / email / action vote) + test no-PII des templates.

## QA

`make lint typecheck test` **exit 0** (utils 62 / data 221 / ui 558 / web 427). Edge Deno **18/18**. Conformité visuelle vs maquette **≥ 90 %** (pré-prompt ~93 %, profil ~90 %) — `docs/qa/QA_REPORT_2026-06-16-web-push.md`. Correctifs design chirurgicaux sans toucher `packages/ui` (`PwaInstallSheet` inchangé).

## ⚠️ Reste owner (déploiement)

- Le vrai push exige une **preview HTTPS** (SW prod-only + permission) — non testable en localhost.
- Secrets : `VAPID_*` (Edge), `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (Vercel), `BREVO_*`, Vault `poll_push_reminders_url` + `poll_closed_push_url`. Déployer les 4 Edge Functions.

## Follow-up (V1)
Bouton « Tester une notification » (`system.test` ciblé appareil + rate-limit), email closed/reminder câblés, copy push i18n EN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)