### PR TITLE
fix(web): attestation — valorisation portefeuille alignée sur la page /portfolio (espèces incluses)

### DIFF
--- a/apps/web/app/api/attestation/detention/route.ts
+++ b/apps/web/app/api/attestation/detention/route.ts
@@ -27,6 +27,9 @@ import {
 } from '@evolve/data/pdf'
 
 import { checkRateLimit, rateLimitedResponse } from '@/lib/rate-limit'
+// Source de vérité UNIQUE du total portefeuille (= page /portfolio) : agrégat « Portefeuille »
+// (espèces + soldes inclus). Réutilisé ici pour que l'attestation affiche le MÊME montant.
+import { totalFromAggregates, type PortfolioAggregate } from '@/lib/data/portfolio'
 
 export const runtime = 'nodejs'
 
@@ -112,6 +115,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       { data: contributionRow },
       { data: positionRows },
       { data: monthRows },
+      { data: aggregateRows },
     ] = await Promise.all([
       supabase
         .from('users')
@@ -155,6 +159,14 @@ export async function GET(request: Request): Promise<NextResponse> {
         .select('year, month, amount, status')
         .eq('membership_id', membershipId)
         .returns<{ year: number; month: number; amount: number | null; status: string | null }[]>(),
+      // Agrégats du portefeuille (même requête que /portfolio) → total « Portefeuille »
+      // (espèces + soldes inclus) pour aligner la valorisation de l'attestation sur la page.
+      supabase
+        .from('portfolio_aggregates')
+        .select('label, market_value, book_value, allocation_pct')
+        .eq('club_id', clubId)
+        .eq('is_active', true)
+        .returns<PortfolioAggregate[]>(),
     ])
 
     // Pas de valo live serveur (la valo intraday est frontend, cf. CLAUDE.md) → on s'appuie sur
@@ -200,6 +212,9 @@ export async function GET(request: Request): Promise<NextResponse> {
           }
         : null,
       positions,
+      // Total portefeuille IDENTIQUE à /portfolio (agrégat « Portefeuille », espèces incluses) ;
+      // null si l'agrégat est absent → le mapper retombe sur la somme des positions.
+      portfolioTotalValue: totalFromAggregates(aggregateRows ?? []),
       months,
       period,
       generatedAt: new Date(),

--- a/packages/data/src/pdf/attestation.mapper.ts
+++ b/packages/data/src/pdf/attestation.mapper.ts
@@ -60,6 +60,14 @@ export interface AttestationInput {
   identity: AttestationIdentityInput
   contribution: AttestationContributionInput | null
   positions: AttestationPositionInput[]
+  /**
+   * Valorisation TOTALE du portefeuille du club = `market_value` de la ligne d'agrégat
+   * « Portefeuille » (col G de la matrice, `portfolio_aggregates`), qui inclut les ESPÈCES
+   * et les soldes — EXACTEMENT le total affiché sur la page /portfolio. `null` si l'agrégat
+   * est absent → le mapper retombe sur la somme des positions (`sumPortfolioValue`).
+   * Source de vérité unique : `apps/web/lib/data/portfolio.ts#totalFromAggregates`.
+   */
+  portfolioTotalValue: number | null
   months: AttestationMonthInput[]
   /** Période demandée « YYYY-MM » (pilote « investissement année courante » + « effort du mois »). */
   period: string
@@ -97,7 +105,7 @@ export interface AttestationData {
   detentionPct: AttestationMetric
   totalContributed: AttestationMetric
   quotePartValue: AttestationMetric // net_market_value
-  portfolioValue: AttestationMetric // Σ positions (live/snapshot)
+  portfolioValue: AttestationMetric // total agrégat « Portefeuille » (espèces incluses) — fallback Σ positions
 
   // 3 compléments (⚠ dérivés ou `—`)
   yearInvested: AttestationMetric // investissement cumulé année en cours (dérivé)
@@ -227,7 +235,12 @@ export function mapAttestation(input: AttestationInput): AttestationData {
     detentionPct: { value: num(c?.detentionPct ?? null), format: 'pct' },
     totalContributed: { value: num(c?.totalContributed ?? null), format: 'eur' },
     quotePartValue: { value: num(c?.netMarketValue ?? null), format: 'eur' },
-    portfolioValue: { value: sumPortfolioValue(input.positions), format: 'eur' },
+    // Valorisation portefeuille = total agrégat « Portefeuille » (espèces + soldes inclus),
+    // pour COÏNCIDER avec la page /portfolio. Fallback Σ positions si l'agrégat est absent.
+    portfolioValue: {
+      value: num(input.portfolioTotalValue) ?? sumPortfolioValue(input.positions),
+      format: 'eur',
+    },
 
     yearInvested: { value: yearInvested, format: 'eur' },
     // Capacité restante = plafond annuel − investissement cumulé de l'année.

--- a/packages/data/src/tests/pdf.test.ts
+++ b/packages/data/src/tests/pdf.test.ts
@@ -45,6 +45,7 @@ function completeInput(): AttestationInput {
       { quantity: 10, marketValue: 1500, livePrice: 160 }, // live → 1600
       { quantity: 5, marketValue: 800, livePrice: null }, // snapshot → 800
     ],
+    portfolioTotalValue: null, // pas d'agrégat → fallback Σ positions (2400)
     months: [
       { year: 2026, month: 1, amount: 100, status: 'paid' },
       { year: 2026, month: 2, amount: 100, status: 'paid' },
@@ -73,6 +74,18 @@ describe('mapAttestation — structure et formatage', () => {
     expect(data.monthClubEffort.value).toBe(100)
   })
 
+  it('valorisation portefeuille = total agrégat « Portefeuille » (espèces incluses), pas Σ positions', () => {
+    // Cas réel du bug : la somme des positions (2400) EXCLUT les espèces ; le total agrégat
+    // « Portefeuille » (3200 = 2400 titres + 800 espèces) est le montant affiché sur /portfolio.
+    const data = mapAttestation({ ...completeInput(), portfolioTotalValue: 3200 })
+    expect(data.portfolioValue.value).toBe(3200) // = page /portfolio, PAS 2400 (Σ positions)
+  })
+
+  it('valorisation portefeuille : fallback Σ positions si l’agrégat « Portefeuille » est absent', () => {
+    const data = mapAttestation({ ...completeInput(), portfolioTotalValue: null })
+    expect(data.portfolioValue.value).toBe(2400) // 1600 (live) + 800 (snapshot)
+  })
+
   it('produit un n° de référence + une URL de vérification', () => {
     const data = mapAttestation(completeInput())
     expect(data.reference).toMatch(/^REC-202606-[0-9A-Z]{4}$/)
@@ -99,6 +112,7 @@ describe('mapAttestation — structure et formatage', () => {
       },
       contribution: null,
       positions: [],
+      portfolioTotalValue: null,
       months: [],
       period: 'invalide',
       generatedAt: GENERATED_AT,


### PR DESCRIPTION
## Problème

Le montant **« valorisation du portefeuille »** de l'attestation de détention (PDF généré depuis `/contributions`) ne correspondait pas au **total du portefeuille** affiché sur la page `/portfolio`. Comme suspecté par l'owner, l'attestation **n'incluait pas les espèces disponibles** (ni les soldes).

## Analyse (cause racine)

Deux sources de calcul divergentes pour le même montant :

| Vue | Source | Inclut les espèces ? |
| --- | --- | --- |
| **Page `/portfolio`** | `totalFromAggregates(aggregates)` → ligne d'agrégat **« Portefeuille »** de `portfolio_aggregates` (col G de la matrice), fallback Σ positions | ✅ oui (espèces + soldes) |
| **Attestation (avant)** | `sumPortfolioValue(positions)` → **Σ des positions titres uniquement** | ❌ non |

`PortfolioView.tsx` : `const totalValue = totalFromAggregates(aggregates) ?? built.totalValue`.
`attestation.mapper.ts` : `portfolioValue = sumPortfolioValue(input.positions)` → **excluait les espèces**.

## Correctif

L'attestation consomme désormais **exactement la même source** que la page `/portfolio` :

- **`apps/web/app/api/attestation/detention/route.ts`** : ajoute la requête `portfolio_aggregates` (mêmes colonnes/filtres que `/portfolio`) et calcule le total via **`totalFromAggregates`** (source de vérité unique, importée de `@/lib/data/portfolio`), passé au mapper en `portfolioTotalValue`.
- **`packages/data/src/pdf/attestation.mapper.ts`** : `AttestationInput.portfolioTotalValue` ; `portfolioValue = portfolioTotalValue ?? sumPortfolioValue(positions)` (fallback Σ positions si l'agrégat « Portefeuille » est absent — comportement identique à `/portfolio`).

→ La valorisation de l'attestation **coïncide désormais avec la page `/portfolio`** (espèces incluses), par construction (même fonction, même requête, même fallback). Robustesse : si la requête agrégats échoue/est vide (ex. RLS), fallback gracieux sur Σ positions — aucun risque de 500.

## Tests / non-régression

- `make lint typecheck test` → **exit 0** (lint 0/0, typecheck 6/6, **544 tests / 45 fichiers**).
- `packages/data` `pdf.test.ts` : **+2 tests** — valorisation = total agrégat (3200, espèces incluses) ≠ Σ positions (2400) ; et fallback Σ positions quand l'agrégat est absent. **15/15 verts.**
- Aucun impact sur la référence/QR de vérification (basée sur la quote-part `net_market_value`, inchangée).

## Périmètre
2 fichiers de prod + 1 test. Aucun changement de schéma/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zyuyuuSaLmrbCYD2ZJFND)_