### PR TITLE
fix(web): cotisations relance V2 — bugs email/mois + email brandé + i18n

### DIFF
--- a/apps/web/app/(app)/admin/cotisations/AdminCotisationsView.tsx
+++ b/apps/web/app/(app)/admin/cotisations/AdminCotisationsView.tsx
@@ -51,24 +51,33 @@ export function AdminCotisationsView({
   const [relanceOpen, setRelanceOpen] = useState(false)
   const [relanceMemberId, setRelanceMemberId] = useState<string>('')
   const [relanceMemberName, setRelanceMemberName] = useState<string>('')
+  const [relanceMemberEmail, setRelanceMemberEmail] = useState<string | null>(null)
+  const [relanceMemberEmailIsPlaceholder, setRelanceMemberEmailIsPlaceholder] = useState(false)
 
-  const openRelance = (mId: string, mName: string) => {
+  const openRelance = (mId: string, mName: string, email: string, emailIsPlaceholder: boolean) => {
     setRelanceMemberId(mId)
     setRelanceMemberName(mName)
+    setRelanceMemberEmail(email)
+    setRelanceMemberEmailIsPlaceholder(emailIsPlaceholder)
     setRelanceOpen(true)
   }
 
   const closeRelance = () => setRelanceOpen(false)
 
-  // Mode CLUB : on retrouve le nom depuis regulariserList
+  // Mode CLUB : on retrouve le nom et l'email depuis regulariserList
   const handleClubRelancer = (mId: string) => {
     const item = payload.regulariserList.find((m) => m.membershipId === mId)
-    openRelance(mId, item?.fullName ?? '')
+    openRelance(mId, item?.fullName ?? '', item?.email ?? '', item?.emailIsPlaceholder ?? true)
   }
 
-  // Mode MEMBRE : on utilise le nom du membre déjà chargé
+  // Mode MEMBRE : on utilise le nom et l'email du membre déjà chargé
   const handleMemberRelancer = (mId: string) => {
-    openRelance(mId, payload.member?.fullName ?? '')
+    openRelance(
+      mId,
+      payload.member?.fullName ?? '',
+      payload.member?.email ?? '',
+      payload.member?.emailIsPlaceholder ?? true
+    )
   }
 
   // lateMonths pour la RelanceModal : si on est en mode membre, on les a ;
@@ -161,7 +170,9 @@ export function AdminCotisationsView({
         lateMonths={relanceLateMonths}
         amountDue={relanceAmountDue}
         currency={currency}
-        memberEmail={null}
+        memberEmail={
+          relanceMemberEmailIsPlaceholder || !relanceMemberEmail ? null : relanceMemberEmail
+        }
         clubId={initialData.clubId}
       />
     </div>

--- a/apps/web/app/(app)/admin/cotisations/actions.ts
+++ b/apps/web/app/(app)/admin/cotisations/actions.ts
@@ -11,8 +11,10 @@
 //
 // Réf : T5 brief, CLAUDE.md (jamais service-role côté client, RLS staff, no any).
 
+import { createElement } from 'react'
 import { cookies } from 'next/headers'
 import { createServerClient } from '@evolve/data'
+import { RelanceEmail, renderEmailHtml } from '@evolve/data/emails'
 import { resolveAdminContext } from '@/lib/data/admin'
 
 /** Expéditeur transactionnel Brevo (miroir de supabase/functions/send-email/index.ts). */
@@ -46,20 +48,6 @@ async function sendBrevoEmail(payload: BrevoEmailPayload): Promise<void> {
     const detail = await res.text().catch(() => '')
     throw new Error(`Brevo ${res.status}: ${detail}`)
   }
-}
-
-/**
- * Convertit un message texte en HTML basique (préserve les sauts de ligne).
- * Simple : les retours à la ligne deviennent des <br /> ; les paragraphes vides = <br />.
- */
-function textToHtml(text: string): string {
-  return text
-    .split('\n')
-    .map((line) => {
-      const escaped = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      return escaped === '' ? '<br />' : `<p style="margin:0 0 4px 0">${escaped}</p>`
-    })
-    .join('\n')
 }
 
 /**
@@ -124,10 +112,18 @@ export async function sendRelanceEmail(params: {
 
   // 3. Envoi Brevo.
   try {
+    const htmlContent = await renderEmailHtml(
+      createElement(RelanceEmail, {
+        memberName,
+        message,
+        clubName: undefined,
+        appUrl: process.env['NEXT_PUBLIC_APP_URL'] ?? 'https://app.reseauevolvecapital.com',
+      })
+    )
     await sendBrevoEmail({
       to: [{ email: resolvedEmail, name: memberName }],
-      subject: 'Rappel de cotisation — Evolve Capital',
-      htmlContent: `<div style="font-family:sans-serif;font-size:14px;color:inherit;">${textToHtml(message)}</div>`,
+      subject: 'Rappel de cotisation · Evolve Capital',
+      htmlContent,
       sender: SENDER,
     })
   } catch (err) {

--- a/apps/web/components/admin/RelanceModal.tsx
+++ b/apps/web/components/admin/RelanceModal.tsx
@@ -12,6 +12,7 @@
 
 import * as React from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
+import { useTranslations } from 'next-intl'
 import { Button, Icon, TextArea, useToast } from '@evolve/ui'
 import { buildRelanceMessage, type LateMonth } from '@/lib/data/admin'
 import { sendRelanceEmail } from '@/app/(app)/admin/cotisations/actions'
@@ -72,6 +73,7 @@ export function RelanceModal({
   currency = 'EUR',
   memberEmail,
 }: RelanceModalProps) {
+  const t = useTranslations('admin.cotisations.relance')
   const toast = useToast()
   const descId = React.useId()
 
@@ -112,16 +114,15 @@ export function RelanceModal({
 
       if (result.success) {
         toast.success({
-          title: 'Relance envoyée',
-          message: `Email envoyé à ${memberName}.`,
+          title: t('successTitle'),
+          message: t('successMessage', { name: memberName }),
         })
         onClose()
       } else {
-        const errorMsg = mapErrorMessage(result.error)
-        setError(errorMsg)
+        setError(mapErrorMessage(result.error, t))
       }
     } catch {
-      setError('Une erreur inattendue est survenue. Veuillez réessayer.')
+      setError(t('unexpectedError'))
     } finally {
       setIsPending(false)
     }
@@ -151,13 +152,13 @@ export function RelanceModal({
           </span>
 
           <Dialog.Title className="mt-4 font-display font-bold text-[18px] text-text">
-            Relancer {memberName}
+            {t('modalTitle', { name: memberName })}
           </Dialog.Title>
 
           <Dialog.Description id={descId} className="mt-2 text-[14px] text-text-sec">
             {hasEmail
-              ? `Un email sera envoyé à ${memberEmail}. Vous pouvez modifier le message ci-dessous.`
-              : 'Aucun email disponible pour ce membre. Transmettez ce message par un autre canal.'}
+              ? t('descriptionHasEmail', { email: memberEmail ?? '' })
+              : t('descriptionNoEmail')}
           </Dialog.Description>
 
           {/* Textarea du message — éditable. */}
@@ -166,7 +167,7 @@ export function RelanceModal({
               htmlFor="relance-message"
               className="text-[12px] font-semibold uppercase tracking-wide text-text-ter"
             >
-              Message
+              {t('messageLabel')}
             </label>
             <TextArea
               id="relance-message"
@@ -186,10 +187,7 @@ export function RelanceModal({
               className="mt-4 flex items-start gap-2 rounded-[10px] p-3 bg-data-warning-50 text-data-warning-strong"
             >
               <Icon name="TriangleAlert" size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-              <span className="text-[13px]">
-                Email manquant — ce membre n&apos;a pas d&apos;email renseigné. L&apos;envoi par
-                email est désactivé.
-              </span>
+              <span className="text-[13px]">{t('warningNoEmail')}</span>
             </div>
           )}
 
@@ -204,7 +202,7 @@ export function RelanceModal({
           <div className="mt-6 flex items-center justify-end gap-2">
             <Dialog.Close asChild>
               <Button variant="ghost" disabled={isPending}>
-                Annuler
+                {t('cancel')}
               </Button>
             </Dialog.Close>
             <Button
@@ -213,13 +211,13 @@ export function RelanceModal({
               disabled={!hasEmail || isPending}
               aria-disabled={!hasEmail || undefined}
             >
-              Envoyer par email
+              {t('sendEmail')}
             </Button>
           </div>
 
           {/* Bouton fermer (croix) — ≥ 44×44px, focus visible. */}
           <Dialog.Close
-            aria-label="Fermer"
+            aria-label={t('close')}
             className="absolute top-4 right-4 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-text-ter focus-visible:shadow-[var(--sh-glow)] outline-none"
           >
             <Icon name="X" size={16} aria-hidden="true" />
@@ -230,20 +228,21 @@ export function RelanceModal({
   )
 }
 
-/** Traduit les codes d'erreur de la Server Action en messages FR. */
-function mapErrorMessage(code: string | undefined): string {
-  switch (code) {
-    case 'unauthorized':
-      return 'Vous devez être connecté pour effectuer cette action.'
-    case 'forbidden':
-      return "Vous n'avez pas les droits pour envoyer une relance dans ce club."
-    case 'missing_email':
-      return "L'adresse email du membre est manquante."
-    case 'missing_message':
-      return 'Le message ne peut pas être vide.'
-    case 'send_failed':
-      return "L'envoi de l'email a échoué. Veuillez réessayer."
-    default:
-      return code ?? 'Une erreur est survenue. Veuillez réessayer.'
+/** Traduit les codes d'erreur de la Server Action via les clés i18n. */
+function mapErrorMessage(
+  code: string | undefined,
+  t: ReturnType<typeof useTranslations<'admin.cotisations.relance'>>
+): string {
+  const knownCodes = [
+    'unauthorized',
+    'forbidden',
+    'missing_email',
+    'missing_message',
+    'send_failed',
+  ] as const
+  type KnownCode = (typeof knownCodes)[number]
+  if (code && (knownCodes as readonly string[]).includes(code)) {
+    return t(`error.${code as KnownCode}`)
   }
+  return t('errorMessage')
 }

--- a/apps/web/lib/data/admin.test.ts
+++ b/apps/web/lib/data/admin.test.ts
@@ -336,14 +336,25 @@ describe('buildRegulariserList', () => {
     expect(result[0]!.membershipId).toBe('m1')
   })
 
-  it('mappe correctement les champs (membershipId, fullName, lateMonthsCount, amountDue)', () => {
-    const members = [mk({ id: 'm1', isUnpaid: true, fullName: 'Alice', amountDue: 300 })]
+  it('mappe correctement les champs (membershipId, fullName, lateMonthsCount, amountDue, email, emailIsPlaceholder)', () => {
+    const members = [
+      mk({
+        id: 'm1',
+        isUnpaid: true,
+        fullName: 'Alice',
+        amountDue: 300,
+        email: 'alice@x.fr',
+        emailIsPlaceholder: false,
+      }),
+    ]
     const result = buildRegulariserList(members, lateMap)
     expect(result[0]).toEqual({
       membershipId: 'm1',
       fullName: 'Alice',
       lateMonthsCount: 3,
       amountDue: 300,
+      email: 'alice@x.fr',
+      emailIsPlaceholder: false,
     })
   })
 
@@ -381,7 +392,14 @@ describe('buildSyntheseParams', () => {
 
   it('1 retard : remonte le nom et le montant du seul membre', () => {
     const regulariserList = [
-      { membershipId: 'm1', fullName: 'Alice', lateMonthsCount: 2, amountDue: 300 },
+      {
+        membershipId: 'm1',
+        fullName: 'Alice',
+        lateMonthsCount: 2,
+        amountDue: 300,
+        email: 'alice@example.com',
+        emailIsPlaceholder: false,
+      },
     ]
     const result = buildSyntheseParams(baseStats, regulariserList)
     expect(result.topMemberName).toBe('Alice')
@@ -393,8 +411,22 @@ describe('buildSyntheseParams', () => {
 
   it('N retards : remonte le 1er (montant le plus élevé, liste déjà triée)', () => {
     const regulariserList = [
-      { membershipId: 'm1', fullName: 'Bob', lateMonthsCount: 3, amountDue: 500 },
-      { membershipId: 'm2', fullName: 'Alice', lateMonthsCount: 1, amountDue: 200 },
+      {
+        membershipId: 'm1',
+        fullName: 'Bob',
+        lateMonthsCount: 3,
+        amountDue: 500,
+        email: 'bob@example.com',
+        emailIsPlaceholder: false,
+      },
+      {
+        membershipId: 'm2',
+        fullName: 'Alice',
+        lateMonthsCount: 1,
+        amountDue: 200,
+        email: 'alice@example.com',
+        emailIsPlaceholder: false,
+      },
     ]
     const result = buildSyntheseParams(baseStats, regulariserList)
     expect(result.topMemberName).toBe('Bob')

--- a/apps/web/lib/data/admin.ts
+++ b/apps/web/lib/data/admin.ts
@@ -637,8 +637,8 @@ export async function getMemberCotisationsForAdmin(
   const currentYear = now.getFullYear()
   const nowYM = currentYear * 12 + now.getMonth()
 
-  // Parallélise les trois requêtes indépendantes.
-  const [membershipRes, contribRes, monthsRes] = await Promise.all([
+  // Parallélise les quatre requêtes indépendantes.
+  const [membershipRes, contribRes, monthsRes, clubRes] = await Promise.all([
     supabase
       .from('memberships')
       .select(
@@ -678,11 +678,18 @@ export async function getMemberCotisationsForAdmin(
           paid_at: string | null
         }[]
       >(),
+    supabase
+      .from('clubs')
+      .select('min_contribution')
+      .eq('id', clubId)
+      .single<{ min_contribution: number }>(),
   ])
 
   if (membershipRes.error) throw membershipRes.error
   if (contribRes.error) throw contribRes.error
   if (monthsRes.error) throw monthsRes.error
+  if (clubRes.error) throw clubRes.error
+  const minContribution = clubRes.data?.min_contribution ?? 100
 
   // Membership introuvable dans ce club → null.
   if (!membershipRes.data) return null
@@ -703,10 +710,17 @@ export async function getMemberCotisationsForAdmin(
   const sheetStatus: ContributionStatus = contrib?.status ?? 'pending'
   const status = deriveContributionStatus(sheetStatus, months, joinedAtYM, nowYM)
 
-  // Montant dû : donnée source prime, sinon dérivé (minContribution=0 → 0 si absent).
-  const amountDue = deriveAmountDue(Number(contrib?.amount_due ?? 0), months, joinedAtYM, nowYM, 0)
+  // Montant dû : donnée source prime, sinon dérivé (plancher = min_contribution du club).
+  const amountDue = deriveAmountDue(
+    Number(contrib?.amount_due ?? 0),
+    months,
+    joinedAtYM,
+    nowYM,
+    minContribution
+  )
 
   // Mois en retard exploitables (post-adhésion, ≤ mois courant).
+  // amount = max(amount_db, min_contribution) : les mois non encore encaissés ont souvent 0.
   const lateMonths: LateMonth[] = months
     .filter((m) => {
       if (m.status !== 'late') return false
@@ -715,7 +729,11 @@ export async function getMemberCotisationsForAdmin(
       if (ym > nowYM) return false
       return true
     })
-    .map((m) => ({ year: m.year, month: m.month, amount: m.amount }))
+    .map((m) => ({
+      year: m.year,
+      month: m.month,
+      amount: m.amount > 0 ? m.amount : minContribution,
+    }))
 
   // Taux de recouvrement du membre (sur ses propres mois).
   const recoveryRate = computeRecoveryRate(months)

--- a/apps/web/lib/data/admin.ts
+++ b/apps/web/lib/data/admin.ts
@@ -105,6 +105,8 @@ export interface RegulariserMember {
   fullName: string
   lateMonthsCount: number
   amountDue: number
+  email: string
+  emailIsPlaceholder: boolean
 }
 
 /** Statistiques de recouvrement du club pour la page cotisations V2. */
@@ -138,6 +140,8 @@ export interface MemberCotisationsData {
   netMarketValue: number | null
   lateMonths: LateMonth[]
   years: TimelineYear[]
+  email: string
+  emailIsPlaceholder: boolean
 }
 
 /** Payload de l'API cotisations admin V2 (remplace l'ancien payload years+stats). */
@@ -276,6 +280,8 @@ export function buildRegulariserList(
       fullName: m.fullName,
       lateMonthsCount: lateMonthsByMembership.get(m.id) ?? 0,
       amountDue: m.amountDue,
+      email: m.email,
+      emailIsPlaceholder: m.emailIsPlaceholder,
     }))
     .sort((a, b) => b.amountDue - a.amountDue)
 }
@@ -635,13 +641,15 @@ export async function getMemberCotisationsForAdmin(
   const [membershipRes, contribRes, monthsRes] = await Promise.all([
     supabase
       .from('memberships')
-      .select('id, joined_at, users!memberships_user_id_fkey!inner(full_name)')
+      .select(
+        'id, joined_at, users!memberships_user_id_fkey!inner(full_name, email, email_is_placeholder)'
+      )
       .eq('id', membershipId)
       .eq('club_id', clubId)
       .maybeSingle<{
         id: string
         joined_at: string | null
-        users: { full_name: string }
+        users: { full_name: string; email: string; email_is_placeholder: boolean }
       }>(),
     supabase
       .from('contributions')
@@ -724,5 +732,7 @@ export async function getMemberCotisationsForAdmin(
     netMarketValue: contrib?.net_market_value != null ? Number(contrib.net_market_value) : null,
     lateMonths,
     years,
+    email: membership.users.email,
+    emailIsPlaceholder: membership.users.email_is_placeholder,
   }
 }

--- a/apps/web/lib/data/admin.ts
+++ b/apps/web/lib/data/admin.ts
@@ -326,14 +326,14 @@ export function buildRelanceMessage(params: {
   return [
     `Bonjour ${memberName},`,
     '',
-    `Nous vous rappelons que votre cotisation au club présente un solde impayé.`,
+    `On te rappelle que ta cotisation au club présente un solde impayé.`,
     '',
     monthsLine,
     `Montant total dû : ${formattedAmount}`,
     '',
-    `Merci de régulariser votre situation dans les meilleurs délais.`,
+    `Merci de régulariser ça dès que tu peux — et n'hésite pas à nous contacter si tu as des questions !`,
     '',
-    `Cordialement,`,
+    `À très vite,`,
     `L'équipe du club`,
   ].join('\n')
 }

--- a/apps/web/lib/hooks/useAdminContributions.ts
+++ b/apps/web/lib/hooks/useAdminContributions.ts
@@ -41,6 +41,9 @@ export function useAdminContributions(
   return useQuery({
     queryKey: ['admin', 'contributions', initialData.clubId, membershipId],
     queryFn: () => fetchAdminContributions(initialData.clubId, membershipId),
+    // Mode club (membershipId=null) : l'initialData SSR fait autorité, ne jamais refetch
+    // (le refetch renverrait EMPTY_CLUB_STATS depuis l'API route et écraserait les vraies stats).
+    enabled: membershipId !== null,
     initialData: membershipId ? undefined : initialData,
     placeholderData: (prev) => prev,
     staleTime: 2 * 60 * 1000,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -720,11 +720,23 @@
         "sendEmail": "Send by email",
         "noEmail": "Email not available",
         "cancel": "Cancel",
+        "close": "Close",
         "sending": "Sending…",
         "successTitle": "Message sent",
         "successMessage": "Follow-up sent to {name}.",
         "errorTitle": "Send error",
-        "errorMessage": "Unable to send the follow-up. Please try again."
+        "errorMessage": "Unable to send the follow-up. Please try again.",
+        "descriptionHasEmail": "An email will be sent to {email}. You can edit the message below.",
+        "descriptionNoEmail": "No email available for this member. Please send this message through another channel.",
+        "warningNoEmail": "Email missing — this member has no email address on file. Email sending is disabled.",
+        "unexpectedError": "An unexpected error occurred. Please try again.",
+        "error": {
+          "unauthorized": "You must be signed in to perform this action.",
+          "forbidden": "You do not have permission to send a follow-up in this club.",
+          "missing_email": "The member's email address is missing.",
+          "missing_message": "The message cannot be empty.",
+          "send_failed": "Failed to send the email. Please try again."
+        }
       },
       "empty": {
         "title": "No contributions",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -720,11 +720,23 @@
         "sendEmail": "Envoyer par email",
         "noEmail": "Email non disponible",
         "cancel": "Annuler",
+        "close": "Fermer",
         "sending": "Envoi en cours…",
         "successTitle": "Relance envoyée",
         "successMessage": "Email envoyé à {name}.",
         "errorTitle": "Erreur d'envoi",
-        "errorMessage": "Impossible d'envoyer la relance. Réessayez."
+        "errorMessage": "Impossible d'envoyer la relance. Réessayez.",
+        "descriptionHasEmail": "Un email sera envoyé à {email}. Tu peux modifier le message ci-dessous.",
+        "descriptionNoEmail": "Aucun email disponible pour ce membre. Transmets ce message par un autre canal.",
+        "warningNoEmail": "Email manquant — ce membre n'a pas d'email renseigné. L'envoi par email est désactivé.",
+        "unexpectedError": "Une erreur inattendue est survenue. Veuillez réessayer.",
+        "error": {
+          "unauthorized": "Tu dois être connecté pour effectuer cette action.",
+          "forbidden": "Tu n'as pas les droits pour envoyer une relance dans ce club.",
+          "missing_email": "L'adresse email du membre est manquante.",
+          "missing_message": "Le message ne peut pas être vide.",
+          "send_failed": "L'envoi de l'email a échoué. Veuillez réessayer."
+        }
       },
       "empty": {
         "title": "Aucune cotisation",

--- a/packages/data/src/emails/RelanceEmail.tsx
+++ b/packages/data/src/emails/RelanceEmail.tsx
@@ -1,0 +1,126 @@
+import { Button, Heading, Section, Text } from '@react-email/components'
+import type { CSSProperties } from 'react'
+import { brand, font, radius, semantic } from '@evolve/design-system'
+import { EvolveEmailShell } from './_layout/EvolveEmailShell.tsx'
+
+export interface RelanceEmailProps {
+  /** Prénom (ou nom complet) du membre destinataire. */
+  memberName: string
+  /** Corps du message de relance (texte libre, rédigé par le trésorier). */
+  message: string
+  /** Nom du club (footer). */
+  clubName?: string
+  /** URL de base de l'application. */
+  appUrl?: string
+}
+
+const APP_URL_DEFAULT = 'https://app.reseauevolvecapital.com'
+
+/** Convertit le texte multi-ligne en tableau de paragraphes non-vides. */
+function messageLines(text: string): string[] {
+  return text.split('\n').filter((line) => line.trim() !== '')
+}
+
+export function RelanceEmail({ memberName, message, clubName, appUrl }: RelanceEmailProps) {
+  const contributionsUrl = `${(appUrl ?? APP_URL_DEFAULT).replace(/\/+$/, '')}/contributions`
+  const lines = messageLines(message)
+
+  return (
+    <EvolveEmailShell
+      preview={`Un rappel de cotisation pour ${memberName}`}
+      clubName={clubName}
+      hideUnsubscribe
+    >
+      <Text style={eyebrow}>Cotisations · Rappel</Text>
+      <Heading as="h1" style={h1}>
+        Un rappel de cotisation
+      </Heading>
+
+      {/* Corps du message rédigé par le trésorier */}
+      <Section style={messageBox}>
+        {lines.map((line, i) => (
+          <Text key={i} style={messageLine}>
+            {line}
+          </Text>
+        ))}
+      </Section>
+
+      <Button href={contributionsUrl} style={cta}>
+        Voir mes cotisations
+      </Button>
+
+      {/* Note : le membre peut répondre via le formulaire de feedback */}
+      <Text style={note}>
+        <strong style={noteStrong}>Une question ou un problème ?</strong> Tu peux nous écrire
+        directement depuis ton espace membre en utilisant le bouton de retour en bas de l&apos;écran
+        — on te répondra rapidement.
+      </Text>
+    </EvolveEmailShell>
+  )
+}
+
+/* ─── Styles inline (tokens miroir TS) ─────────────────────────── */
+
+const eyebrow: CSSProperties = {
+  margin: '0 0 12px',
+  fontFamily: font.mono,
+  fontSize: '11px',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: semantic.textTer,
+}
+
+const h1: CSSProperties = {
+  margin: '0 0 20px',
+  fontFamily: font.display,
+  fontWeight: 800,
+  fontSize: '25px',
+  lineHeight: '1.14',
+  letterSpacing: '-0.02em',
+  color: semantic.text,
+}
+
+const messageBox: CSSProperties = {
+  margin: '0 0 26px',
+  padding: '20px 22px',
+  backgroundColor: semantic.bg,
+  border: `1px solid ${semantic.border}`,
+  borderRadius: radius.md,
+}
+
+const messageLine: CSSProperties = {
+  margin: '0 0 8px',
+  fontSize: '14.5px',
+  lineHeight: '1.6',
+  color: semantic.textSec,
+}
+
+const cta: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'center',
+  boxSizing: 'border-box',
+  backgroundColor: brand.yellow,
+  color: semantic.accentInk,
+  fontFamily: font.display,
+  fontWeight: 700,
+  fontSize: '15px',
+  letterSpacing: '0.04em',
+  textDecoration: 'none',
+  padding: '17px 24px',
+  borderRadius: radius.md,
+}
+
+const note: CSSProperties = {
+  marginTop: '24px',
+  paddingTop: '20px',
+  borderTop: `1px solid ${semantic.border}`,
+  fontSize: '12.5px',
+  lineHeight: '1.55',
+  color: semantic.textTer,
+}
+
+const noteStrong: CSSProperties = {
+  color: semantic.textSec,
+  fontWeight: 600,
+}

--- a/packages/data/src/emails/index.ts
+++ b/packages/data/src/emails/index.ts
@@ -26,6 +26,8 @@ export { mapArticleToEmail } from './mappers/article-to-email.ts'
 export type { MapArticleOptions } from './mappers/article-to-email.ts'
 export { PollEmail } from './PollEmail.tsx'
 export type { PollEmailProps, PollEmailVariant, PollEmailLocale } from './PollEmail.tsx'
+export { RelanceEmail } from './RelanceEmail.tsx'
+export type { RelanceEmailProps } from './RelanceEmail.tsx'
 
 /** Rend un email React Email en chaîne HTML prête à l'envoi. */
 export function renderEmailHtml(element: ReactElement): Promise<string> {


### PR DESCRIPTION
## Résumé des corrections

### Bugs prod

**Bug 1 — Relance toujours désactivée** (`memberEmail={null}` hardcodé)
- `RegulariserMember` et `MemberCotisationsData` : ajout `email` + `emailIsPlaceholder`
- `getMemberCotisationsForAdmin` : récupère maintenant `email` + `email_is_placeholder` depuis `users`
- `buildRegulariserList` : propage les champs email depuis `ClubMember` (déjà présents)
- `AdminCotisationsView` : câble `memberEmail` depuis le payload → le bouton Envoyer s'active si l'email est connu et non-placeholder

**Bug 2 — Montants à 0,00 € dans les mois en retard**
- `getMemberCotisationsForAdmin` : ajoute une requête parallèle `clubs.min_contribution`
- `lateMonths.amount` = `m.amount > 0 ? m.amount : minContribution` (plancher `min_contribution`)
- `deriveAmountDue` reçoit `minContribution` au lieu de `0`

**Bug 3 — Glitch "tout le monde est à jour" (puis reload = données correctes)**
- `useAdminContributions` : `enabled: membershipId !== null` — le hook ne refetch jamais en mode club ; `refetchOnWindowFocus` appelait l'API qui retournait `EMPTY_CLUB_STATS`, écrasant l'`initialData` SSR

### Features V2

**Email de relance brandé** (à la place du HTML brut)
- Nouveau composant React Email `RelanceEmail.tsx` dans `packages/data/src/emails/`
- Shell `EvolveEmailShell`, eyebrow, titre, corps en encadré, CTA jaune "Voir mes cotisations", note feedback
- `actions.ts` : rendu via `renderEmailHtml(createElement(RelanceEmail, …))`

**Tutoiement + ton humain** dans `buildRelanceMessage`
- "On te rappelle que ta cotisation… / Merci de régulariser ça dès que tu peux / À très vite"

**i18n RelanceModal** (clés `relance.*` existaient dans les JSON mais n'étaient pas câblées)
- Toutes les chaînes hardcodées FR remplacées par `useTranslations('admin.cotisations.relance')`

## Gate ✅

```
pnpm turbo typecheck --force   → 7/7 successful
pnpm turbo test --force        → 4/4 successful (58 tests data layer)
```

## Actions avant deploy

1. **Aucune migration** — changements purement frontend + data layer
2. **`NEXT_PUBLIC_APP_URL`** : vérifier que cette variable est définie sur Vercel (utilisée pour le lien CTA de l'email de relance). Si absente, fallback `https://app.reseauevolvecapital.com`.
3. **Test de validation post-deploy** :
   - Ouvrir un membre avec email connu en retard → bouton "Envoyer par email" doit être actif
   - Envoyer une relance → vérifier que l'email reçu est brandé (shell Evolve, CTA jaune)
   - Vérifier le montant affiché dans "Mois en retard" = `min_contribution` du club (ex. 100 €)
   - Aller sur `/admin/cotisations`, switcher de fenêtre et revenir → ne doit plus afficher "tout le monde est à jour"

🤖 Generated with [Claude Code](https://claude.com/claude-code)