### PR TITLE
fix(a11y): corriger les violations d'accessibilité — score 86 → cible ≥ 90

### DIFF
--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -76,7 +76,7 @@ const STYLES = `
 .ecb-accept:hover{opacity:.9}
 .ecb-refuse{background:transparent;color:#231F20;border:1px solid #E4E4DF}
 .ecb-refuse:hover{background:#FAFAF9}
-.ecb-link{appearance:none;background:none;border:0;cursor:pointer;font:600 13.5px/1 inherit;padding:13px 4px;color:rgba(35,31,32,.42);text-decoration:underline;text-decoration-color:rgba(35,31,32,.25);text-underline-offset:3px;transition:color .15s}
+.ecb-link{appearance:none;background:none;border:0;cursor:pointer;font:600 13.5px/1 inherit;padding:13px 4px;color:rgba(35,31,32,.70);text-decoration:underline;text-decoration-color:rgba(35,31,32,.25);text-underline-offset:3px;transition:color .15s}
 .ecb-link:hover{color:#231F20}
 .ecb-link:focus-visible{outline:none;box-shadow:0 0 0 4px rgba(253,199,12,.30);border-radius:2px}
 .ecb-cat{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;border:1px solid #E4E4DF;border-radius:10px;background:#FAFAF9;padding:12px}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -147,20 +147,21 @@ export function Footer({ locale }: FooterProps) {
                                 </h3>
                                 <div className="flex gap-4">
                                     {[
-                                        { Icon: Linkedin, href: siteConfig.links.linkedin },
-                                        { Icon: Twitter, href: siteConfig.links.twitter },
-                                        { Icon: Facebook, href: siteConfig.links.facebook },
-                                        { Icon: Instagram, href: siteConfig.links.instagram },
-                                        { Icon: Mail, href: `/${locale}/contact` }
-                                    ].map(({ Icon, href }) => (
+                                        { Icon: Linkedin, href: siteConfig.links.linkedin, label: 'LinkedIn' },
+                                        { Icon: Twitter, href: siteConfig.links.twitter, label: 'X (Twitter)' },
+                                        { Icon: Facebook, href: siteConfig.links.facebook, label: 'Facebook' },
+                                        { Icon: Instagram, href: siteConfig.links.instagram, label: 'Instagram' },
+                                        { Icon: Mail, href: `/${locale}/contact`, label: locale === 'fr' ? 'Nous contacter' : 'Contact us' }
+                                    ].map(({ Icon, href, label }) => (
                                         <Link
                                             key={href}
                                             href={href}
+                                            aria-label={label}
                                             target={href.startsWith('/') ? undefined : "_blank"}
                                             className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center hover:bg-[#F3903F] transition-colors"
                                             rel={href.startsWith('/') ? undefined : "noopener noreferrer"}
                                         >
-                                            <Icon className="w-4 h-4" />
+                                            <Icon className="w-4 h-4" aria-hidden="true" />
                                         </Link>
                                     ))}
                                 </div>

--- a/src/components/sections/Membership.tsx
+++ b/src/components/sections/Membership.tsx
@@ -53,7 +53,7 @@ const BenefitItem = ({ title, description, index }: BenefitItemProps) => (
       <Check className="w-4 h-4 text-white" />
     </div>
     <div>
-      <h4 className="font-heading text-lg mb-1">{title}</h4>
+      <h3 className="font-heading text-lg mb-1">{title}</h3>
       <p className="text-neutral-600">{description}</p>
     </div>
   </motion.div>

--- a/src/components/sections/ValueProposition.tsx
+++ b/src/components/sections/ValueProposition.tsx
@@ -144,6 +144,10 @@ export function ValueProposition({ locale }: ValuePropositionProps) {
                         <button
                             key={index}
                             onClick={() => setCurrentTestimonial(index)}
+                            aria-label={locale === 'fr'
+                                ? `Témoignage ${index + 1} sur ${content.testimonials.length}`
+                                : `Testimonial ${index + 1} of ${content.testimonials.length}`
+                            }
                             className={`w-3 h-3 rounded-full transition-colors ${currentTestimonial === index
                                 ? 'bg-[#F3903F]'
                                 : 'bg-neutral-300'


### PR DESCRIPTION
## Contexte

Routine hebdomadaire Performance Guardian (2026-06-29).
Audit Lighthouse mobile : **accessibilité 86/100** (seuil configuré : 90).

## Violations corrigées

| Audit Lighthouse | Fichier | Fix |
|---|---|---|
| `button-name` (6 boutons) | `ValueProposition.tsx` | `aria-label` i18n sur les points du carrousel de témoignages |
| `link-name` (5 liens) | `Footer.tsx` | `aria-label` sur les 5 liens d'icônes sociales + `aria-hidden` sur les icônes décoratifs |
| `heading-order` (h2 → h4) | `Membership.tsx` | `h4` → `h3` pour les titres de bénéfices (saut de niveau corrigé) |
| `color-contrast` (2.4:1) | `ConsentBanner.tsx` | `.ecb-link` opacity `.42` → `.70` (contraste ~5.7:1, AA ✅) |

## Scores PageSpeed actuels (avant fix)

| Métrique | Mobile | Desktop | Seuil |
|---|---|---|---|
| Performance | 83 | 97 | 90 / 95 |
| LCP | 3,4 s | 0,9 s | 2,5 s |
| CLS | 0,011 | 0,002 | 0,1 |
| Accessibilité | **86** | **86** | **90** |
| Best Practices | 100 | 100 | 90 |
| SEO | 100 | 100 | 95 |
| Open Graph | 100/100 | — | ≥ 80 |

> Note : la performance mobile (83) est due au temps d'exécution JS (~7 s sur mobile) — non adressée dans ce PR atomique (périmètre = accessibilité).

## Build

✅ `pnpm build` vert (export statique Next.js 15 complet)

## Labels

`perf` `automated`

---
🤖 Généré par [Performance Guardian](https://claude.ai/code/session_01LnUVV5FBrfQGa9wzQJ63Cq) via Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnUVV5FBrfQGa9wzQJ63Cq)_