### PR TITLE
fix(web): corrige 3 retours prod (carte valo club, ville/pays au sync, attestation PWA)

### DIFF
--- a/apps/web/app/(app)/contributions/ContributionsView.tsx
+++ b/apps/web/app/(app)/contributions/ContributionsView.tsx
@@ -28,10 +28,15 @@ import {
 import { formatCurrency } from '@evolve/utils'
 
 import { analyticsEvents } from '@/lib/analytics'
-import { openAttestation } from '@/lib/attestation/openAttestation'
+import {
+  chooseAttestationStrategy,
+  downloadAttestationBlob,
+  openAttestation,
+} from '@/lib/attestation/openAttestation'
 import type { ContributionsData, ContributionStatus } from '@/lib/data/contributions'
 import { useContributions } from '@/lib/hooks/useContributions'
 import { useSyncStatus } from '@/lib/hooks/useSyncStatus'
+import { detectPwaCase } from '@/lib/pwa/platform-detection'
 
 // La variante visuelle (couleur) du Pill reste interne ; seul le libellé est externalisé (i18n).
 const STATUS_PILL: Record<ContributionStatus, PillStatus> = {
@@ -71,35 +76,59 @@ export function ContributionsView({
     },
   })
 
-  // Ouvre le PDF d'attestation dans un nouvel onglet (lecture inline — meilleure UX mobile).
+  // Délivre le PDF d'attestation selon le contexte (web vs PWA installée).
   //
-  // FIX iOS (CHANTIER 3) : l'ancien flux `fetch → blob → a.click()` plaçait l'ouverture APRÈS
-  // un `await`, ce qui casse sur iOS Safari (le geste utilisateur synchrone est perdu → popup
-  // bloquée, rien ne s'ouvre). On rend donc l'ouverture SYNCHRONE : `window.open(url)` est la
-  // 1re action du onClick, sur l'URL GET de la route (qui sert déjà le PDF `inline` via le cookie
-  // d'auth — pas besoin de fetch côté client). Aucun `await` avant le window.open.
+  // WEB / navigateur (y compris iOS Safari hors-PWA) : ouverture SYNCHRONE dans un nouvel onglet.
+  // L'ouverture est la 1re action du onClick, sans `await` préalable → préserve le geste
+  // utilisateur sur iOS Safari (sinon popup bloquée). La route sert déjà le PDF `inline` via le
+  // cookie d'auth. FIX RT-04 : le helper `openAttestation` ne passe PAS 'noopener' (sinon
+  // window.open renvoie `null` même en succès → faux toast d'erreur). Erreur QUE si 'blocked'.
   //
-  // FIX RT-04 : on délègue l'ouverture au helper pur `openAttestation` qui ne passe PLUS 'noopener'
-  // — avec 'noopener', window.open renvoyait `null` même en cas de SUCCÈS (faux toast d'erreur
-  // persistant à chaque clic). On n'affiche donc l'erreur QUE si le helper renvoie 'blocked'.
+  // FIX PWA iOS (standalone) : dans une PWA installée, `_blank` navigue SUR PLACE → le PDF inline
+  // remplit l'unique vue sans retour possible (utilisateur piégé). On télécharge alors le PDF en
+  // blob (`<a download>`) → iOS ouvre l'aperçu Fichiers avec un bouton « OK » qui ramène dans l'app.
   function downloadAttestation() {
     if (downloading) return
     setAttestationError(null)
     const clubId = data?.clubId
     const qs = clubId ? `?clubId=${encodeURIComponent(clubId)}` : ''
-    const result = openAttestation(window.open.bind(window), `/api/attestation/detention${qs}`)
-    if (result === 'blocked') {
-      // Popup réellement bloquée (navigateur/extension) → erreur inline persistante (role=alert) + toast.
+    const url = `/api/attestation/detention${qs}`
+
+    const fail = () => {
       setAttestationError(t('attestation.error'))
       toast.error({ title: t('attestation.error') })
+    }
+    const succeed = () => {
+      toast.success({ title: t('attestation.success') })
+      // 🎯 attestation_download (key event) — succès uniquement, déclenchement in-app.
+      analyticsEvents.attestation.downloaded({ triggerSource: 'in_app' })
+    }
+
+    if (chooseAttestationStrategy(detectPwaCase()) === 'download') {
+      // PWA standalone : téléchargement blob (asynchrone) — flag visuel maintenu le temps du fetch.
+      setDownloading(true)
+      void downloadAttestationBlob(url, 'attestation-detention.pdf').then((r) => {
+        setDownloading(false)
+        if (r === 'error') {
+          fail()
+          return
+        }
+        succeed()
+      })
+      return
+    }
+
+    // Web : ouverture synchrone dans un nouvel onglet.
+    const result = openAttestation(window.open.bind(window), url)
+    if (result === 'blocked') {
+      // Popup réellement bloquée (navigateur/extension) → erreur inline persistante (role=alert) + toast.
+      fail()
       return
     }
     // Confirmation éphémère + flag visuel bref (l'ouverture n'est pas toujours visible).
     setDownloading(true)
     setTimeout(() => setDownloading(false), 1500)
-    toast.success({ title: t('attestation.success') })
-    // 🎯 attestation_download (key event) — succès uniquement, déclenchement in-app.
-    analyticsEvents.attestation.downloaded({ triggerSource: 'in_app' })
+    succeed()
   }
 
   async function refresh() {

--- a/apps/web/components/dashboard/DashboardViewV2.tsx
+++ b/apps/web/components/dashboard/DashboardViewV2.tsx
@@ -13,7 +13,11 @@
 //     branché sur variations.d1 (null → pas de badge — jamais de NaN). Pas de label demo.
 //   - DEMO  : `chartData` null (aucune ligne REPORTING / erreur serveur) → séries demo
 //     déterministes ILLUSTRATIVES, comportement historique STRICTEMENT inchangé, label
-//     « Courbe illustrative » affiché. Le teaser club desktop reste demo dans les deux modes.
+//     « Courbe illustrative » affiché.
+//
+// Le teaser « Portefeuille du club » (desktop) affiche la valo club RÉELLE (agrégat
+// « Portefeuille » de portfolio_aggregates, via DashboardData.clubPortfolio) dans les deux
+// modes — même source que /portfolio, fin du montant demo codé en dur.
 //
 // Réf : PROMPT-DEV-DASHBOARD-V2-AB, DSH-011/DSH-012, CLAUDE.md (jamais de NaN, a11y, tokens).
 
@@ -46,11 +50,7 @@ import { type DashboardData } from '@/lib/data/dashboard'
 // Import type-only : dashboard-chart.ts est un module serveur (requêtes Supabase) — seul
 // son CONTRAT est consommé ici, effacé à la compilation (aucun code serveur dans le bundle).
 import type { DashboardChartData } from '@/lib/data/dashboard-chart'
-import {
-  DEMO_CLUB_PORTFOLIO,
-  getDemoEvolutionSeries,
-  getDemoVariation1d,
-} from '@/lib/data/dashboard-chart-demo'
+import { getDemoEvolutionSeries, getDemoVariation1d } from '@/lib/data/dashboard-chart-demo'
 import { downsample, slicePeriod, summarize } from '@/lib/data/dashboard-chart-view'
 import { useDashboard } from '@/lib/hooks/useDashboard'
 import { useSyncStatus } from '@/lib/hooks/useSyncStatus'
@@ -480,8 +480,10 @@ export function DashboardViewV2({
           </section>
 
           {/* Teaser « Portefeuille du club » — desktop. Card entière cliquable (Link →
-              cursor géré par la règle globale a[href]). Valorisation DEMO : la valeur club
-              réelle n'est pas exposée aux membres en V0 (/api/admin/* est réservé staff). */}
+              cursor géré par la règle globale a[href]). Valorisation RÉELLE : même source que la
+              page /portfolio (agrégat « Portefeuille »), pour des valeurs cohérentes entre les
+              deux écrans. Badge = gain/perte total (valeur de marché vs prix d'achat) ; masqué si
+              le prix d'achat club est absent. Valeur « — » si l'agrégat n'est pas encore synchronisé. */}
           <Link
             href="/portfolio"
             className="group hidden flex-col gap-1 rounded-[10px] border border-border bg-card px-4 py-3 shadow-[var(--sh-card)] outline-none hover:border-accent focus-visible:shadow-[var(--sh-glow)] motion-safe:transition-colors motion-safe:duration-[var(--dur-fast)] lg:flex"
@@ -492,12 +494,16 @@ export function DashboardViewV2({
             <p className="text-[13px] text-text-sec">{data.club.name}</p>
             <div className="flex flex-wrap items-center gap-2">
               <span className="font-display text-[22px] font-bold tabular-nums text-text">
-                {currNoCents(DEMO_CLUB_PORTFOLIO.totalValuation, currency)}
+                {data.clubPortfolio.value !== null
+                  ? currNoCents(data.clubPortfolio.value, currency)
+                  : '—'}
               </span>
-              <TrendBadge
-                direction="up"
-                value={formatPct(DEMO_CLUB_PORTFOLIO.variation1dPercent / 100)}
-              />
+              {data.clubPortfolio.gainLossPct !== null ? (
+                <TrendBadge
+                  direction={data.clubPortfolio.gainLossPct >= 0 ? 'up' : 'down'}
+                  value={formatPct(data.clubPortfolio.gainLossPct)}
+                />
+              ) : null}
             </div>
             <span className="mt-1 text-[13px] font-semibold text-text group-hover:underline">
               {t('v2.club.viewDetail')} <span aria-hidden="true">→</span>

--- a/apps/web/lib/attestation/openAttestation.test.ts
+++ b/apps/web/lib/attestation/openAttestation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { openAttestation } from './openAttestation'
+import { chooseAttestationStrategy, openAttestation } from './openAttestation'
 
 // RT-04 — Régression du faux popup « génération échouée ».
 //
@@ -49,5 +49,20 @@ describe('openAttestation', () => {
     if (features !== undefined) {
       expect(features).not.toContain('noopener')
     }
+  })
+})
+
+// FIX PWA iOS (standalone) — la stratégie d'ouverture dépend du contexte PWA.
+describe('chooseAttestationStrategy', () => {
+  it("télécharge (blob) en PWA installée (standalone) — sinon l'utilisateur reste piégé", () => {
+    expect(chooseAttestationStrategy('standalone')).toBe('download')
+  })
+
+  it('ouvre un nouvel onglet partout ailleurs (web, iOS Safari hors-PWA, Android, desktop)', () => {
+    expect(chooseAttestationStrategy('ios-safari')).toBe('open')
+    expect(chooseAttestationStrategy('ios-other')).toBe('open')
+    expect(chooseAttestationStrategy('android-chrome')).toBe('open')
+    expect(chooseAttestationStrategy('desktop')).toBe('open')
+    expect(chooseAttestationStrategy('unsupported')).toBe('open')
   })
 })

--- a/apps/web/lib/attestation/openAttestation.ts
+++ b/apps/web/lib/attestation/openAttestation.ts
@@ -27,3 +27,57 @@ export function openAttestation(open: Window['open'], url: string): 'opened' | '
   const handle = open(url, '_blank')
   return handle ? 'opened' : 'blocked'
 }
+
+// --- FIX PWA iOS (standalone) ---------------------------------------------------------------
+//
+// Dans une PWA INSTALLÉE (display-mode: standalone), il n'existe pas de « nouvel onglet » :
+// `window.open(url, '_blank')` NAVIGUE SUR PLACE vers le PDF servi `inline` par la route → le
+// PDF remplit l'unique vue, sans barre d'adresse, sans bouton retour : l'utilisateur est PIÉGÉ
+// (aucun moyen de revenir dans l'app ni de télécharger). Sur le web/navigateur, `_blank` ouvre
+// un vrai onglet → comportement nominal conservé.
+//
+// On choisit donc la stratégie selon le contexte PWA : `'download'` en standalone (blob +
+// `<a download>` → iOS ouvre l'aperçu Fichiers/Quick Look AVEC un bouton « OK » qui ramène dans
+// l'app), `'open'` partout ailleurs (ouverture synchrone, geste utilisateur préservé).
+
+import type { PwaCase } from '@evolve/types'
+
+/**
+ * Décision PURE (testable en env. `node`) : faut-il OUVRIR (nouvel onglet) ou TÉLÉCHARGER (blob) ?
+ * Seul le mode `standalone` (PWA installée) impose le téléchargement — sinon l'utilisateur reste
+ * piégé sur le PDF inline. iOS Safari hors-PWA (`ios-safari`) garde l'ouverture en onglet (OK).
+ */
+export function chooseAttestationStrategy(pwaCase: PwaCase): 'open' | 'download' {
+  return pwaCase === 'standalone' ? 'download' : 'open'
+}
+
+/**
+ * Télécharge le PDF d'attestation en blob puis déclenche un `<a download>` (cas PWA standalone).
+ * Asynchrone (fetch) : réservé au standalone car le geste utilisateur n'est PAS requis pour un
+ * download d'ancre (≠ popup `window.open`, bloquée si différée). `doc` injectable pour les tests.
+ * @returns `'downloaded'` si le clic a été déclenché, `'error'` en cas d'échec réseau/lecture.
+ */
+export async function downloadAttestationBlob(
+  url: string,
+  filename: string,
+  doc: Document = document
+): Promise<'downloaded' | 'error'> {
+  try {
+    const res = await fetch(url, { credentials: 'same-origin' })
+    if (!res.ok) return 'error'
+    const blob = await res.blob()
+    const objectUrl = URL.createObjectURL(blob)
+    const a = doc.createElement('a')
+    a.href = objectUrl
+    a.download = filename
+    a.rel = 'noopener'
+    doc.body.appendChild(a)
+    a.click()
+    a.remove()
+    // Révocation différée : laisse iOS lire le blob avant de libérer l'URL objet.
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000)
+    return 'downloaded'
+  } catch {
+    return 'error'
+  }
+}

--- a/apps/web/lib/data/dashboard-chart-demo.test.ts
+++ b/apps/web/lib/data/dashboard-chart-demo.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { EvolutionPeriod } from '@evolve/ui'
 
-import {
-  DEMO_CLUB_PORTFOLIO,
-  getDemoEvolutionSeries,
-  getDemoVariation1d,
-} from './dashboard-chart-demo'
+import { getDemoEvolutionSeries, getDemoVariation1d } from './dashboard-chart-demo'
 
 const ANCHOR = '2026-06-10T08:00:00.000Z'
 const FINAL = 65574.87
@@ -107,12 +103,5 @@ describe('getDemoVariation1d', () => {
     const v = getDemoVariation1d(ANCHOR, Number.NaN)
     expect(v.amount).toBe(0)
     expect(Number.isFinite(v.percent)).toBe(true)
-  })
-})
-
-describe('DEMO_CLUB_PORTFOLIO', () => {
-  it('expose la valorisation demo du club et sa variation 1j', () => {
-    expect(DEMO_CLUB_PORTFOLIO.totalValuation).toBe(708408)
-    expect(DEMO_CLUB_PORTFOLIO.variation1dPercent).toBe(0.8)
   })
 })

--- a/apps/web/lib/data/dashboard-chart-demo.ts
+++ b/apps/web/lib/data/dashboard-chart-demo.ts
@@ -20,12 +20,6 @@ export interface DemoEvolutionSeries {
   deltaPct: number
 }
 
-/** Valorisation DEMO du portefeuille club (teaser desktop) — montants illustratifs. */
-export const DEMO_CLUB_PORTFOLIO: { totalValuation: number; variation1dPercent: number } = {
-  totalValuation: 708408,
-  variation1dPercent: 0.8,
-}
-
 const DAY_MS = 86_400_000
 /** Croissance cible par borne de tranche quotidienne (daysBack → valeur_finale / valeur). */
 const DAILY_GROWTH_CONTROLS: Array<[daysBack: number, growth: number]> = [

--- a/apps/web/lib/data/dashboard.test.ts
+++ b/apps/web/lib/data/dashboard.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest'
 
 import type { createServerClient } from '@evolve/data'
 
-import { contributionStatusLabel, getDashboardData, type ContributionStatus } from './dashboard'
+import {
+  clubPortfolioFromAggregates,
+  contributionStatusLabel,
+  getDashboardData,
+  type ContributionStatus,
+} from './dashboard'
 
 type ServerClient = ReturnType<typeof createServerClient>
 
@@ -26,6 +31,10 @@ function makeSupabaseMock(fixtures: Record<string, SingleResult>): ServerClient 
     chain.order = () => chain
     chain.maybeSingle = () => Promise.resolve(result)
     chain.returns = () => Promise.resolve(result)
+    // `portfolio_aggregates` est awaité SANS terminateur (le builder Supabase est thenable) →
+    // on rend la chaîne thenable pour qu'un `await` résolve vers la fixture {data, error}.
+    chain.then = (onFulfilled: (v: SingleResult) => unknown) =>
+      Promise.resolve(result).then(onFulfilled)
     return chain
   }
   return { from } as unknown as ServerClient
@@ -79,11 +88,20 @@ describe('getDashboardData', () => {
       users: { data: { firstname: 'Ruben', full_name: 'AFOUDAH Ruben' }, error: null },
       // E2 : syncedAt vient de clubs.synced_at (timestamp du club), pas de member_quote_part.
       clubs: { data: { name: 'Club Test', synced_at: '2026-06-05T10:00:00Z' }, error: null },
+      // Valo club RÉELLE (teaser V2) : agrégat « Portefeuille » → valeur + gain/perte total.
+      portfolio_aggregates: {
+        data: [{ label: 'Portefeuille', market_value: 732510.61, book_value: 315429.61 }],
+        error: null,
+      },
     })
 
     const result = await getDashboardData(supabase, 'user-1', 'club-1')
 
     expect(result).not.toBeNull()
+    // clubPortfolio : valeur = market_value de l'agrégat « Portefeuille » (même source que /portfolio).
+    expect(result?.clubPortfolio.value).toBe(732510.61)
+    expect(result?.clubPortfolio.gainLossEur).toBeCloseTo(417081, 0)
+    expect(result?.clubPortfolio.gainLossPct).toBeCloseTo(1.3223, 3)
     // E2 : la source du statut de sync est clubs.synced_at (unifiée avec la topbar desktop).
     expect(result?.syncedAt).toBe('2026-06-05T10:00:00Z')
     // Coercition Number() : valeurs numériques renvoyées comme number, pas string.
@@ -191,5 +209,79 @@ describe('getDashboardData', () => {
 
     const result = await getDashboardData(supabase, 'user-1', 'club-1')
     expect(result?.contribution.status).toBe('ok')
+  })
+
+  it('clubPortfolio.value null quand l’agrégat « Portefeuille » est absent', async () => {
+    const supabase = makeSupabaseMock({
+      member_quote_part: {
+        data: {
+          role: 'member',
+          joined_at: null,
+          detention_pct: '0',
+          total_contributed: '0',
+          net_market_value: '0',
+          contribution_status: 'ok',
+          amount_due: '0',
+        },
+        error: null,
+      },
+      users: { data: null, error: null },
+      clubs: { data: { name: 'Club Test' }, error: null },
+      // pas de fixture portfolio_aggregates → aucune ligne « Portefeuille ».
+    })
+
+    const result = await getDashboardData(supabase, 'user-1', 'club-1')
+    expect(result?.clubPortfolio.value).toBeNull()
+    expect(result?.clubPortfolio.gainLossPct).toBeNull()
+  })
+})
+
+describe('clubPortfolioFromAggregates', () => {
+  it('extrait la valeur + le gain/perte total depuis l’agrégat « Portefeuille »', () => {
+    const out = clubPortfolioFromAggregates([
+      { label: 'Portefeuille', market_value: 1200, book_value: 1000 },
+      { label: 'ESPECES', market_value: 50, book_value: null },
+    ])
+    expect(out.value).toBe(1200)
+    expect(out.gainLossEur).toBe(200)
+    expect(out.gainLossPct).toBeCloseTo(0.2, 6)
+  })
+
+  it('match insensible à la casse/aux accents (« PORTEFEUILLE »)', () => {
+    const out = clubPortfolioFromAggregates([
+      { label: '  PORTEFEUILLE ', market_value: 500, book_value: 400 },
+    ])
+    expect(out.value).toBe(500)
+    expect(out.gainLossEur).toBe(100)
+  })
+
+  it('agrégat absent → tout null', () => {
+    expect(clubPortfolioFromAggregates([])).toEqual({
+      value: null,
+      gainLossEur: null,
+      gainLossPct: null,
+    })
+  })
+
+  it('prix d’achat absent ou ≤ 0 → valeur seule, gain/perte null (jamais de division par 0)', () => {
+    const noBook = clubPortfolioFromAggregates([
+      { label: 'Portefeuille', market_value: 1200, book_value: null },
+    ])
+    expect(noBook.value).toBe(1200)
+    expect(noBook.gainLossEur).toBeNull()
+    expect(noBook.gainLossPct).toBeNull()
+
+    const zeroBook = clubPortfolioFromAggregates([
+      { label: 'Portefeuille', market_value: 1200, book_value: 0 },
+    ])
+    expect(zeroBook.gainLossPct).toBeNull()
+  })
+
+  it('perte (valeur < prix d’achat) → gain/perte négatif', () => {
+    const out = clubPortfolioFromAggregates([
+      { label: 'Portefeuille', market_value: 800, book_value: 1000 },
+    ])
+    expect(out.gainLossEur).toBe(-200)
+    expect(out.gainLossPct).toBeCloseTo(-0.2, 6)
   })
 })

--- a/apps/web/lib/data/dashboard.ts
+++ b/apps/web/lib/data/dashboard.ts
@@ -16,6 +16,7 @@ import type { createServerClient } from '@evolve/data'
 import type { Database } from '@evolve/data'
 
 import { deriveContributionStatus, joinedAtToYM } from './contributionStatus'
+import { normalizeAggregateLabel } from './portfolio'
 
 /** Client Supabase serveur tel que retourné par `createServerClient` (session + RLS). */
 type ServerClient = ReturnType<typeof createServerClient>
@@ -40,7 +41,48 @@ export interface DashboardData {
    *  `cap`/`remaining` null si le plafond n'est pas renseigné sur le club. */
   investment: { cap: number | null; yearInvested: number; remaining: number | null }
   club: { name: string }
+  /** Valorisation RÉELLE du portefeuille du club (teaser dashboard V2). Lue depuis l'agrégat
+   *  « Portefeuille » de `portfolio_aggregates` — MÊME source que la page /portfolio, donc
+   *  valeurs cohérentes entre les deux écrans (fin du teaser demo codé en dur).
+   *  `value` null si l'agrégat est absent ; `gainLoss*` null si le prix d'achat club manque. */
+  clubPortfolio: ClubPortfolioSummary
   syncedAt: string | null
+}
+
+/** Synthèse de la valo club affichée sur la carte teaser (valeur + gain/perte total). */
+export interface ClubPortfolioSummary {
+  /** Valeur de marché de l'agrégat « Portefeuille » (€), ou null si absent. */
+  value: number | null
+  /** Gain/perte total en € (valeur de marché − prix d'achat), ou null si prix d'achat absent. */
+  gainLossEur: number | null
+  /** Gain/perte total en fraction 0..1 (pour formatPct), ou null si prix d'achat absent/nul. */
+  gainLossPct: number | null
+}
+
+/** Libellé normalisé de l'agrégat « Portefeuille » (= total club affiché). */
+const PORTEFEUILLE_AGG_LABEL = 'portefeuille'
+
+/**
+ * Calcule la synthèse de valo club depuis les lignes d'agrégat. PUR.
+ * Le gain/perte total dérive de l'agrégat « Portefeuille » (market_value vs book_value) — c'est
+ * le « Gain/perte total » du club, cohérent dans l'esprit avec celui de /portfolio. Si le prix
+ * d'achat (book_value) est absent ou ≤ 0, on n'affiche que la valeur (gain/perte null).
+ */
+export function clubPortfolioFromAggregates(
+  rows: Array<{ label: string; market_value: number | null; book_value: number | null }>
+): ClubPortfolioSummary {
+  const row = rows.find((a) => normalizeAggregateLabel(a.label) === PORTEFEUILLE_AGG_LABEL)
+  const value =
+    typeof row?.market_value === 'number' && Number.isFinite(row.market_value)
+      ? row.market_value
+      : null
+  const book =
+    typeof row?.book_value === 'number' && Number.isFinite(row.book_value) ? row.book_value : null
+  if (value === null || book === null || book <= 0) {
+    return { value, gainLossEur: null, gainLossPct: null }
+  }
+  const gainLossEur = value - book
+  return { value, gainLossEur, gainLossPct: gainLossEur / book }
 }
 
 const STATUS_LABEL: Record<ContributionStatus, string> = {
@@ -65,46 +107,66 @@ export async function getDashboardData(
   // La vue ne porte PAS les colonnes de nom : profil lu séparément (DATA_MODEL.md §2).
   // `clubs.synced_at` : source unique du statut de sync (E2), partagée avec la topbar.
   // `memberships.id` : requis pour cibler contribution_months (clé par adhésion, E3).
-  const [{ data: mqp, error }, { data: profile }, { data: club }, { data: membership }] =
-    await Promise.all([
-      supabase
-        .from('member_quote_part')
-        .select(
-          'role, joined_at, detention_pct, total_contributed, net_market_value, contribution_status, amount_due'
-        )
-        .eq('user_id', userId)
-        .eq('club_id', clubId)
-        .maybeSingle<
-          Pick<
-            MemberQuotePartRow,
-            | 'role'
-            | 'joined_at'
-            | 'detention_pct'
-            | 'total_contributed'
-            | 'net_market_value'
-            | 'contribution_status'
-            | 'amount_due'
-          >
-        >(),
-      supabase
-        .from('users')
-        .select('firstname, full_name')
-        .eq('id', userId)
-        .maybeSingle<Pick<UserRow, 'firstname' | 'full_name'>>(),
-      supabase
-        .from('clubs')
-        .select('name, synced_at, annual_investment_cap')
-        .eq('id', clubId)
-        .maybeSingle<Pick<ClubRow, 'name' | 'synced_at' | 'annual_investment_cap'>>(),
-      supabase
-        .from('memberships')
-        .select('id')
-        .eq('user_id', userId)
-        .eq('club_id', clubId)
-        .maybeSingle<{ id: string }>(),
-    ])
+  const [
+    { data: mqp, error },
+    { data: profile },
+    { data: club },
+    { data: membership },
+    { data: aggRows },
+  ] = await Promise.all([
+    supabase
+      .from('member_quote_part')
+      .select(
+        'role, joined_at, detention_pct, total_contributed, net_market_value, contribution_status, amount_due'
+      )
+      .eq('user_id', userId)
+      .eq('club_id', clubId)
+      .maybeSingle<
+        Pick<
+          MemberQuotePartRow,
+          | 'role'
+          | 'joined_at'
+          | 'detention_pct'
+          | 'total_contributed'
+          | 'net_market_value'
+          | 'contribution_status'
+          | 'amount_due'
+        >
+      >(),
+    supabase
+      .from('users')
+      .select('firstname, full_name')
+      .eq('id', userId)
+      .maybeSingle<Pick<UserRow, 'firstname' | 'full_name'>>(),
+    supabase
+      .from('clubs')
+      .select('name, synced_at, annual_investment_cap')
+      .eq('id', clubId)
+      .maybeSingle<Pick<ClubRow, 'name' | 'synced_at' | 'annual_investment_cap'>>(),
+    supabase
+      .from('memberships')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('club_id', clubId)
+      .maybeSingle<{ id: string }>(),
+    // Agrégats du club (RLS isole par club, comme /portfolio) → valo club RÉELLE du teaser V2.
+    // Un échec de lecture ne casse PAS le dashboard : `aggRows` null → clubPortfolio.value null.
+    supabase
+      .from('portfolio_aggregates')
+      .select('label, market_value, book_value')
+      .eq('club_id', clubId)
+      .eq('is_active', true),
+  ])
   if (error) throw error
   if (!mqp) return null
+
+  const clubPortfolio = clubPortfolioFromAggregates(
+    (aggRows as Array<{
+      label: string
+      market_value: number | null
+      book_value: number | null
+    }> | null) ?? []
+  )
 
   // E3 — capacité d'investissement restante de l'année (même calcul que l'attestation :
   // plafond annuel du club − somme des mois cotisés `paid` de l'année en cours).
@@ -156,6 +218,7 @@ export async function getDashboardData(
     },
     investment: { cap, yearInvested, remaining },
     club: { name: club?.name ?? '—' },
+    clubPortfolio,
     // E2 : statut de sync unifié sur le timestamp du CLUB (≠ member_quote_part.synced_at par-membre).
     syncedAt: club?.synced_at ?? null,
   }

--- a/apps/web/lib/hooks/useDashboard.test.ts
+++ b/apps/web/lib/hooks/useDashboard.test.ts
@@ -12,6 +12,7 @@ const sample: DashboardData = {
   contribution: { status: 'ok', amountDue: 0 },
   investment: { cap: 5500, yearInvested: 500, remaining: 5000 },
   club: { name: 'Club Test' },
+  clubPortfolio: { value: 708408, gainLossEur: 120000, gainLossPct: 0.2 },
   syncedAt: '2026-05-31T10:00:00.000Z',
 }
 

--- a/apps/web/playwright/dashboard-v2.spec.ts
+++ b/apps/web/playwright/dashboard-v2.spec.ts
@@ -68,9 +68,47 @@ async function purgeReportingRows(): Promise<void> {
   }
 }
 
-// File-level (workers:1) : table REPORTING propre AVANT tous les tests du fichier.
+// Valo club RÉELLE du teaser desktop (clubPortfolio, lue depuis l'agrégat « Portefeuille »).
+// Valeur 732 510 €, prix d'achat 315 429 € → gain/perte total = +417 081 € (+132,23 %).
+const CLUB_AGG_VALUE = 732_510
+const CLUB_AGG_BOOK = 315_429
+
+/** Seede l'agrégat « Portefeuille » du club seed → le teaser V2 affiche une valo club réelle
+ *  (le seed de base n'en pose pas, sinon la carte tomberait sur « — »). Idempotent. */
+async function seedPortefeuilleAggregate(): Promise<void> {
+  const sql = postgres(DB_URL, { max: 1 })
+  try {
+    await sql`
+      INSERT INTO portfolio_aggregates (club_id, label, market_value, book_value, is_active, synced_at)
+      VALUES (${SEED_CLUB_ID}::uuid, 'Portefeuille', ${CLUB_AGG_VALUE}, ${CLUB_AGG_BOOK}, true, now())
+      ON CONFLICT (club_id, label) DO UPDATE
+        SET market_value = EXCLUDED.market_value, book_value = EXCLUDED.book_value,
+            is_active = true, synced_at = now()
+    `
+  } finally {
+    await sql.end()
+  }
+}
+
+/** Retire l'agrégat seedé (n'impacte pas les autres specs). */
+async function purgePortefeuilleAggregate(): Promise<void> {
+  const sql = postgres(DB_URL, { max: 1 })
+  try {
+    await sql`DELETE FROM portfolio_aggregates WHERE club_id = ${SEED_CLUB_ID}::uuid AND label = 'Portefeuille'`
+  } finally {
+    await sql.end()
+  }
+}
+
+// File-level (workers:1) : table REPORTING propre + agrégat « Portefeuille » seedé AVANT tous
+// les tests du fichier.
 test.beforeAll(async () => {
   await purgeReportingRows()
+  await seedPortefeuilleAggregate()
+})
+
+test.afterAll(async () => {
+  await purgePortefeuilleAggregate()
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -106,6 +144,8 @@ function makeDashboardData(syncedAt: string): DashboardData {
     contribution: { status: 'ok', amountDue: 0 },
     investment: { cap: 5500, yearInvested: 2000, remaining: 3500 },
     club: { name: 'Club E2E' },
+    // Valo club RÉELLE (teaser V2) : valeur + gain/perte total déterministes.
+    clubPortfolio: { value: 732_510, gainLossEur: 417_081, gainLossPct: 1.3223 },
     syncedAt,
   }
 }
@@ -294,6 +334,10 @@ test.describe('Dashboard V2 — cookie v2, desktop', () => {
     await expect(teaser).toBeVisible()
     await expect(teaser).toHaveAttribute('href', '/portfolio')
     await expect(teaser.getByText(/voir le détail/i)).toBeVisible()
+    // Valo club RÉELLE (≠ ancien montant demo codé en dur) : la carte affiche la valeur de
+    // l'agrégat « Portefeuille » seedé (732 510 €) et le badge gain/perte total (+132,23 %).
+    await expect(teaser.getByText(/732\s?510/)).toBeVisible()
+    await expect(teaser.getByText(/132,23\s?%/)).toBeVisible()
   })
 
   test('« Comprendre ma quote-part » ouvre le dialog ; Escape ferme', async ({ page }) => {

--- a/apps/web/playwright/dashboard.spec.ts
+++ b/apps/web/playwright/dashboard.spec.ts
@@ -60,6 +60,7 @@ function makeDashboardData(syncedAt: string): DashboardData {
     contribution: { status: 'ok', amountDue: 0 },
     investment: { cap: 5500, yearInvested: 2000, remaining: 3500 },
     club: { name: 'Club E2E' },
+    clubPortfolio: { value: 732_510, gainLossEur: 417_081, gainLossPct: 1.3223 },
     syncedAt,
   }
 }

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,7 +1,7 @@
 export { readSheet } from './sheets/client.ts'
 export { mapBaseRowToMember } from './sheets/mappers/base.mapper.ts'
 export { resolveBaseEmail, normalizeName } from './sheets/mappers/baseEmailResolution.ts'
-export { mapParametragesToClub } from './sheets/mappers/parametrages.mapper.ts'
+export { mapParametragesToClub, stripEmptyClubMeta } from './sheets/mappers/parametrages.mapper.ts'
 export { mapPortefeuilleRows, mapAggregateRows } from './sheets/mappers/portefeuille.mapper.ts'
 export { mapHistoriqueRows } from './sheets/mappers/historique.mapper.ts'
 export { mapCotisationsRows } from './sheets/mappers/cotisations.mapper.ts'

--- a/packages/data/src/sheets/mappers/__tests__/parametrages.mapper.test.ts
+++ b/packages/data/src/sheets/mappers/__tests__/parametrages.mapper.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { mapParametragesToClub, mapParametragesToOfficers } from '../parametrages.mapper.ts'
+import {
+  mapParametragesToClub,
+  mapParametragesToOfficers,
+  stripEmptyClubMeta,
+} from '../parametrages.mapper.ts'
 
 describe('mapParametragesToClub', () => {
   it('génère slug + settings.penalty_rate', () => {
@@ -62,6 +66,34 @@ describe('mapParametragesToClub', () => {
   it('country null reste null (colonne devenue nullable, migration 024)', () => {
     const club = mapParametragesToClub([{ clubName: 'Club', minContribution: 0 }], 's')
     expect(club.country).toBeNull()
+  })
+})
+
+describe('stripEmptyClubMeta (anti-écrasement ville/pays au sync)', () => {
+  it("retire city/country quand null → l'UPDATE ne les touche pas (valeur en base préservée)", () => {
+    const out = stripEmptyClubMeta({ name: 'Club', city: null, country: null })
+    expect('city' in out).toBe(false)
+    expect('country' in out).toBe(false)
+    expect(out.name).toBe('Club')
+  })
+
+  it('retire city/country quand chaîne vide ou espaces', () => {
+    const out = stripEmptyClubMeta({ city: '', country: '   ' })
+    expect('city' in out).toBe(false)
+    expect('country' in out).toBe(false)
+  })
+
+  it('PRÉSERVE city/country quand renseignées (la feuille fait alors autorité)', () => {
+    const out = stripEmptyClubMeta({ city: 'Cotonou', country: 'BJ' })
+    expect(out.city).toBe('Cotonou')
+    expect(out.country).toBe('BJ')
+  })
+
+  it("ne mute pas l'objet source", () => {
+    const src = { city: null as string | null, country: 'FR' }
+    stripEmptyClubMeta(src)
+    expect(src.city).toBeNull()
+    expect(src.country).toBe('FR')
   })
 })
 

--- a/packages/data/src/sheets/mappers/parametrages.mapper.ts
+++ b/packages/data/src/sheets/mappers/parametrages.mapper.ts
@@ -33,6 +33,24 @@ export function mapParametragesToClub(rows: ParametragesRowDTO[], sheetId: strin
   }
 }
 
+/**
+ * Politique de sync « anti-écrasement » (option A) : ne JAMAIS null-ifier une métadonnée club
+ * saisie à la main (ville, pays) par une valeur vide venant de la feuille. La feuille
+ * PARAMETRAGES n'a pas toujours ces colonnes ; or l'admin/président les renseigne dans l'assistant
+ * d'ajout de club. Un `null`/`''` issu de la feuille ne doit donc PAS écraser la valeur existante.
+ *
+ * On RETIRE `city`/`country` de l'objet d'update quand elles sont vides → l'UPDATE Postgres ne
+ * touche tout simplement pas ces colonnes (la valeur courante en base est préservée). Pur.
+ */
+export function stripEmptyClubMeta<T extends { city?: string | null; country?: string | null }>(
+  club: T
+): T {
+  const out = { ...club }
+  if (out.city == null || out.city.trim() === '') delete out.city
+  if (out.country == null || out.country.trim() === '') delete out.country
+  return out
+}
+
 /** Noms BRUTS des dirigeants extraits de PARAMETRAGES (pour réconciliation des rôles). */
 export interface ClubOfficers {
   /** Nom complet du Président(e), ou null si absent de la feuille. */

--- a/supabase/functions/sync/__tests__/sync.test.ts
+++ b/supabase/functions/sync/__tests__/sync.test.ts
@@ -1099,6 +1099,33 @@ Deno.test('handler : ordre impératif → PARAMETRAGES avant Base', async () => 
   assert(idxParam < idxBase, 'PARAMETRAGES doit précéder Base')
 })
 
+// Test 5bis — anti-écrasement ville/pays (option A) : la feuille ne fait PAS autorité sur
+// ville/pays. Si PARAMETRAGES ne les fournit pas, le sync NE DOIT PAS null-ifier les valeurs
+// saisies à la création du club (bug : ville/pays vidés après connexion de la vraie matrice).
+Deno.test(
+  'handler : PARAMETRAGES sans ville/pays → city/country saisis préservés (anti-écrasement)',
+  async () => {
+    const store = emptyStore(true)
+    // Club créé via l'assistant avec une ville/pays renseignés.
+    store.clubs[0]!.city = 'Cotonou'
+    store.clubs[0]!.country = 'BJ'
+    // Matrice réelle dont PARAMETRAGES n'a PAS de lignes Ville/Pays.
+    const paramsNoCity: string[][] = [
+      ['Paramètre', 'Valeur'],
+      ['Nom du club', 'Évolve Capital'],
+      ['Cotisation min', '100'],
+    ]
+    const res = await buildHandler(store, { overrides: { PARAMETRAGES: paramsNoCity } })(
+      syncRequest(CLUB_ID)
+    )
+    assertEquals(res.status, 200)
+    // La sync a tourné (nom MAJ) mais ville/pays sont CONSERVÉS (non écrasés par null).
+    const club = store.clubs.find((c) => c.id === CLUB_ID)!
+    assertEquals(club.city, 'Cotonou')
+    assertEquals(club.country, 'BJ')
+  }
+)
+
 // ===========================================================================
 // 3bis. RÉCONCILIATION DES RÔLES (B1) — dérivés de PARAMETRAGES
 // ===========================================================================

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   mapParametragesToClub,
   mapParametragesToOfficers,
+  stripEmptyClubMeta,
 } from '../../../packages/data/src/sheets/mappers/parametrages.mapper.ts'
 import type { ClubOfficers } from '../../../packages/data/src/sheets/mappers/parametrages.mapper.ts'
 import { normalizeName } from '../../../packages/data/src/sheets/normalizeName.ts'
@@ -327,7 +328,11 @@ export function createSyncHandler(deps: SyncDeps): (req: Request) => Promise<Res
       // slug dérivé du « Nom du club », la branche DO UPDATE l'écraserait → collision clubs_slug_key
       // si ce slug est déjà pris par un autre club. L'UPDATE ne touche donc JAMAIS le slug
       // (identité applicative fixée à la création) ; il met à jour le reste (nom, ville, plafond…).
-      const { slug: _slugIgnored, ...clubUpdate } = clubUpsert
+      const { slug: _slugIgnored, ...clubUpdateAll } = clubUpsert
+      // Option A (anti-écrasement) : la feuille ne fait pas autorité sur ville/pays. Si elle ne
+      // les fournit pas (colonnes absentes → null), on NE réécrit PAS ces colonnes pour ne pas
+      // null-ifier la valeur saisie à la création du club. cf. stripEmptyClubMeta + bug ville vide.
+      const clubUpdate = stripEmptyClubMeta(clubUpdateAll)
       const { error } = await supabase.from('clubs').update(clubUpdate).eq('id', clubId)
       if (error) throw new Error(`upsert clubs: ${error.message}`)
       snapshots['PARAMETRAGES'] = await createSnapshot(


### PR DESCRIPTION
## Résumé

Corrige 3 retours de test en production, debuggés en root-cause avant tout changement (aucune migration, aucune dépendance touchée).

## Changements

### 1. Carte « Portefeuille du club » (dashboard V2) → vraie valo
- La carte affichait un montant **DEMO codé en dur** (`708 408 € / +0,80 %`) incohérent avec /portfolio (`732 510 €`).
- Branchée sur l'agrégat « Portefeuille » de `portfolio_aggregates` via `DashboardData.clubPortfolio` (helper pur `clubPortfolioFromAggregates`, lecture serveur) — **même source que /portfolio** → valeurs alignées.
- Badge = **gain/perte total** (valeur de marché vs prix d'achat) ; masqué si prix d'achat absent ; valeur `—` si agrégat absent (jamais de NaN). Constante `DEMO_CLUB_PORTFOLIO` supprimée.

### 2. Ville/pays du club effacés après connexion de la vraie matrice
- Cause : le sync (étape `PARAMETRAGES`) faisait un `UPDATE clubs` **inconditionnel** ; quand la feuille n'a pas de colonnes Ville/Pays, `city/country` étaient null-ifiés, écrasant la valeur saisie à la création.
- **Option A (anti-écrasement)** : helper pur `stripEmptyClubMeta` retire `city/country` de l'update quand elles sont vides → l'UPDATE ne touche plus ces colonnes (valeur en base préservée). La feuille ne fait plus autorité sur ces champs saisis à la main.
- ⚠️ Ce fix **empêche les futurs écrasements mais ne restaure pas la valeur déjà perdue** (cf. déploiement).

### 3. Attestation piégée dans la PWA iOS standalone
- Cause : `window.open(url,'_blank')` + route PDF `Content-Disposition: inline` → en PWA installée, navigation sur place sans retour ni téléchargement. Web/iOS-Safari hors-PWA : OK.
- **Option A** : en `standalone` (`detectPwaCase`), téléchargement du PDF en **blob** (`<a download>` → iOS ouvre l'aperçu Fichiers avec bouton retour). Décision pure `chooseAttestationStrategy`. Web inchangé (ouverture synchrone, geste utilisateur préservé).

## Tests & non-régression

- `typecheck` (tous workspaces) ✅ · `lint` 0 erreur ✅
- vitest web **37** ✅ · vitest data **14** (`stripEmptyClubMeta`) ✅
- **Deno sync 44** ✅ (régression anti-écrasement ville/pays ajoutée)
- e2e dashboard + dashboard-v2 ✅ — **preuve runtime** : le teaser affiche la valo réelle seedée (`732 510 € / +132,23 %`)
- 1 échec e2e `contributions` (« Popover détail », `Avril 2026`) = **flake date-drift PRÉ-EXISTANT** (prouvé indépendant en stashant le diff), pas une régression

## ⚠️ Risk

| Niveau | Fichier |
|--------|---------|
| High | `supabase/functions/sync/index.ts` (Edge Function — nécessite redeploy ; attention pin `verify_jwt`/`config.toml`) |

## Déploiement (owner)

- [ ] **Aucune migration** (colonnes `clubs.city/country` + `portfolio_aggregates` déjà présentes)
- [ ] Redéployer l'Edge **`sync`** (fix #2) — vérifier le pin `verify_jwt` / `config.toml`
- [ ] Redéployer le **web Vercel** (fix #1 + #3)
- [ ] **Re-renseigner Ville/Pays** dans l'onglet `PARAMETRAGES` de la matrice (le fix ne restaure pas le passé ; au prochain sync la valeur sera écrite et préservée)
- [ ] **Valider l'attestation sur un vrai iPhone PWA** (chemin blob standalone non testable en local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)