### PR TITLE
perf(vitrine): corriger LCP héros — initial opacity 0→1 Framer Motion

### DIFF
--- a/apps/vitrine/src/app/[locale]/HomePage.tsx
+++ b/apps/vitrine/src/app/[locale]/HomePage.tsx
@@ -125,7 +125,7 @@ export default function HomePage({ locale }: HomePageProps) {
                 </div> */}
         <div className="container mx-auto px-4 z-10">
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
+            initial={{ opacity: 1, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
             className="text-center"


### PR DESCRIPTION
## Problème

Le `motion.div` héros dans `HomePage.tsx` démarrait avec `initial={{ opacity: 0, y: 20 }}`, ce qui rendait le h1 invisible dans le HTML server-side-rendered (SSR). Sur mobile throttlé (simulation Lighthouse), JavaScript prend plusieurs secondes à s'exécuter — pendant ce temps, le titre principal reste **invisible**, retardant le LCP à **8,9 s** (seuil : 2,5 s).

## Scores PageSpeed actuels (avant fix)

| Métrique | Mobile | Desktop | Seuil |
|---|---|---|---|
| Performance | 71 | 87 | 90 / 95 |
| LCP | **8,9 s** ❌ | 2,4 s ✅ | 2,5 s |
| CLS | 0 ✅ | 0 ✅ | 0,1 |
| Accessibilité | 86 | 86 | 90 |
| Best-practices | 100 | 100 | 90 |
| SEO | 100 | 100 | 95 |
| Open Graph | ✅ complet | — | ≥ 80 |

## Fix appliqué

**`apps/vitrine/src/app/[locale]/HomePage.tsx`** — une seule ligne :

```diff
- initial={{ opacity: 0, y: 20 }}
+ initial={{ opacity: 1, y: 20 }}
```

Le h1 est désormais visible dès le premier paint SSR (opacity: 1). L'animation slide-up (`y: 20 → 0`) est conservée côté client quand JS se charge. Changement minimal, sans impact fonctionnel ni visuel significatif.

## Impact attendu

- LCP mobile : 8,9 s → estimé < 2,5 s (h1 peint dès le premier render)
- Score Performance mobile : 71 → estimé 85–92

## Autres problèmes détectés (hors scope — tickets follow-up)

- Accessibilité 86 < 90 : contraste ConsentBanner, liens footer sans `aria-label`, ordre de titres h4, boutons carousel sans label
- Unused JS 133 KiB : Google Analytics (85 KiB) + 2 chunks Next.js — nécessite stratégie de lazy-loading GTM

---

🤖 Généré par [Performance Guardian](https://claude.ai/code) — Routine hebdo du 2026-06-22

https://claude.ai/code/session_017vtHne4ZxJ89h1TWErjiB8

---
_Generated by [Claude Code](https://claude.ai/code/session_017vtHne4ZxJ89h1TWErjiB8)_